### PR TITLE
Update README with accurate prerequisites, build steps, and example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,42 +29,31 @@ iOS global proxy app powered by [Mihomo](https://github.com/MetaCubeX/mihomo) (C
 ## Prerequisites
 
 - macOS with Xcode 15+
-- Go 1.22+
-- gomobile (`go install golang.org/x/mobile/cmd/gomobile@latest`)
+- Go 1.25+
+- `gomobile` and `gobind` are installed automatically by the build system — no manual setup needed
 
 ## Build
 
 ### 1. Build the Go framework
 
 ```bash
-make framework
+make framework            # Build for iOS + Simulator (universal)
+make framework-arm64      # Build for arm64 only (faster, device-only)
 ```
 
-This compiles the Mihomo Go core into `Framework/MihomoCore.xcframework` using gomobile.
-
-### 2. Open in Xcode
+This compiles the Mihomo Go core into `Framework/MihomoCore.xcframework` using gomobile. To remove the built framework:
 
 ```bash
-open BaoLianDeng.xcodeproj
+make clean
 ```
 
-### 3. Configure signing
+### 2. Configure signing
 
-The project has no Team ID committed. You must set your own before building on a device.
+Copy the xcconfig template and set your Apple development team ID:
 
-**In Xcode (recommended):**
-1. Open `BaoLianDeng.xcodeproj`
-2. Select the **BaoLianDeng** target → Signing & Capabilities → set your Team
-3. Repeat for the **PacketTunnel** target
-4. Xcode will write your Team ID into `project.pbxproj` — do **not** commit that change
-
-**From the command line:**
 ```bash
-xcodebuild build \
-  -scheme BaoLianDeng \
-  -destination 'id=<YOUR_DEVICE_UDID>' \
-  -allowProvisioningUpdates \
-  DEVELOPMENT_TEAM=<YOUR_TEAM_ID>
+cp Local.xcconfig.template Local.xcconfig
+# Edit Local.xcconfig and replace YOUR_TEAM_ID_HERE with your Team ID
 ```
 
 > **Finding your Team ID:** Apple Developer portal → Membership → Team ID (10-character string, e.g. `AB12CD34EF`).
@@ -75,28 +64,56 @@ Both targets require these capabilities (already configured in entitlements):
 
 If you distribute under a different bundle ID, also update `appGroupIdentifier` and `tunnelBundleIdentifier` in `Shared/Constants.swift` and the matching entitlement files.
 
-### 4. Build and run
+### 3. Build and run
+
+```bash
+open BaoLianDeng.xcodeproj
+```
 
 Select your device and press `Cmd+R`.
+
+**CI-style simulator build (no signing required):**
+
+```bash
+xcodebuild build \
+  -project BaoLianDeng.xcodeproj \
+  -scheme BaoLianDeng \
+  -configuration Debug \
+  -destination 'generic/platform=iOS Simulator' \
+  CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+```
 
 ## Configuration
 
 The app uses Mihomo YAML configuration format. Edit the config through the in-app editor or place a `config.yaml` in the app's shared container.
 
-Example minimal config:
+Example config:
 
 ```yaml
 mixed-port: 7890
 mode: rule
 log-level: info
+allow-lan: false
+external-controller: 127.0.0.1:9090
+
+tun:
+  enable: true
+  stack: gvisor
+  dns-hijack:
+    - 198.18.0.2:53
+  auto-route: false
+  auto-detect-interface: false
+
+geo-auto-update: false
 
 dns:
   enable: true
-  listen: 198.18.0.2:53
+  listen: 127.0.0.1:1053
   enhanced-mode: fake-ip
   fake-ip-range: 198.18.0.1/16
   nameserver:
     - https://dns.alidns.com/dns-query
+    - https://doh.pub/dns-query
 
 proxies:
   - name: "my-proxy"
@@ -113,9 +130,36 @@ proxy-groups:
       - my-proxy
 
 rules:
+  # Google
+  - DOMAIN-SUFFIX,google.com,PROXY
+  - DOMAIN-SUFFIX,googleapis.com,PROXY
+  - DOMAIN-SUFFIX,googlevideo.com,PROXY
+  - DOMAIN-SUFFIX,gstatic.com,PROXY
+  - DOMAIN-SUFFIX,gmail.com,PROXY
+  # YouTube
+  - DOMAIN-SUFFIX,youtube.com,PROXY
+  - DOMAIN-SUFFIX,ytimg.com,PROXY
+  # Social
+  - DOMAIN-SUFFIX,twitter.com,PROXY
+  - DOMAIN-SUFFIX,x.com,PROXY
+  - DOMAIN-SUFFIX,instagram.com,PROXY
+  - DOMAIN-SUFFIX,facebook.com,PROXY
+  # Messaging
+  - DOMAIN-SUFFIX,telegram.org,PROXY
+  - DOMAIN-SUFFIX,t.me,PROXY
+  # Dev
+  - DOMAIN-SUFFIX,github.com,PROXY
+  - DOMAIN-SUFFIX,githubusercontent.com,PROXY
+  # AI
+  - DOMAIN-SUFFIX,openai.com,PROXY
+  - DOMAIN-SUFFIX,anthropic.com,PROXY
+  - DOMAIN-SUFFIX,claude.ai,PROXY
+  # Catch-all
   - GEOIP,CN,DIRECT
   - MATCH,PROXY
 ```
+
+> **Note:** The app includes a more comprehensive default config with additional rules when no config file is present. The TUN stack must be `gvisor` (not `system`) and `geo-auto-update` must be `false` for the Network Extension to work reliably. The app will auto-correct these settings on launch if needed.
 
 ## Project Structure
 
@@ -124,19 +168,27 @@ BaoLianDeng/
 ├── BaoLianDeng/              # Main iOS app target
 │   ├── BaoLianDengApp.swift  # App entry point
 │   ├── Views/                # SwiftUI views
+│   │   ├── HomeView.swift    #   VPN toggle, mode selector, subscriptions
+│   │   ├── ConfigEditorView  #   YAML config editor
+│   │   ├── TrafficView.swift #   Usage stats and charts
+│   │   ├── SettingsView.swift#   Proxy groups, log level, about
+│   │   └── ...               #   ProxyGroupView, TunnelLogView, etc.
 │   ├── Assets.xcassets/      # App assets
 │   └── Info.plist
 ├── PacketTunnel/             # Network Extension target
 │   └── PacketTunnelProvider.swift
 ├── Shared/                   # Code shared between targets
-│   ├── Constants.swift
-│   ├── ConfigManager.swift
-│   └── VPNManager.swift
+│   ├── Constants.swift       # App group ID, bundle IDs, network constants
+│   ├── ConfigManager.swift   # YAML config I/O, defaults, sanitization
+│   └── VPNManager.swift      # VPN lifecycle (ObservableObject)
 ├── Go/mihomo-bridge/         # Go bridge to Mihomo core
-│   ├── bridge.go             # Main bridge API
-│   ├── tun_ios.go            # iOS TUN device integration
-│   └── Makefile              # gomobile build script
-└── Framework/                # Built xcframework output
+│   ├── bridge.go             # gomobile API boundary
+│   ├── tun_ios.go            # iOS TUN fd discovery
+│   ├── Makefile              # gomobile build (setup, ios, ios-arm64)
+│   └── patches/              # Vendored dependency patches
+├── Framework/                # Built xcframework output (gitignored)
+├── Local.xcconfig.template   # Copy to Local.xcconfig, set DEVELOPMENT_TEAM
+└── Makefile                  # Top-level: make framework / clean
 ```
 
 ## License


### PR DESCRIPTION
- Bump Go requirement to 1.25+ (matches go.mod)
- Note gomobile/gobind are auto-installed by the build system
- Add Local.xcconfig signing workflow instead of Xcode-only instructions
- Document make framework-arm64, make clean, and CI simulator build
- Replace minimal example config with one that includes TUN, DNS, and
  domain-based rules for common services (Google, YouTube, GitHub, etc.)
- Add note about gvisor stack and geo-auto-update constraints
- Expand project structure tree with file descriptions

https://claude.ai/code/session_015Sjs7EmD1Bz6TCtXNnDuSx