### PR TITLE
Hide the System Extension settings section in app-extension builds

### DIFF
--- a/BaoLianDeng/Views/SettingsView.swift
+++ b/BaoLianDeng/Views/SettingsView.swift
@@ -71,12 +71,16 @@ struct SettingsView: View {
                 }
             }
 
-            Section("System Extension") {
-                Button("Uninstall System Extension") {
-                    vpnManager.stop()
-                    vpnManager.deactivateSystemExtension()
+            // App-extension builds (Mac App Store) have no system extension
+            // to uninstall — the provider lives inside the app bundle.
+            if !VPNManager.providerIsAppExtension {
+                Section("System Extension") {
+                    Button("Uninstall System Extension") {
+                        vpnManager.stop()
+                        vpnManager.deactivateSystemExtension()
+                    }
+                    .foregroundStyle(.red)
                 }
-                .foregroundStyle(.red)
             }
 
             Section("About") {


### PR DESCRIPTION
## Summary
- App Store/TestFlight builds ship the provider as an app extension inside the app bundle, so the "Uninstall System Extension" section in Settings is meaningless there — hide it when `VPNManager.providerIsAppExtension` is true
- Developer ID (system-extension) builds keep the section unchanged

## Test plan
- `swiftlint lint --strict`: 0 violations
- `xcodebuild test -only-testing:BaoLianDengTests`: TEST SUCCEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)