### PR TITLE
Add TestFlight beta link to landing page and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 macOS VPN proxy app powered by [Mihomo](https://github.com/MetaCubeX/mihomo) (Clash Meta) core.
 
-**[Download PKG](https://github.com/madeye/BaoLianDeng/releases/latest)** · **[Website](https://madeye.github.io/BaoLianDeng/)**
+**[Download PKG](https://github.com/madeye/BaoLianDeng/releases/latest)** · **[TestFlight Beta](https://testflight.apple.com/join/VpX3tHnS)** · **[Website](https://madeye.github.io/BaoLianDeng/)**
 
 ## Features
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -526,6 +526,10 @@ footer .footer-links {
       <svg viewBox="0 0 16 16"><path d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14ZM7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06l1.97 1.969Z"/></svg>
       Download PKG
     </a>
+    <a href="https://testflight.apple.com/join/VpX3tHnS" class="btn btn-outline">
+      <svg viewBox="0 0 16 16"><path d="M8 0a.75.75 0 0 1 .53.22l3.25 3.25a.75.75 0 0 1-1.06 1.06L8.75 2.56v8.69a.75.75 0 0 1-1.5 0V2.56L5.28 4.53a.75.75 0 0 1-1.06-1.06L7.47.22A.75.75 0 0 1 8 0ZM3.5 7.25a.75.75 0 0 0-1.5 0v5A2.75 2.75 0 0 0 4.75 15h6.5A2.75 2.75 0 0 0 14 12.25v-5a.75.75 0 0 0-1.5 0v5c0 .69-.56 1.25-1.25 1.25h-6.5c-.69 0-1.25-.56-1.25-1.25Z"/></svg>
+      TestFlight Beta
+    </a>
     <a href="https://github.com/madeye/BaoLianDeng" class="btn btn-outline">
       <svg viewBox="0 0 16 16"><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"/></svg>
       GitHub
@@ -593,8 +597,17 @@ footer .footer-links {
 <div class="section-alt">
 <section id="install" class="section">
   <h2 class="section-title">Installation</h2>
-  <p class="section-subtitle">Two paths — grab the signed installer, or build it from source.</p>
+  <p class="section-subtitle">Three paths — grab the signed installer, join the beta, or build it from source.</p>
   <div class="install-methods">
+    <div class="install-card">
+      <h3>&#x2708;&#xFE0F; TestFlight Beta</h3>
+      <ol>
+        <li>Install <a href="https://apps.apple.com/app/testflight/id899247664">TestFlight</a> from the Mac App Store</li>
+        <li>Join the beta: <a href="https://testflight.apple.com/join/VpX3tHnS">testflight.apple.com/join/VpX3tHnS</a></li>
+        <li>Install BaoLianDeng from TestFlight and launch it</li>
+        <li>Enable the network extension when prompted</li>
+      </ol>
+    </div>
     <div class="install-card">
       <h3>&#x1F4E5; Download PKG</h3>
       <ol>
@@ -623,6 +636,7 @@ footer .footer-links {
   <div class="footer-links">
     <a href="https://github.com/madeye/BaoLianDeng">GitHub</a>
     <a href="https://github.com/madeye/BaoLianDeng/releases">Releases</a>
+    <a href="https://testflight.apple.com/join/VpX3tHnS">TestFlight Beta</a>
     <a href="https://github.com/MetaCubeX/mihomo">Mihomo</a>
     <a href="https://github.com/madeye/BaoLianDeng/blob/main/LICENSE">GPL-3.0 License</a>
   </div>


### PR DESCRIPTION
## Summary
- Landing page (docs/index.html): TestFlight Beta button in the hero, a TestFlight install card (first position) in the Installation section, and a footer link
- README: TestFlight Beta link in the top download line

Link: https://testflight.apple.com/join/VpX3tHnS

🤖 Generated with [Claude Code](https://claude.com/claude-code)