### PR TITLE
Exclude all LAN and private IP ranges from VPN route

### DIFF
--- a/BaoLianDeng.xcodeproj/xcshareddata/xcschemes/BaoLianDeng.xcscheme
+++ b/BaoLianDeng.xcodeproj/xcshareddata/xcschemes/BaoLianDeng.xcscheme
@@ -29,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "037A5AF56A256698DCED8763"
-               BuildableName = "TransparentProxy.systemextension"
+               BuildableName = "io.github.baoliandeng.macos.TransparentProxy.systemextension"
                BlueprintName = "TransparentProxy"
                ReferencedContainer = "container:BaoLianDeng.xcodeproj">
             </BuildableReference>

--- a/TransparentProxy/TransparentProxyProvider.swift
+++ b/TransparentProxy/TransparentProxyProvider.swift
@@ -534,16 +534,31 @@ class TransparentProxyProvider: NETransparentProxyProvider {
         )
         settings.includedNetworkRules = [tcpRule, udpRule]
 
-        // Exclude localhost and LAN traffic
+        // Exclude localhost, LAN, and all reserved/private IP ranges
         var excluded: [NENetworkRule] = []
         let excludedRanges: [(String, Int)] = [
-            ("127.0.0.0", 8),     // Loopback
-            ("10.0.0.0", 8),      // Private
-            ("172.16.0.0", 12),   // Private
-            ("192.168.0.0", 16),  // Private
-            ("169.254.0.0", 16),  // Link-local
-            ("224.0.0.0", 4),     // Multicast
-            ("100.64.0.0", 10)    // CGNAT
+            // IPv4
+            ("0.0.0.0", 8),       // "This" network (RFC 1122)
+            ("10.0.0.0", 8),      // Private (RFC 1918)
+            ("100.64.0.0", 10),   // CGNAT (RFC 6598)
+            ("127.0.0.0", 8),     // Loopback (RFC 1122)
+            ("169.254.0.0", 16),  // Link-local (RFC 3927)
+            ("172.16.0.0", 12),   // Private (RFC 1918)
+            ("192.0.0.0", 24),    // IETF Protocol Assignments (RFC 6890)
+            ("192.0.2.0", 24),    // Documentation TEST-NET-1 (RFC 5737)
+            ("192.88.99.0", 24),  // 6to4 Relay Anycast (RFC 7526)
+            ("192.168.0.0", 16),  // Private (RFC 1918)
+            ("198.18.0.0", 15),   // Benchmarking (RFC 2544)
+            ("198.51.100.0", 24), // Documentation TEST-NET-2 (RFC 5737)
+            ("203.0.113.0", 24),  // Documentation TEST-NET-3 (RFC 5737)
+            ("224.0.0.0", 4),     // Multicast (RFC 5771)
+            ("240.0.0.0", 4),     // Reserved for future use (RFC 1112)
+            ("255.255.255.255", 32), // Limited broadcast
+            // IPv6
+            ("::1", 128),         // Loopback
+            ("fc00::", 7),        // Unique local address (RFC 4193)
+            ("fe80::", 10),       // Link-local (RFC 4291)
+            ("ff00::", 8),        // Multicast (RFC 4291)
         ]
         for (network, prefix) in excludedRanges {
             excluded.append(


### PR DESCRIPTION
## Summary
- Add comprehensive IPv4 reserved ranges (0.0.0.0/8, 192.0.0.0/24, TEST-NETs, 6to4 relay, benchmarking, class E, broadcast) to excluded network rules
- Add IPv6 private ranges (loopback, ULA, link-local, multicast)
- Previously only excluded RFC 1918, loopback, link-local, multicast, and CGNAT

## Test plan
- [ ] Build and install locally via `scripts/dev-deploy.sh`
- [ ] Verify LAN devices (e.g. router at 192.168.x.x, NAS at 10.x.x.x) remain accessible with VPN on
- [ ] Verify external traffic still routes through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)