### PR TITLE
Update README and landing page for v5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 macOS VPN proxy app powered by [Mihomo](https://github.com/MetaCubeX/mihomo) (Clash Meta) core.
 
-**[Download DMG](https://github.com/madeye/BaoLianDeng/releases/latest)** · **[Website](https://madeye.github.io/BaoLianDeng/)**
+**[Download PKG](https://github.com/madeye/BaoLianDeng/releases/latest)** · **[Website](https://madeye.github.io/BaoLianDeng/)**
 
 ## Features
 
@@ -44,20 +44,14 @@ macOS VPN proxy app powered by [Mihomo](https://github.com/MetaCubeX/mihomo) (Cl
 
 ## Install
 
-### Homebrew
+### From PKG
 
-```bash
-brew install --cask baoliandeng
-```
-
-### From DMG
-
-1. Download the latest DMG from [Releases](https://github.com/madeye/BaoLianDeng/releases/latest)
-2. Open the DMG and drag **BaoLianDeng** to **Applications**
-3. Launch from Applications
+1. Download the latest PKG from [Releases](https://github.com/madeye/BaoLianDeng/releases/latest)
+2. Open the PKG installer and follow the prompts (installs to **/Applications**)
+3. Launch **BaoLianDeng** from Applications
 4. Enable the network extension: **System Settings → General → Login Items & Extensions → Network Extensions** → toggle on **BaoLianDeng**
 
-The DMG is signed with Developer ID and notarized by Apple.
+The PKG is signed with Developer ID and notarized by Apple.
 
 ### Build from Source
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -420,9 +420,9 @@ footer .footer-links {
   <img src="images/AppIcon.png" alt="BaoLianDeng App Icon" class="hero-icon">
   <h1>BaoLianDeng</h1>
   <p class="tagline">macOS VPN proxy app powered by Mihomo (Clash Meta) with NETransparentProxyProvider</p>
-  <p class="hero-version"><a href="https://github.com/madeye/BaoLianDeng/releases/tag/v5.2">v5.2</a></p>
+  <p class="hero-version"><a href="https://github.com/madeye/BaoLianDeng/releases/tag/v5.3">v5.3</a></p>
   <div class="hero-buttons">
-    <a href="https://github.com/madeye/BaoLianDeng/releases/download/v5.2/BaoLianDeng-5.1.pkg" class="btn btn-primary">
+    <a href="https://github.com/madeye/BaoLianDeng/releases/download/v5.3/BaoLianDeng-5.3.pkg" class="btn btn-primary">
       <svg viewBox="0 0 16 16"><path d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14ZM7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06l1.97 1.969Z"/></svg>
       Download PKG
     </a>
@@ -479,7 +479,7 @@ footer .footer-links {
     <div class="install-card">
       <h3>&#x1F4E5; Download PKG</h3>
       <ol>
-        <li>Download <a href="https://github.com/madeye/BaoLianDeng/releases/download/v5.2/BaoLianDeng-5.1.pkg"><code>BaoLianDeng-5.1.pkg</code></a></li>
+        <li>Download <a href="https://github.com/madeye/BaoLianDeng/releases/download/v5.3/BaoLianDeng-5.3.pkg"><code>BaoLianDeng-5.3.pkg</code></a></li>
         <li>Open the PKG installer and follow the prompts</li>
         <li>Launch from Applications</li>
         <li>Enable the network extension: <strong>System Settings &rarr; General &rarr; Login Items &amp; Extensions &rarr; Network Extensions</strong> &rarr; toggle on <strong>BaoLianDeng</strong></li>


### PR DESCRIPTION
## Summary
- Drop deprecated Homebrew cask section from README; point download link/instructions to the signed PKG
- Bump landing page version badge, hero download button, and install card to v5.3 (`BaoLianDeng-5.3.pkg`)

## Test plan
- [ ] Render `README.md` on GitHub and confirm download link and install steps reference the PKG
- [ ] Open `docs/index.html` locally and confirm the v5.3 badge and `BaoLianDeng-5.3.pkg` links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)