### PR TITLE
Bump marketing version to 5.4

### DIFF
--- a/BaoLianDeng.xcodeproj/project.pbxproj
+++ b/BaoLianDeng.xcodeproj/project.pbxproj
@@ -599,7 +599,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 5.3;
+				MARKETING_VERSION = 5.4;
 				OTHER_LDFLAGS = (
 					"-lresolv",
 					"-ObjC",
@@ -638,7 +638,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 5.3;
+				MARKETING_VERSION = 5.4;
 				OTHER_LDFLAGS = (
 					"-lresolv",
 					"-ObjC",
@@ -673,7 +673,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 5.3;
+				MARKETING_VERSION = 5.4;
 				OTHER_LDFLAGS = (
 					"-lresolv",
 					"-ObjC",
@@ -712,7 +712,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 5.3;
+				MARKETING_VERSION = 5.4;
 				OTHER_LDFLAGS = (
 					"-lresolv",
 					"-ObjC",

--- a/BaoLianDeng/Info.plist
+++ b/BaoLianDeng/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.3</string>
+	<string>5.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>

--- a/TransparentProxyMac/Info.plist
+++ b/TransparentProxyMac/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.3</string>
+	<string>5.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary
- Update `MARKETING_VERSION` to 5.4 in `BaoLianDeng.xcodeproj/project.pbxproj` (all 4 configurations)
- Update `CFBundleShortVersionString` to 5.4 in `BaoLianDeng/Info.plist` and `TransparentProxyMac/Info.plist`

## Test plan
- [ ] Build succeeds with `xcodebuild build ...`
- [ ] About panel shows 5.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)