### PR TITLE
Set MARKETING_VERSION=5.3 in project.pbxproj

### DIFF
--- a/BaoLianDeng.xcodeproj/project.pbxproj
+++ b/BaoLianDeng.xcodeproj/project.pbxproj
@@ -586,7 +586,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -599,7 +599,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 5.2;
+				MARKETING_VERSION = 5.3;
 				OTHER_LDFLAGS = (
 					"-lresolv",
 					"-ObjC",
@@ -625,7 +625,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -638,7 +638,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 5.2;
+				MARKETING_VERSION = 5.3;
 				OTHER_LDFLAGS = (
 					"-lresolv",
 					"-ObjC",
@@ -673,7 +673,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 5.2;
+				MARKETING_VERSION = 5.3;
 				OTHER_LDFLAGS = (
 					"-lresolv",
 					"-ObjC",
@@ -712,7 +712,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 5.2;
+				MARKETING_VERSION = 5.3;
 				OTHER_LDFLAGS = (
 					"-lresolv",
 					"-ObjC",


### PR DESCRIPTION
## Summary
- The earlier PR #25 only updated Info.plist via agvtool; Xcode reads MARKETING_VERSION from build settings, so release builds were still stamped as 5.2.
- Update all four MARKETING_VERSION entries in project.pbxproj to 5.3.

## Test plan
- [x] xcodebuild -showBuildSettings reports MARKETING_VERSION=5.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)