### PR TITLE
Fix toolbar items hidden by long node names

### DIFF
--- a/BaoLianDeng/Views/VPNToolbarContent.swift
+++ b/BaoLianDeng/Views/VPNToolbarContent.swift
@@ -35,6 +35,8 @@ struct VPNToolbarContent: ToolbarContent {
                     Text(node)
                         .font(.subheadline.weight(.medium))
                         .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: 200)
                 }
 
                 Toggle("", isOn: Binding(


### PR DESCRIPTION
## Summary
- Cap proxy node name at 200pt max width with tail truncation in the toolbar
- Prevents long node names from pushing the VPN toggle switch off-screen

## Test plan
- [ ] Select a proxy node with a very long name
- [ ] Verify the node name truncates with ellipsis and the toggle switch remains visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)