### PR TITLE
Fix subscription switch not updating proxy groups and toolbar name

### DIFF
--- a/BaoLianDeng/Views/HomeView.swift
+++ b/BaoLianDeng/Views/HomeView.swift
@@ -132,8 +132,8 @@ struct HomeView: View {
             }
         }
         .onChange(of: selectedSubscriptionID) { _, _ in
-            // Reload proxy groups when subscription changes
-            loadProxyGroups()
+            // Proxy groups are reloaded inside selectSubscription()
+            // after the config reload completes — no need to reload here.
         }
         .overlay {
             if showToast {
@@ -328,13 +328,16 @@ struct HomeView: View {
         AppConstants.sharedDefaults
             .set(sub.id.uuidString, forKey: "selectedSubscriptionID")
         if let raw = sub.rawContent {
-            Task.detached {
-                let merged = (try? ConfigManager.shared.applySubscriptionConfig(raw)) ?? ""
+            Task {
+                let merged = await Task.detached {
+                    (try? ConfigManager.shared.applySubscriptionConfig(raw)) ?? ""
+                }.value
                 await Self.reloadMihomoConfig(with: merged)
+                loadProxyGroups()
             }
+        } else {
+            loadProxyGroups()
         }
-        // Reload proxy groups with new subscription's YAML
-        loadProxyGroups()
     }
 
     private func loadSubscriptions() {

--- a/BaoLianDeng/Views/VPNToolbarContent.swift
+++ b/BaoLianDeng/Views/VPNToolbarContent.swift
@@ -18,6 +18,8 @@ import NetworkExtension
 
 struct VPNToolbarContent: ToolbarContent {
     @EnvironmentObject var vpnManager: VPNManager
+    @AppStorage("selectedSubscriptionID") private var selectedIDString: String?
+    @AppStorage("subscriptions") private var subscriptionsData: Data?
 
     var body: some ToolbarContent {
         ToolbarItem(placement: .principal) {
@@ -51,9 +53,8 @@ struct VPNToolbarContent: ToolbarContent {
     }
 
     private var selectedSubscriptionName: String? {
-        let defaults = AppConstants.sharedDefaults
-        guard let idStr = defaults.string(forKey: "selectedSubscriptionID"),
-              let data = defaults.data(forKey: "subscriptions") else {
+        guard let idStr = selectedIDString,
+              let data = subscriptionsData else {
             return nil
         }
         struct Sub: Decodable { var id: UUID; var name: String }


### PR DESCRIPTION
## Summary
- Fix race condition where proxy groups were fetched before mihomo finished reloading the new subscription config — `loadProxyGroups()` now runs after `reloadMihomoConfig()` completes
- Fix toolbar subscription name not updating by replacing raw `UserDefaults` reads with `@AppStorage` for SwiftUI reactivity
- Remove redundant `loadProxyGroups()` call in `onChange(of: selectedSubscriptionID)` that triggered the same race

## Test plan
- [ ] Switch between subscriptions and verify proxy groups update correctly
- [ ] Verify the toolbar displays the newly selected subscription name immediately
- [ ] Confirm proxy groups load correctly when VPN is both connected and disconnected

🤖 Generated with [Claude Code](https://claude.com/claude-code)