### PR TITLE
Guard appex FD close and flow continuations against teardown races

### DIFF
--- a/TransparentProxy/TransparentProxyProvider.swift
+++ b/TransparentProxy/TransparentProxyProvider.swift
@@ -202,6 +202,37 @@ class TransparentProxyProvider: NETransparentProxyProvider {
         return false
     }
 
+    // MARK: - Flow open helper
+
+    /// Open a proxy flow, bridging the completion-handler API to async.
+    ///
+    /// `NEAppProxy*Flow.open(withLocalEndpoint:)` can invoke its completion
+    /// handler more than once during teardown races. A bare
+    /// `withCheckedThrowingContinuation` would then call `cont.resume` twice and
+    /// trap with "SWIFT TASK CONTINUATION MISUSE" (EXC_BREAKPOINT), killing the
+    /// extension. The `resumed` flag (guarded by a lock, since the handler may
+    /// fire on different threads) makes resumption happen exactly once.
+    private func openFlow(_ flow: NEAppProxyFlow) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            let lock = NSLock()
+            var resumed = false
+            flow.open(withLocalEndpoint: nil) { error in
+                lock.lock()
+                if resumed {
+                    lock.unlock()
+                    return
+                }
+                resumed = true
+                lock.unlock()
+                if let error = error {
+                    cont.resume(throwing: error)
+                } else {
+                    cont.resume()
+                }
+            }
+        }
+    }
+
     // MARK: - TCP Flow (SOCKS5 relay)
 
     private func handleTCPFlow(_ flow: NEAppProxyTCPFlow) {
@@ -235,15 +266,7 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                 )
 
                 // Open the flow
-                try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-                    flow.open(withLocalEndpoint: nil) { error in
-                        if let error = error {
-                            cont.resume(throwing: error)
-                        } else {
-                            cont.resume()
-                        }
-                    }
-                }
+                try await openFlow(flow)
 
                 // Relay bidirectionally: flow ↔ SOCKS5 connection
                 await relayTCP(flow: flow, connection: conn)
@@ -267,15 +290,7 @@ class TransparentProxyProvider: NETransparentProxyProvider {
         Task {
             do {
                 // Open the UDP flow
-                try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-                    flow.open(withLocalEndpoint: nil) { error in
-                        if let error = error {
-                            cont.resume(throwing: error)
-                        } else {
-                            cont.resume()
-                        }
-                    }
-                }
+                try await openFlow(flow)
 
                 // Create relay lazily — initialized on first non-DNS datagram
                 var relay: UDPNATRelay?
@@ -306,7 +321,20 @@ class TransparentProxyProvider: NETransparentProxyProvider {
             var readError: Error?
 
             await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                // Like `open`, `readDatagrams` can fire its completion handler
+                // more than once during teardown races; the lock-guarded
+                // `resumed` flag keeps `cont.resume` to exactly one call so we
+                // don't trap with a continuation-misuse EXC_BREAKPOINT.
+                let lock = NSLock()
+                var resumed = false
                 flow.readDatagrams { dgs, eps, err in
+                    lock.lock()
+                    if resumed {
+                        lock.unlock()
+                        return
+                    }
+                    resumed = true
+                    lock.unlock()
                     datagrams = dgs ?? []
                     endpoints = (eps ?? []).compactMap {
                         $0 as? NWHostEndpoint

--- a/TransparentProxy/UDPNATRelay.swift
+++ b/TransparentProxy/UDPNATRelay.swift
@@ -42,6 +42,7 @@ final class UDPNATRelay {
     private var readSource: DispatchSourceRead?
     private let sentAddresses = NSMutableSet()  // Thread-safe via lock
     private let lock = NSLock()
+    private var closed = false  // guarded by `lock`; ensures fd is closed exactly once
     private weak var flow: NEAppProxyUDPFlow?
 
     init?(flow: NEAppProxyUDPFlow) {
@@ -118,7 +119,14 @@ final class UDPNATRelay {
             Darwin.close(fd)
         }
         source.resume()
+        // Publish under the lock so `cancel()` (which reads `readSource` under
+        // the same lock) sees a consistent value. The relay's lifecycle is
+        // single-Task — every `startReceiving()` completes before `cancel()`
+        // runs — so `closed` can't already be set here; the lock is purely for
+        // memory-visibility consistency with the teardown path.
+        lock.lock()
         readSource = source
+        lock.unlock()
     }
 
     private func receiveDatagrams() {
@@ -163,9 +171,24 @@ final class UDPNATRelay {
     }
 
     func cancel() {
-        if let source = readSource {
+        // Close the fd exactly once. `cancel()` is reachable both from the
+        // provider's explicit teardown and from `deinit`; without this guard
+        // the fd would be closed twice. By the time the second close runs the
+        // kernel has often handed fd 26 (etc.) to a *guarded* descriptor opened
+        // by Network.framework/dispatch, so the stray close trips EXC_GUARD
+        // (GUARD_TYPE_FD / CLOSE) and the extension is killed.
+        lock.lock()
+        if closed {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let source = readSource
+        readSource = nil
+        lock.unlock()
+
+        if let source = source {
             source.cancel()  // fd closed in cancel handler
-            readSource = nil
         } else {
             Darwin.close(fd)  // No read source — close fd directly
         }


### PR DESCRIPTION
## Summary
Fixes an `EXC_GUARD` (`GUARD_TYPE_FD` / `CLOSE`) crash in the `TransparentProxy` app extension caused by a double-close of the `UDPNATRelay` socket fd during teardown.

## Root cause
`UDPNATRelay.cancel()` is reachable both from the provider's explicit teardown and from `deinit`. The old code closed the fd on both calls:
1. First `cancel()` → `source.cancel()` schedules the dispatch cancel handler **asynchronously** and nils `readSource`.
2. Second `cancel()` (from `deinit`) → `readSource` is now nil → `else` branch runs `Darwin.close(fd)` **synchronously**, freeing the fd number. The kernel hands it to a *guarded* Network.framework/dispatch descriptor.
3. The async cancel handler from step 1 fires and closes the now-guarded fd → `EXC_GUARD`, extension killed.

This matches observed crash reports where the faulting frame is the dispatch cancel handler (`closure #2 in UDPNATRelay.startReceiving()`).

## Fix
- Add a lock-guarded `closed` flag so the fd is closed exactly once; the second `cancel()` early-returns.
- Publish `readSource` under the same lock for memory-visibility consistency with teardown.
- Harden flow continuations (`readDatagrams`/`open`) against multiple completion-handler invocations during teardown races to avoid continuation-misuse traps.

## Testing
- `swiftlint lint --strict` — 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)