### PR TITLE
Prevent status text truncation in VPN toolbar

### DIFF
--- a/BaoLianDeng/Views/VPNToolbarContent.swift
+++ b/BaoLianDeng/Views/VPNToolbarContent.swift
@@ -31,6 +31,7 @@ struct VPNToolbarContent: ToolbarContent {
                 Text(statusText)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: true, vertical: false)
 
                 if let name = selectedSubscriptionName, !name.isEmpty {
                     Text(name)


### PR DESCRIPTION
## Summary
- Add `.fixedSize(horizontal: true, vertical: false)` to the status `Text` in `VPNToolbarContent` so labels like "Not Connected" / "Disconnecting..." render fully instead of being truncated when the toolbar is tight.
- Subscription name keeps its existing `maxWidth: 200` + tail truncation so the toggle switch stays visible.

## Test plan
- [ ] Launch app; confirm toolbar status text is never ellipsized across all states (Connected, Connecting..., Disconnecting..., Not Connected, Reconnecting..., Not Configured).
- [ ] Narrow the window; confirm the toggle switch remains visible and the subscription name truncates with an ellipsis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)