### PR TITLE
[codex] Harden config and controller parsing

### DIFF
--- a/BaoLianDeng/BaoLianDengApp.swift
+++ b/BaoLianDeng/BaoLianDengApp.swift
@@ -22,6 +22,7 @@ struct BaoLianDengApp: App {
     @StateObject private var trafficStore = TrafficStore.shared
 
     init() {
+        guard !AppConstants.isRunningUnitTests else { return }
         FirebaseApp.configure()
         ConfigManager.shared.sanitizeConfig()
     }

--- a/BaoLianDeng/Models/MihomoAPI.swift
+++ b/BaoLianDeng/Models/MihomoAPI.swift
@@ -84,14 +84,18 @@ enum MihomoAPIError: Error, LocalizedError {
 }
 
 enum MihomoAPI {
-    /// Returns "" when the tunnel hasn't run yet (the live controller addr
-    /// is published by the extension at startup, not known up-front). The
-    /// empty string makes every URL(string:) call below fail to parse,
-    /// which surfaces as `MihomoAPIError.invalidURL` at the call site —
-    /// the same path as a real malformed URL.
-    private static var baseURL: String {
-        guard let addr = AppConstants.externalControllerAddr else { return "" }
-        return "http://\(addr)"
+    static func makeURL(pathSegments: [String], queryItems: [URLQueryItem] = []) throws -> URL {
+        guard let addr = AppConstants.externalControllerAddr, !addr.isEmpty else {
+            throw MihomoAPIError.notConnected
+        }
+        guard let url = AppConstants.externalControllerURL(
+            controllerAddr: addr,
+            pathSegments: pathSegments,
+            queryItems: queryItems
+        ) else {
+            throw MihomoAPIError.invalidURL
+        }
+        return url
     }
 
     // MARK: - Rules
@@ -116,13 +120,17 @@ enum MihomoAPI {
 
     static func fetchConnections() async throws -> MihomoConnectionsResponse {
         let data = try await get("/connections")
+        return try parseConnectionsResponse(data)
+    }
+
+    static func parseConnectionsResponse(_ data: Data) throws -> MihomoConnectionsResponse {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let connections = json["connections"] as? [[String: Any]] else {
             throw MihomoAPIError.decodingFailed
         }
 
-        let uploadTotal = (json["upload_total"] as? NSNumber)?.int64Value ?? 0
-        let downloadTotal = (json["download_total"] as? NSNumber)?.int64Value ?? 0
+        let uploadTotal = int64Value(json["uploadTotal"] ?? json["upload_total"])
+        let downloadTotal = int64Value(json["downloadTotal"] ?? json["download_total"])
 
         let isoFormatter = ISO8601DateFormatter()
         isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -132,15 +140,15 @@ enum MihomoAPI {
             let metadata = conn["metadata"] as? [String: Any] ?? [:]
             let host = metadata["host"] as? String ?? ""
             let destIP = metadata["destinationIP"] as? String ?? ""
-            let destPort = (metadata["destinationPort"] as? String).flatMap(Int.init) ?? 0
+            let destPort = intValue(metadata["destinationPort"])
             let network = metadata["network"] as? String ?? ""
             let type = metadata["type"] as? String ?? ""
 
             let rule = conn["rule"] as? String ?? ""
             let rulePayload = conn["rulePayload"] as? String ?? ""
             let chains = conn["chains"] as? [String] ?? []
-            let upload = (conn["upload"] as? NSNumber)?.int64Value ?? 0
-            let download = (conn["download"] as? NSNumber)?.int64Value ?? 0
+            let upload = int64Value(conn["upload"])
+            let download = int64Value(conn["download"])
             let startStr = conn["start"] as? String ?? ""
             let start = isoFormatter.date(from: startStr) ?? Date()
 
@@ -168,11 +176,11 @@ enum MihomoAPI {
     }
 
     static func closeConnection(_ id: String) async throws {
-        try await delete("/connections/\(id)")
+        try await delete(pathSegments: ["connections", id])
     }
 
     static func closeAllConnections() async throws {
-        try await delete("/connections")
+        try await delete(pathSegments: ["connections"])
     }
 
     // MARK: - Proxy Groups & Providers
@@ -211,10 +219,7 @@ enum MihomoAPI {
 
     /// Select a proxy node within a group via PUT /proxies/{group}
     static func selectProxy(group: String, name: String) async throws {
-        guard let encoded = group.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
-              let url = URL(string: "\(baseURL)/proxies/\(encoded)") else {
-            throw MihomoAPIError.invalidURL
-        }
+        let url = try makeURL(pathSegments: ["proxies", group])
         var request = URLRequest(url: url)
         request.httpMethod = "PUT"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -228,11 +233,14 @@ enum MihomoAPI {
 
     // MARK: - Delay Testing
 
-    static func testGroupDelay(group: String, url: String = "https://www.gstatic.com/generate_204", timeout: Int = 5000) async throws -> [MihomoDelayResult] {
-        guard let encoded = group.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
-              let url = URL(string: "\(baseURL)/group/\(encoded)/delay?url=\(url)&timeout=\(timeout)") else {
-            throw MihomoAPIError.invalidURL
-        }
+    static func testGroupDelay(group: String, url testURL: String = "https://www.gstatic.com/generate_204", timeout: Int = 5000) async throws -> [MihomoDelayResult] {
+        let url = try makeURL(
+            pathSegments: ["group", group, "delay"],
+            queryItems: [
+                URLQueryItem(name: "url", value: testURL),
+                URLQueryItem(name: "timeout", value: String(timeout)),
+            ]
+        )
 
         let (data, response) = try await URLSession.shared.data(from: url)
         guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
@@ -254,11 +262,14 @@ enum MihomoAPI {
         }
     }
 
-    static func testProxyDelay(proxy: String, url: String = "https://www.gstatic.com/generate_204", timeout: Int = 5000) async throws -> Int {
-        guard let encoded = proxy.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
-              let url = URL(string: "\(baseURL)/proxies/\(encoded)/delay?url=\(url)&timeout=\(timeout)") else {
-            throw MihomoAPIError.invalidURL
-        }
+    static func testProxyDelay(proxy: String, url testURL: String = "https://www.gstatic.com/generate_204", timeout: Int = 5000) async throws -> Int {
+        let url = try makeURL(
+            pathSegments: ["proxies", proxy, "delay"],
+            queryItems: [
+                URLQueryItem(name: "url", value: testURL),
+                URLQueryItem(name: "timeout", value: String(timeout)),
+            ]
+        )
 
         let (data, response) = try await URLSession.shared.data(from: url)
         guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
@@ -276,9 +287,7 @@ enum MihomoAPI {
     // MARK: - Config / Mode
 
     static func patchConfig(_ config: [String: Any]) async throws {
-        guard let url = URL(string: "\(baseURL)/configs") else {
-            throw MihomoAPIError.invalidURL
-        }
+        let url = try makeURL(pathSegments: ["configs"])
         var request = URLRequest(url: url)
         request.httpMethod = "PATCH"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -293,9 +302,10 @@ enum MihomoAPI {
     /// Reload config from disk. Forces mihomo to re-read config.yaml and apply changes.
     /// This will close existing connections.
     static func reloadConfig() async throws {
-        guard let url = URL(string: "\(baseURL)/configs?force=true") else {
-            throw MihomoAPIError.invalidURL
-        }
+        let url = try makeURL(
+            pathSegments: ["configs"],
+            queryItems: [URLQueryItem(name: "force", value: "true")]
+        )
         var request = URLRequest(url: url)
         request.httpMethod = "PUT"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -336,10 +346,13 @@ enum MihomoAPI {
     // MARK: - DNS
 
     static func queryDNS(name: String, type: String = "A") async throws -> [String: Any] {
-        guard let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-              let url = URL(string: "\(baseURL)/dns/query?name=\(encoded)&type=\(type)") else {
-            throw MihomoAPIError.invalidURL
-        }
+        let url = try makeURL(
+            pathSegments: ["dns", "query"],
+            queryItems: [
+                URLQueryItem(name: "name", value: name),
+                URLQueryItem(name: "type", value: type),
+            ]
+        )
         let (data, _) = try await URLSession.shared.data(from: url)
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw MihomoAPIError.decodingFailed
@@ -361,9 +374,7 @@ enum MihomoAPI {
     // MARK: - HTTP Helpers
 
     private static func get(_ path: String) async throws -> Data {
-        guard let url = URL(string: "\(baseURL)\(path)") else {
-            throw MihomoAPIError.invalidURL
-        }
+        let url = try makeURL(pathSegments: pathSegments(from: path))
         let (data, response) = try await URLSession.shared.data(from: url)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             throw MihomoAPIError.requestFailed("GET \(path) failed")
@@ -372,14 +383,37 @@ enum MihomoAPI {
     }
 
     private static func delete(_ path: String) async throws {
-        guard let url = URL(string: "\(baseURL)\(path)") else {
-            throw MihomoAPIError.invalidURL
-        }
+        try await delete(pathSegments: pathSegments(from: path), errorPath: path)
+    }
+
+    private static func delete(pathSegments: [String]) async throws {
+        try await delete(pathSegments: pathSegments, errorPath: "/" + pathSegments.joined(separator: "/"))
+    }
+
+    private static func delete(pathSegments: [String], errorPath: String) async throws {
+        let url = try makeURL(pathSegments: pathSegments)
         var request = URLRequest(url: url)
         request.httpMethod = "DELETE"
         let (_, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
-            throw MihomoAPIError.requestFailed("DELETE \(path) failed")
+            throw MihomoAPIError.requestFailed("DELETE \(errorPath) failed")
         }
+    }
+
+    private static func pathSegments(from path: String) -> [String] {
+        path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+    }
+
+    private static func intValue(_ value: Any?) -> Int {
+        if let number = value as? NSNumber { return number.intValue }
+        if let string = value as? String { return Int(string) ?? 0 }
+        return 0
+    }
+
+    private static func int64Value(_ value: Any?) -> Int64 {
+        if let number = value as? NSNumber { return number.int64Value }
+        if let int = value as? Int { return Int64(int) }
+        if let string = value as? String { return Int64(string) ?? 0 }
+        return 0
     }
 }

--- a/BaoLianDeng/Models/ProxiesResult.swift
+++ b/BaoLianDeng/Models/ProxiesResult.swift
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import Foundation
+import Yams
 
 // MARK: - Proxy Leaf (non-group proxy from /proxies endpoint)
 
@@ -87,60 +88,30 @@ struct ProxiesResult {
         var proxies: [String: ProxyLeaf] = [:]
         var groups: [String: MihomoProxyGroup] = [:]
 
-        let lines = yamlContent.components(separatedBy: "\n")
-        var inProxies = false
-        var inProxyGroups = false
-        var currentGroup: [String: Any] = [:]
+        guard let dict = (try? Yams.load(yaml: yamlContent)) as? [String: Any] else {
+            return ProxiesResult(groups: [:], proxies: [:])
+        }
 
-        for line in lines {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-
-            // Section detection
-            if line.hasPrefix("proxies:") {
-                inProxies = true
-                inProxyGroups = false
-                continue
-            }
-            if line.hasPrefix("proxy-groups:") {
-                inProxyGroups = true
-                inProxies = false
-                continue
-            }
-            // Top-level key ends current section
-            if !line.hasPrefix(" ") && !line.isEmpty && line.contains(":") &&
-               !line.hasPrefix("proxies:") && !line.hasPrefix("proxy-groups:") {
-                if inProxyGroups, let group = makeGroup(from: currentGroup) {
-                    groups[group.name] = group
+        if let proxyList = dict["proxies"] as? [[String: Any]] {
+            for proxy in proxyList {
+                guard let name = proxy["name"] as? String, !name.isEmpty else {
+                    continue
                 }
-                inProxies = false
-                inProxyGroups = false
-                currentGroup = [:]
-                continue
-            }
-
-            // Parse proxies section
-            if inProxies {
-                if let name = extractProxyName(from: trimmed) {
-                    // We don't have full type info from simple parsing, use "Unknown"
-                    proxies[name] = ProxyLeaf(name: name, type: "Unknown", latestDelay: nil)
-                }
-            }
-
-            // Parse proxy-groups section
-            if inProxyGroups {
-                if trimmed.hasPrefix("- name:") || trimmed == "-" {
-                    if let group = makeGroup(from: currentGroup) {
-                        groups[group.name] = group
-                    }
-                    currentGroup = [:]
-                }
-                parseGroupLine(trimmed, into: &currentGroup)
+                proxies[name] = ProxyLeaf(
+                    name: name,
+                    type: proxy["type"] as? String ?? "Unknown",
+                    latestDelay: nil
+                )
             }
         }
 
-        // Handle last group
-        if inProxyGroups, let group = makeGroup(from: currentGroup) {
-            groups[group.name] = group
+        if let groupList = dict["proxy-groups"] as? [[String: Any]] {
+            for group in groupList {
+                guard let parsedGroup = makeGroup(from: group) else {
+                    continue
+                }
+                groups[parsedGroup.name] = parsedGroup
+            }
         }
 
         // Add built-in DIRECT/REJECT if not present
@@ -156,81 +127,9 @@ struct ProxiesResult {
 
     // MARK: - YAML Parsing Helpers
 
-    private static func extractProxyName(from line: String) -> String? {
-        // Flow style: - {name: "foo", ...}
-        if line.hasPrefix("- {") && line.contains("name:") {
-            if let nameRange = line.range(of: "name:") {
-                let afterName = line[nameRange.upperBound...]
-                let trimmed = afterName.trimmingCharacters(in: .whitespaces)
-                // Extract value until comma or }
-                var value = ""
-                var inQuote: Character?
-                for ch in trimmed {
-                    if inQuote != nil {
-                        if ch == inQuote { break }
-                        value.append(ch)
-                    } else if ch == "\"" || ch == "'" {
-                        inQuote = ch
-                    } else if ch == "," || ch == "}" {
-                        break
-                    } else {
-                        value.append(ch)
-                    }
-                }
-                let name = value.trimmingCharacters(in: .whitespaces)
-                return name.isEmpty ? nil : name
-            }
-        }
-        // Block style: - name: foo or name: foo
-        if line.hasPrefix("- name:") {
-            return extractValue(from: line, key: "- name:")
-        }
-        if line.hasPrefix("name:") {
-            return extractValue(from: line, key: "name:")
-        }
-        return nil
-    }
-
-    private static func extractValue(from line: String, key: String) -> String? {
-        guard line.hasPrefix(key) else { return nil }
-        var value = String(line.dropFirst(key.count)).trimmingCharacters(in: .whitespaces)
-        // Remove quotes
-        if value.count >= 2 {
-            if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-               (value.hasPrefix("'") && value.hasSuffix("'")) {
-                value = String(value.dropFirst().dropLast())
-            }
-        }
-        return value.isEmpty ? nil : value
-    }
-
-    private static func parseGroupLine(_ line: String, into group: inout [String: Any]) {
-        if line.contains("name:") {
-            if let value = extractValue(from: line.replacingOccurrences(of: "- ", with: ""), key: "name:") {
-                group["name"] = value
-            }
-        } else if line.contains("type:") {
-            if let value = extractValue(from: line, key: "type:") {
-                group["type"] = normalizeGroupType(value)
-            }
-        } else if line.trimmingCharacters(in: .whitespaces).hasPrefix("- ") &&
-                  !line.contains(":") {
-            // Proxy member line
-            var members = group["proxies"] as? [String] ?? []
-            let member = line.trimmingCharacters(in: .whitespaces)
-                .dropFirst(2) // Remove "- "
-                .trimmingCharacters(in: .whitespaces)
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
-            if !member.isEmpty {
-                members.append(String(member))
-                group["proxies"] = members
-            }
-        }
-    }
-
     private static func makeGroup(from dict: [String: Any]) -> MihomoProxyGroup? {
         guard let name = dict["name"] as? String, !name.isEmpty else { return nil }
-        let type = dict["type"] as? String ?? "Selector"
+        let type = normalizeGroupType(dict["type"] as? String ?? "select")
         let all = dict["proxies"] as? [String] ?? []
         let now = all.first ?? ""
         return MihomoProxyGroup(name: name, type: type, now: now, all: all)

--- a/BaoLianDeng/Models/TrafficStore.swift
+++ b/BaoLianDeng/Models/TrafficStore.swift
@@ -150,8 +150,7 @@ final class TrafficStore: ObservableObject {
     }
 
     private func fetchConnections() {
-        guard let addr = AppConstants.externalControllerAddr,
-              let url = URL(string: "http://\(addr)/connections") else { return }
+        guard let url = AppConstants.externalControllerURL(pathSegments: ["connections"]) else { return }
         URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
             guard let data = data, error == nil else { return }
             guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -161,12 +160,19 @@ final class TrafficStore: ObservableObject {
             // The tunnel tracks total upload/download across all connections.
             // Per-connection stats are only finalized when connections close,
             // so use the tunnel totals for accurate real-time tracking.
-            let uploadTotal = (json["uploadTotal"] as? NSNumber)?.int64Value ?? 0
-            let downloadTotal = (json["downloadTotal"] as? NSNumber)?.int64Value ?? 0
+            let uploadTotal = Self.int64Value(json["upload_total"] ?? json["uploadTotal"])
+            let downloadTotal = Self.int64Value(json["download_total"] ?? json["downloadTotal"])
             Task { @MainActor [weak self] in
                 self?.processConnections(connections, uploadTotal: uploadTotal, downloadTotal: downloadTotal)
             }
         }.resume()
+    }
+
+    private static func int64Value(_ value: Any?) -> Int64 {
+        if let number = value as? NSNumber { return number.int64Value }
+        if let int = value as? Int { return Int64(int) }
+        if let string = value as? String { return Int64(string) ?? 0 }
+        return 0
     }
 
     private func processConnections(_ connections: [[String: Any]], uploadTotal: Int64, downloadTotal: Int64) {

--- a/BaoLianDeng/Views/HomeView.swift
+++ b/BaoLianDeng/Views/HomeView.swift
@@ -116,6 +116,7 @@ struct HomeView: View {
             }
         }
         .onAppear {
+            guard !AppConstants.isRunningUnitTests else { return }
             loadSubscriptions()
             loadCurrentMode()
             proxyGroupsVM.loadSelections()
@@ -394,8 +395,10 @@ struct HomeView: View {
     }
 
     static func reloadMihomoConfig(with yaml: String) async {
-        guard let addr = AppConstants.externalControllerAddr,
-              let url = URL(string: "http://\(addr)/configs?force=true") else { return }
+        guard let url = AppConstants.externalControllerURL(
+            pathSegments: ["configs"],
+            queryItems: [URLQueryItem(name: "force", value: "true")]
+        ) else { return }
         var request = URLRequest(url: url)
         request.httpMethod = "PUT"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -404,6 +407,7 @@ struct HomeView: View {
     }
 
     private func fetchNewSubscriptions() {
+        guard !AppConstants.isRunningUnitTests else { return }
         for sub in subscriptions where sub.nodes.isEmpty {
             let id = sub.id
             let url = sub.url
@@ -450,6 +454,7 @@ struct HomeView: View {
     }
 
     private func loadProxyGroups() {
+        guard !AppConstants.isRunningUnitTests else { return }
         // Get fallback YAML from selected subscription
         var fallbackYAML: String?
         if let selID = selectedSubscriptionID,
@@ -596,6 +601,15 @@ struct HomeView: View {
         request.setValue("ClashMetaForAndroid/2.11.1.Meta", forHTTPHeaderField: "User-Agent")
         let (data, response) = try await URLSession.shared.data(for: request)
         AppLogger.log(AppLogger.network, category: "network", "fetchSubscription URL=\(urlString) status=\((response as? HTTPURLResponse)?.statusCode ?? -1) bytes=\(data.count)")
+        return try Self.parseFetchedSubscription(data: data, response: response)
+    }
+
+    static func parseFetchedSubscription(data: Data, response: URLResponse?) throws -> (nodes: [ProxyNode], raw: String) {
+        if let http = response as? HTTPURLResponse,
+           !(200..<300).contains(http.statusCode) {
+            AppLogger.log(AppLogger.network, category: "network", "ERROR: fetchSubscription HTTP status \(http.statusCode)")
+            throw URLError(.badServerResponse)
+        }
         guard let text = String(data: data, encoding: .utf8) else {
             AppLogger.log(AppLogger.network, category: "network", "ERROR: fetchSubscription cannot decode as UTF-8")
             throw URLError(.cannotDecodeContentData)

--- a/BaoLianDeng/Views/SubscriptionModels.swift
+++ b/BaoLianDeng/Views/SubscriptionModels.swift
@@ -349,11 +349,7 @@ enum SubscriptionParser {
         guard !cleaned.isEmpty else { return nil }
         // Base64 text shouldn't contain proxy URI schemes or YAML markers
         if cleaned.hasPrefix("proxies:") || cleaned.contains("://") { return nil }
-        // Pad if needed
-        var padded = cleaned
-        let remainder = padded.count % 4
-        if remainder > 0 { padded += String(repeating: "=", count: 4 - remainder) }
-        guard let data = Data(base64Encoded: padded, options: .ignoreUnknownCharacters),
+        guard let data = decodeBase64(cleaned),
               let decoded = String(data: data, encoding: .utf8) else {
             return nil
         }
@@ -383,7 +379,7 @@ enum SubscriptionParser {
         }
 
         // Build complete YAML with proxies + proxy-groups (no leading indentation)
-        let nodeNames = nodes.map { "      - \"\($0.name)\"" }.joined(separator: "\n")
+        let nodeNames = nodes.map { "      - \(yamlQuoted($0.name))" }.joined(separator: "\n")
         var fullYAML = "proxies:\n"
         fullYAML += yamlProxies.joined(separator: "\n")
         fullYAML += "\n\nproxy-groups:\n"
@@ -427,6 +423,29 @@ enum SubscriptionParser {
     private static func yamlEscape(_ s: String) -> String {
         s.replacingOccurrences(of: "\\", with: "\\\\")
          .replacingOccurrences(of: "\"", with: "\\\"")
+         .replacingOccurrences(of: "\n", with: "\\n")
+         .replacingOccurrences(of: "\r", with: "\\r")
+         .replacingOccurrences(of: "\t", with: "\\t")
+    }
+
+    private static func yamlQuoted(_ s: String) -> String {
+        "\"\(yamlEscape(s))\""
+    }
+
+    private static func splitOnce(_ s: String, separator: Character) -> (head: String, tail: String?) {
+        guard let separatorIdx = s.firstIndex(of: separator) else {
+            return (s, nil)
+        }
+        return (
+            String(s[..<separatorIdx]),
+            String(s[s.index(after: separatorIdx)...])
+        )
+    }
+
+    private static func normalizedNetwork(_ raw: String?) -> String {
+        let supportedNetworks: Set<String> = ["tcp", "ws", "grpc", "http", "h2"]
+        let network = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? "tcp"
+        return supportedNetworks.contains(network) ? network : "tcp"
     }
 
     // MARK: - VLESS Parser
@@ -441,10 +460,8 @@ enum SubscriptionParser {
         guard let schemeEnd = beforeHash.range(of: "://") else { return nil }
         let afterScheme = String(beforeHash[schemeEnd.upperBound...])
 
-        let queryParts = afterScheme.components(separatedBy: "?")
-        let userHost = queryParts[0]
-        let queryString = queryParts.count > 1 ? queryParts[1] : ""
-        let params = parseQueryString(queryString)
+        let (userHost, queryString) = splitOnce(afterScheme, separator: "?")
+        let params = parseQueryString(queryString ?? "")
 
         guard let atIdx = userHost.lastIndex(of: "@") else { return nil }
         let uuid = String(userHost[..<atIdx])
@@ -454,53 +471,52 @@ enum SubscriptionParser {
         guard let port = Int(hostPort[hostPort.index(after: colonIdx)...]) else { return nil }
 
         let name = uniqueName(rawName, seenNames: &seenNames)
-        let escapedName = yamlEscape(name)
 
-        var yaml = "  - name: \"\(escapedName)\"\n"
+        var yaml = "  - name: \(yamlQuoted(name))\n"
         yaml += "    type: vless\n"
-        yaml += "    server: \(server)\n"
+        yaml += "    server: \(yamlQuoted(server))\n"
         yaml += "    port: \(port)\n"
-        yaml += "    uuid: \(uuid)\n"
+        yaml += "    uuid: \(yamlQuoted(uuid))\n"
         yaml += "    udp: true\n"
 
         if let tls = params["security"], tls == "tls" {
             yaml += "    tls: true\n"
-            if let sni = params["sni"] { yaml += "    servername: \(sni)\n" }
-            if let fp = params["fp"] { yaml += "    client-fingerprint: \(fp)\n" }
+            if let sni = params["sni"] { yaml += "    servername: \(yamlQuoted(sni))\n" }
+            if let fp = params["fp"] { yaml += "    client-fingerprint: \(yamlQuoted(fp))\n" }
             if let alpn = params["alpn"] {
-                let alpnList = alpn.removingPercentEncoding?.components(separatedBy: ",") ?? [alpn]
+                let alpnList = alpn.components(separatedBy: ",")
                 yaml += "    alpn:\n"
-                for a in alpnList { yaml += "      - \(a)\n" }
+                for a in alpnList { yaml += "      - \(yamlQuoted(a))\n" }
             }
         } else if params["security"] == "reality" {
             yaml += "    tls: true\n"
-            if let sni = params["sni"] { yaml += "    servername: \(sni)\n" }
-            if let fp = params["fp"] { yaml += "    client-fingerprint: \(fp)\n" }
+            if let sni = params["sni"] { yaml += "    servername: \(yamlQuoted(sni))\n" }
+            if let fp = params["fp"] { yaml += "    client-fingerprint: \(yamlQuoted(fp))\n" }
             yaml += "    reality-opts:\n"
-            if let pbk = params["pbk"] { yaml += "      public-key: \(pbk)\n" }
-            if let sid = params["sid"] { yaml += "      short-id: \(sid)\n" }
+            if let pbk = params["pbk"] { yaml += "      public-key: \(yamlQuoted(pbk))\n" }
+            if let sid = params["sid"] { yaml += "      short-id: \(yamlQuoted(sid))\n" }
         }
 
-        let network = params["type"] ?? "tcp"
+        let network = normalizedNetwork(params["type"])
         yaml += "    network: \(network)\n"
         if network == "ws" {
             yaml += "    ws-opts:\n"
-            if let path = params["path"]?.removingPercentEncoding {
-                yaml += "      path: \"\(yamlEscape(path))\"\n"
+            if let path = params["path"] {
+                yaml += "      path: \(yamlQuoted(path))\n"
             }
             if let host = params["host"] {
                 yaml += "      headers:\n"
-                yaml += "        Host: \(host)\n"
+                yaml += "        Host: \(yamlQuoted(host))\n"
             }
         } else if network == "grpc" {
             if let serviceName = params["serviceName"] {
                 yaml += "    grpc-opts:\n"
-                yaml += "      grpc-service-name: \(serviceName)\n"
+                yaml += "      grpc-service-name: \(yamlQuoted(serviceName))\n"
             }
         }
 
         if let flow = params["flow"], !flow.isEmpty {
-            yaml += "    flow: \(flow)\n"
+            yaml += "    flow: \(yamlQuoted(flow))\n"
         }
 
         let node = ProxyNode(name: name, type: "vless", server: server, port: port)
@@ -513,7 +529,7 @@ enum SubscriptionParser {
         // vmess://base64json
         guard let schemeEnd = uri.range(of: "://") else { return nil }
         let encoded = String(uri[schemeEnd.upperBound...])
-        guard let data = Data(base64Encoded: encoded, options: .ignoreUnknownCharacters),
+        guard let data = decodeBase64(encoded),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return nil
         }
@@ -529,24 +545,23 @@ enum SubscriptionParser {
 
         let rawName = (json["ps"] as? String) ?? "\(server):\(port)"
         let name = uniqueName(rawName, seenNames: &seenNames)
-        let escapedName = yamlEscape(name)
         let aid = (json["aid"] as? Int) ?? Int(json["aid"] as? String ?? "0") ?? 0
-        let network = (json["net"] as? String) ?? "tcp"
+        let network = normalizedNetwork(json["net"] as? String)
         let tls = (json["tls"] as? String) ?? ""
 
-        var yaml = "  - name: \"\(escapedName)\"\n"
+        var yaml = "  - name: \(yamlQuoted(name))\n"
         yaml += "    type: vmess\n"
-        yaml += "    server: \(server)\n"
+        yaml += "    server: \(yamlQuoted(server))\n"
         yaml += "    port: \(port)\n"
-        yaml += "    uuid: \(uuid)\n"
+        yaml += "    uuid: \(yamlQuoted(uuid))\n"
         yaml += "    alterId: \(aid)\n"
-        yaml += "    cipher: auto\n"
+        yaml += "    cipher: \"auto\"\n"
         yaml += "    udp: true\n"
 
         if tls == "tls" {
             yaml += "    tls: true\n"
             if let sni = json["sni"] as? String, !sni.isEmpty {
-                yaml += "    servername: \(sni)\n"
+                yaml += "    servername: \(yamlQuoted(sni))\n"
             }
         }
 
@@ -554,15 +569,15 @@ enum SubscriptionParser {
         if network == "ws" {
             yaml += "    ws-opts:\n"
             let path = (json["path"] as? String) ?? "/"
-            yaml += "      path: \"\(yamlEscape(path))\"\n"
+            yaml += "      path: \(yamlQuoted(path))\n"
             if let host = json["host"] as? String, !host.isEmpty {
                 yaml += "      headers:\n"
-                yaml += "        Host: \(host)\n"
+                yaml += "        Host: \(yamlQuoted(host))\n"
             }
         } else if network == "grpc" {
             if let serviceName = json["path"] as? String {
                 yaml += "    grpc-opts:\n"
-                yaml += "      grpc-service-name: \(serviceName)\n"
+                yaml += "      grpc-service-name: \(yamlQuoted(serviceName))\n"
             }
         }
 
@@ -582,10 +597,8 @@ enum SubscriptionParser {
         guard let schemeEnd = beforeHash.range(of: "://") else { return nil }
         let afterScheme = String(beforeHash[schemeEnd.upperBound...])
 
-        let queryParts = afterScheme.components(separatedBy: "?")
-        let userHost = queryParts[0]
-        let queryString = queryParts.count > 1 ? queryParts[1] : ""
-        let params = parseQueryString(queryString)
+        let (userHost, queryString) = splitOnce(afterScheme, separator: "?")
+        let params = parseQueryString(queryString ?? "")
 
         guard let atIdx = userHost.lastIndex(of: "@") else { return nil }
         let password = String(userHost[..<atIdx]).removingPercentEncoding ?? String(userHost[..<atIdx])
@@ -595,34 +608,33 @@ enum SubscriptionParser {
         guard let port = Int(hostPort[hostPort.index(after: colonIdx)...]) else { return nil }
 
         let name = uniqueName(rawName, seenNames: &seenNames)
-        let escapedName = yamlEscape(name)
 
-        var yaml = "  - name: \"\(escapedName)\"\n"
+        var yaml = "  - name: \(yamlQuoted(name))\n"
         yaml += "    type: trojan\n"
-        yaml += "    server: \(server)\n"
+        yaml += "    server: \(yamlQuoted(server))\n"
         yaml += "    port: \(port)\n"
-        yaml += "    password: \"\(yamlEscape(password))\"\n"
+        yaml += "    password: \(yamlQuoted(password))\n"
         yaml += "    udp: true\n"
 
-        if let sni = params["sni"] { yaml += "    sni: \(sni)\n" }
-        if let fp = params["fp"] { yaml += "    client-fingerprint: \(fp)\n" }
+        if let sni = params["sni"] { yaml += "    sni: \(yamlQuoted(sni))\n" }
+        if let fp = params["fp"] { yaml += "    client-fingerprint: \(yamlQuoted(fp))\n" }
 
-        let network = params["type"] ?? "tcp"
+        let network = normalizedNetwork(params["type"])
         if network == "ws" {
             yaml += "    network: ws\n"
             yaml += "    ws-opts:\n"
-            if let path = params["path"]?.removingPercentEncoding {
-                yaml += "      path: \"\(yamlEscape(path))\"\n"
+            if let path = params["path"] {
+                yaml += "      path: \(yamlQuoted(path))\n"
             }
             if let host = params["host"] {
                 yaml += "      headers:\n"
-                yaml += "        Host: \(host)\n"
+                yaml += "        Host: \(yamlQuoted(host))\n"
             }
         } else if network == "grpc" {
             yaml += "    network: grpc\n"
             if let serviceName = params["serviceName"] {
                 yaml += "    grpc-opts:\n"
-                yaml += "      grpc-service-name: \(serviceName)\n"
+                yaml += "      grpc-service-name: \(yamlQuoted(serviceName))\n"
             }
         }
 
@@ -654,17 +666,20 @@ enum SubscriptionParser {
 
         if rest.contains("@") {
             // SIP002: base64(method:password)@server:port or method:password@server:port
-            let parts = rest.components(separatedBy: "@")
-            let userInfo = parts[0]
-            let hostPort = parts[1].components(separatedBy: "?")[0] // strip query
+            guard let atIdx = rest.lastIndex(of: "@") else { return nil }
+            let userInfo = String(rest[..<atIdx])
+            let hostAndQuery = String(rest[rest.index(after: atIdx)...])
+            let hostPort = splitOnce(hostAndQuery, separator: "?").head
 
-            // Decode userInfo if base64
+            // Decode userInfo if base64; plain method:password is also valid.
             let decoded: String
-            if let data = Data(base64Encoded: userInfo, options: .ignoreUnknownCharacters),
-               let d = String(data: data, encoding: .utf8) {
-                decoded = d
+            if userInfo.contains(":") {
+                decoded = userInfo.removingPercentEncoding ?? userInfo
+            } else if let data = decodeBase64(userInfo),
+                      let d = String(data: data, encoding: .utf8) {
+                decoded = d.removingPercentEncoding ?? d
             } else {
-                decoded = userInfo
+                decoded = userInfo.removingPercentEncoding ?? userInfo
             }
 
             guard let colonIdx = decoded.firstIndex(of: ":") else { return nil }
@@ -677,7 +692,7 @@ enum SubscriptionParser {
             port = p
         } else {
             // Legacy: ss://base64(method:password@server:port)
-            guard let data = Data(base64Encoded: rest, options: .ignoreUnknownCharacters),
+            guard let data = decodeBase64(rest),
                   let decoded = String(data: data, encoding: .utf8) else { return nil }
             guard let atIdx = decoded.lastIndex(of: "@") else { return nil }
             let userInfo = String(decoded[..<atIdx])
@@ -693,14 +708,13 @@ enum SubscriptionParser {
 
         let finalName = rawName.isEmpty ? "\(server):\(port)" : rawName
         let name = uniqueName(finalName, seenNames: &seenNames)
-        let escapedName = yamlEscape(name)
 
-        var yaml = "  - name: \"\(escapedName)\"\n"
+        var yaml = "  - name: \(yamlQuoted(name))\n"
         yaml += "    type: ss\n"
-        yaml += "    server: \(server)\n"
+        yaml += "    server: \(yamlQuoted(server))\n"
         yaml += "    port: \(port)\n"
-        yaml += "    cipher: \(method)\n"
-        yaml += "    password: \"\(yamlEscape(password))\"\n"
+        yaml += "    cipher: \(yamlQuoted(method))\n"
+        yaml += "    password: \(yamlQuoted(password))\n"
         yaml += "    udp: true\n"
 
         let node = ProxyNode(name: name, type: "ss", server: server, port: port)
@@ -712,10 +726,26 @@ enum SubscriptionParser {
     private static func parseQueryString(_ query: String) -> [String: String] {
         var result: [String: String] = [:]
         for pair in query.components(separatedBy: "&") {
-            let kv = pair.components(separatedBy: "=")
-            guard kv.count == 2 else { continue }
-            result[kv[0]] = kv[1]
+            guard let separator = pair.firstIndex(of: "=") else { continue }
+            let key = String(pair[..<separator]).removingPercentEncoding ?? String(pair[..<separator])
+            let rawValue = String(pair[pair.index(after: separator)...])
+            let value = rawValue.removingPercentEncoding ?? rawValue
+            result[key] = value
         }
         return result
+    }
+
+    private static func decodeBase64(_ text: String) -> Data? {
+        var normalized = text
+            .components(separatedBy: .whitespacesAndNewlines)
+            .joined()
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        guard !normalized.isEmpty else { return nil }
+        let remainder = normalized.count % 4
+        if remainder > 0 {
+            normalized += String(repeating: "=", count: 4 - remainder)
+        }
+        return Data(base64Encoded: normalized)
     }
 }

--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -247,6 +247,176 @@ struct MergeSubscriptionTests {
     }
 }
 
+@Suite("Proxy group serialization")
+struct ProxyGroupSerializationTests {
+
+    @Test("Quotes editable proxy group string values")
+    func quotesEditableProxyGroupStringValues() {
+        let groups = [
+            EditableProxyGroup(
+                name: "Node # chooser",
+                type: "select",
+                proxies: ["proxy: one", "line\nbreak"],
+                url: "https://example.com/health?x=1#frag",
+                interval: 300
+            )
+        ]
+
+        let yaml = ConfigManager.shared.updateProxyGroups(
+            groups,
+            in: "rules:\n  - MATCH,DIRECT"
+        )
+
+        #expect(yaml.contains("  - name: \"Node # chooser\""))
+        #expect(yaml.contains("    url: \"https://example.com/health?x=1#frag\""))
+        #expect(yaml.contains("      - \"proxy: one\""))
+        #expect(yaml.contains("      - \"line\\nbreak\""))
+
+        let parsed = ConfigManager.shared.parseProxyGroups(from: yaml)
+        #expect(parsed.count == 1)
+        #expect(parsed[0].name == "Node # chooser")
+        #expect(parsed[0].proxies == ["proxy: one", "line\nbreak"])
+    }
+
+    @Test("Global proxy group quotes selected node and replaces previous group")
+    func globalProxyGroupQuotesSelectedNodeAndReplacesPreviousGroup() {
+        let defaults = AppConstants.sharedDefaults
+        let previous = defaults.string(forKey: "selectedNode")
+        defer {
+            if let previous {
+                defaults.set(previous, forKey: "selectedNode")
+            } else {
+                defaults.removeObject(forKey: "selectedNode")
+            }
+        }
+        defaults.set("node #1\nnext", forKey: "selectedNode")
+
+        let yaml = """
+        proxy-groups:
+          - name: "GLOBAL"
+            type: select
+            proxies:
+              - old
+          - name: PROXY
+            type: select
+            proxies:
+              - node #1
+        rules:
+          - MATCH,PROXY
+        """
+
+        let updated = ConfigManager.shared.updateGlobalProxyGroup(yaml, enabled: true)
+        let globalNameCount = updated.components(separatedBy: "name: \"GLOBAL\"").count - 1
+
+        #expect(globalNameCount == 1)
+        #expect(updated.contains("      - \"node #1\\nnext\""))
+        #expect(!updated.contains("      - old"))
+    }
+
+}
+
+@Suite("Proxy server hostname rewrite")
+struct ProxyServerHostnameRewriteTests {
+
+    @Test("Rewrites only exact server scalar matches")
+    func rewritesOnlyExactServerScalarMatches() {
+        let yaml = """
+        proxies:
+          - name: exact
+            server: example.com
+          - name: prefix
+            server: example.com.hk
+          - name: quoted
+            server: "example.com"
+          - name: single-quoted
+            server: 'example.com'
+          - name: comment
+            server: example.com # pre-resolved at startup
+          - name: different-key
+            servername: example.com
+        """
+
+        let rewritten = ConfigManager.rewriteProxyServerHostnames(
+            in: yaml,
+            hostToIP: ["example.com": "93.184.216.34"]
+        )
+
+        #expect(rewritten.contains("server: 93.184.216.34\n"))
+        #expect(rewritten.contains("server: example.com.hk"))
+        #expect(rewritten.contains("server: \"93.184.216.34\""))
+        #expect(rewritten.contains("server: '93.184.216.34'"))
+        #expect(rewritten.contains("server: 93.184.216.34 # pre-resolved at startup"))
+        #expect(rewritten.contains("servername: example.com"))
+        #expect(!rewritten.contains("93.184.216.34.hk"))
+    }
+
+    @Test("Leaves unknown server values unchanged")
+    func leavesUnknownServerValuesUnchanged() {
+        let yaml = """
+        proxies:
+          - name: untouched
+            server: other.example
+        """
+
+        let rewritten = ConfigManager.rewriteProxyServerHostnames(
+            in: yaml,
+            hostToIP: ["example.com": "93.184.216.34"]
+        )
+
+        #expect(rewritten == yaml)
+    }
+}
+
+@Suite("Rule serialization")
+struct RuleSerializationTests {
+
+    @Test("Quotes rule strings containing comment characters")
+    func quotesRuleStringsContainingCommentCharacters() throws {
+        let rules = [
+            EditableRule(
+                type: "MATCH",
+                value: "",
+                target: "Group #1",
+                noResolve: false
+            ),
+            EditableRule(
+                type: "DOMAIN-SUFFIX",
+                value: "example.com",
+                target: "Proxy #2",
+                noResolve: false
+            ),
+        ]
+
+        let yaml = ConfigManager.shared.updateRules(rules, in: "proxies: []")
+
+        #expect(yaml.contains("  - \"MATCH,Group #1\""))
+        #expect(yaml.contains("  - \"DOMAIN-SUFFIX,example.com,Proxy #2\""))
+
+        let parsed = ConfigManager.shared.parseRules(from: yaml)
+        #expect(parsed.count == 2)
+        #expect(parsed[0].target == "Group #1")
+        #expect(parsed[1].target == "Proxy #2")
+    }
+
+    @Test("Preserves no-resolve marker when quoting rules")
+    func preservesNoResolveMarkerWhenQuotingRules() {
+        let rules = [
+            EditableRule(
+                type: "IP-CIDR",
+                value: "10.0.0.0/8",
+                target: "DIRECT",
+                noResolve: true
+            )
+        ]
+
+        let yaml = ConfigManager.shared.updateRules(rules, in: "proxies: []")
+        let parsed = ConfigManager.shared.parseRules(from: yaml)
+
+        #expect(yaml.contains("  - \"IP-CIDR,10.0.0.0/8,DIRECT,no-resolve\""))
+        #expect(parsed.first?.noResolve == true)
+    }
+}
+
 // MARK: - Sanitize Config
 
 @Suite("sanitizeConfigString")
@@ -335,6 +505,48 @@ struct SanitizeConfigStringTests {
 
 // MARK: - Subscription Parser (URI Lists)
 
+@Suite("Subscription Fetch Response")
+struct SubscriptionFetchResponseTests {
+
+    @Test("Rejects non-success HTTP status")
+    func rejectsNonSuccessHTTPStatus() throws {
+        let url = try #require(URL(string: "https://example.com/sub"))
+        let response = try #require(HTTPURLResponse(
+            url: url,
+            statusCode: 403,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+
+        do {
+            _ = try HomeView.parseFetchedSubscription(data: Data("forbidden".utf8), response: response)
+            #expect(Bool(false), "Expected badServerResponse")
+        } catch let error as URLError {
+            #expect(error.code == .badServerResponse)
+        } catch {
+            #expect(Bool(false), "Expected URLError, got \(error)")
+        }
+    }
+
+    @Test("Parses successful URI response")
+    func parsesSuccessfulURIResponse() throws {
+        let url = try #require(URL(string: "https://example.com/sub"))
+        let response = try #require(HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+        let uri = "vless://uuid@1.2.3.4:443?security=tls&type=ws#Node1"
+
+        let result = try HomeView.parseFetchedSubscription(data: Data(uri.utf8), response: response)
+
+        #expect(result.nodes.count == 1)
+        #expect(result.nodes.first?.name == "Node1")
+        #expect(result.raw.contains("proxies:"))
+    }
+}
+
 @Suite("SubscriptionParser URI list")
 struct SubscriptionParserURITests {
 
@@ -416,6 +628,79 @@ struct SubscriptionParserURITests {
         #expect(result.generatedYAML != nil)
     }
 
+    @Test("URI query values are decoded and YAML-quoted")
+    func queryValuesDecodedAndQuoted() throws {
+        let uri = "vless://uuid@1.2.3.4:443?security=tls&type=ws&host=edge.example%20%23comment&path=%2Fproxy%3Fx%3Da%3Db%25#Node1"
+
+        let result = SubscriptionParser.parseWithYAML(uri)
+        let yaml = try #require(result.generatedYAML)
+
+        #expect(yaml.contains("server: \"1.2.3.4\""))
+        #expect(yaml.contains("uuid: \"uuid\""))
+        #expect(yaml.contains("path: \"/proxy?x=a=b%\""))
+        #expect(yaml.contains("Host: \"edge.example #comment\""))
+    }
+
+    @Test("URI query values may contain question marks")
+    func queryValuesMayContainQuestionMarks() throws {
+        let uri = "vless://uuid@1.2.3.4:443?security=tls&type=ws&host=edge.example&path=/proxy?x=a=b#Node1"
+
+        let result = SubscriptionParser.parseWithYAML(uri)
+        let yaml = try #require(result.generatedYAML)
+
+        #expect(yaml.contains("path: \"/proxy?x=a=b\""))
+        #expect(yaml.contains("Host: \"edge.example\""))
+    }
+
+    @Test("Unsupported network query does not inject YAML")
+    func unsupportedNetworkQueryDoesNotInjectYAML() throws {
+        let uri = "vless://uuid@1.2.3.4:443?security=tls&type=ws%0A%20%20%20%20injected:%20true#Node1"
+
+        let result = SubscriptionParser.parseWithYAML(uri)
+        let yaml = try #require(result.generatedYAML)
+
+        #expect(yaml.contains("network: tcp"))
+        #expect(!yaml.contains("injected: true"))
+    }
+
+    @Test("Raw shadowsocks user info splits at final at-sign")
+    func rawShadowsocksUserInfoSplitsAtFinalAtSign() throws {
+        let uri = "ss://aes-128-gcm:pa@ss@1.2.3.4:8388#Node1"
+
+        let result = SubscriptionParser.parseWithYAML(uri)
+        let yaml = try #require(result.generatedYAML)
+
+        #expect(result.nodes.count == 1)
+        #expect(yaml.contains("cipher: \"aes-128-gcm\""))
+        #expect(yaml.contains("password: \"pa@ss\""))
+    }
+
+    @Test("Parses URL-safe unpadded vmess payload")
+    func parsesURLSafeUnpaddedVmessPayload() throws {
+        let json = """
+        {"v":"2","ps":"VMess Node","add":"1.2.3.4","port":"443","id":"uuid","aid":"0","net":"ws","type":"none","host":"edge.example","path":"/ws","tls":"tls","sni":"edge.example"}
+        """
+        let payload = Self.urlSafeUnpaddedBase64(json)
+        let result = SubscriptionParser.parseWithYAML("vmess://\(payload)")
+        let yaml = try #require(result.generatedYAML)
+
+        #expect(result.nodes.count == 1)
+        #expect(result.nodes.first?.name == "VMess Node")
+        #expect(yaml.contains("network: ws"))
+        #expect(yaml.contains("Host: \"edge.example\""))
+    }
+
+    @Test("Parses unpadded shadowsocks user info")
+    func parsesUnpaddedShadowsocksUserInfo() throws {
+        let userInfo = Self.urlSafeUnpaddedBase64("aes-128-gcm:password")
+        let result = SubscriptionParser.parseWithYAML("ss://\(userInfo)@1.2.3.4:8388#SSNode")
+        let yaml = try #require(result.generatedYAML)
+
+        #expect(result.nodes.count == 1)
+        #expect(yaml.contains("cipher: \"aes-128-gcm\""))
+        #expect(yaml.contains("password: \"password\""))
+    }
+
     @Test("Clash YAML subscription returns nil generatedYAML")
     func clashYAMLReturnsNilGenerated() {
         let yaml = """
@@ -440,6 +725,14 @@ struct SubscriptionParserURITests {
         let result = SubscriptionParser.parseWithYAML("")
         #expect(result.nodes.isEmpty)
         #expect(result.generatedYAML == nil)
+    }
+
+    private static func urlSafeUnpaddedBase64(_ text: String) -> String {
+        Data(text.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "="))
     }
 }
 

--- a/BaoLianDengTests/MihomoAPITests.swift
+++ b/BaoLianDengTests/MihomoAPITests.swift
@@ -104,6 +104,79 @@ struct MihomoConnectionsResponseTests {
     }
 }
 
+@Suite("Mihomo Connections Parser")
+struct MihomoConnectionsParserTests {
+
+    @Test("Parses current mihomo connection totals and metadata")
+    func parsesCurrentConnectionResponse() throws {
+        let json = """
+        {
+          "uploadTotal": 12345,
+          "downloadTotal": 67890,
+          "connections": [
+            {
+              "id": "conn-1",
+              "metadata": {
+                "host": "example.com",
+                "destinationIP": "93.184.216.34",
+                "destinationPort": "443",
+                "network": "tcp",
+                "type": "HTTPS"
+              },
+              "rule": "DOMAIN-SUFFIX",
+              "rulePayload": "example.com",
+              "chains": ["PROXY", "node-1"],
+              "upload": 111,
+              "download": 222,
+              "start": "2026-06-13T08:00:00.000Z"
+            }
+          ]
+        }
+        """
+
+        let response = try MihomoAPI.parseConnectionsResponse(Data(json.utf8))
+
+        #expect(response.uploadTotal == 12345)
+        #expect(response.downloadTotal == 67890)
+        #expect(response.connections.count == 1)
+        let connection = try #require(response.connections.first)
+        #expect(connection.destinationPort == 443)
+        #expect(connection.upload == 111)
+        #expect(connection.download == 222)
+        #expect(connection.chains == ["PROXY", "node-1"])
+    }
+
+    @Test("Parses legacy totals and numeric ports")
+    func parsesLegacyConnectionResponse() throws {
+        let json = """
+        {
+          "upload_total": "12",
+          "download_total": "34",
+          "connections": [
+            {
+              "id": "conn-2",
+              "metadata": {
+                "destinationPort": 53,
+                "network": "udp"
+              },
+              "upload": "5",
+              "download": "6"
+            }
+          ]
+        }
+        """
+
+        let response = try MihomoAPI.parseConnectionsResponse(Data(json.utf8))
+
+        #expect(response.uploadTotal == 12)
+        #expect(response.downloadTotal == 34)
+        let connection = try #require(response.connections.first)
+        #expect(connection.destinationPort == 53)
+        #expect(connection.upload == 5)
+        #expect(connection.download == 6)
+    }
+}
+
 @Suite("MihomoProxyGroup")
 struct MihomoProxyGroupTests {
 
@@ -122,6 +195,81 @@ struct MihomoProxyGroupTests {
         let group = MihomoProxyGroup(name: "Empty", type: "Selector", now: "", all: [])
         #expect(group.all.isEmpty)
         #expect(group.now == "")
+    }
+}
+
+@Suite("ProxiesResult YAML fallback")
+struct ProxiesResultYAMLTests {
+
+    @Test("Parses quoted proxy and group names")
+    func parsesQuotedProxyAndGroupNames() throws {
+        let yaml = """
+        proxies:
+          - name: "node: one # primary"
+            type: vmess
+            server: 1.2.3.4
+            port: 443
+          - {name: "node, two", type: ss, server: 5.6.7.8, port: 8388}
+        proxy-groups:
+          - name: "Group #1"
+            type: select
+            proxies:
+              - "node: one # primary"
+              - "node, two"
+              - DIRECT
+        rules:
+          - MATCH,Group #1
+        """
+
+        let result = ProxiesResult.fromYAML(yaml)
+
+        #expect(result.proxies["node: one # primary"]?.type == "vmess")
+        #expect(result.proxies["node, two"]?.type == "ss")
+        let group = try #require(result.groups["Group #1"])
+        #expect(group.type == "Selector")
+        #expect(group.now == "node: one # primary")
+        #expect(group.all == ["node: one # primary", "node, two", "DIRECT"])
+    }
+
+    @Test("Parses non-select group types")
+    func parsesNonSelectGroupTypes() throws {
+        let yaml = """
+        proxies:
+          - {name: node1, type: vmess, server: 1.2.3.4, port: 443}
+        proxy-groups:
+          - name: Auto
+            type: url-test
+            url: https://www.gstatic.com/generate_204
+            interval: 300
+            proxies:
+              - node1
+        """
+
+        let result = ProxiesResult.fromYAML(yaml)
+        let group = try #require(result.groups["Auto"])
+
+        #expect(group.type == "URLTest")
+        #expect(group.now == "node1")
+        #expect(group.all == ["node1"])
+    }
+
+    @Test("Invalid YAML returns empty result")
+    func invalidYAMLReturnsEmptyResult() {
+        let result = ProxiesResult.fromYAML("proxies: [[[not valid yaml")
+
+        #expect(result.groups.isEmpty)
+        #expect(result.proxies.isEmpty)
+    }
+
+    @Test("Adds built-in direct and reject proxies")
+    func addsBuiltInDirectAndRejectProxies() {
+        let result = ProxiesResult.fromYAML("""
+        proxies: []
+        proxy-groups: []
+        """)
+
+        #expect(result.proxies["DIRECT"]?.type == "Direct")
+        #expect(result.proxies["REJECT"]?.type == "Reject")
     }
 }
 
@@ -184,6 +332,61 @@ struct MihomoAPIErrorTests {
     func conformsToLocalizedError() {
         let error: any LocalizedError = MihomoAPIError.invalidURL
         #expect(error.errorDescription != nil)
+    }
+}
+
+// MARK: - API URL Builder Tests
+
+@Suite("MihomoAPI URL Builder")
+struct MihomoAPIURLBuilderTests {
+
+    @Test("Missing controller address throws notConnected")
+    func missingControllerAddress() {
+        let previousAddr = AppConstants.externalControllerAddr
+        AppConstants.sharedDefaults.removeObject(forKey: AppConstants.externalControllerAddrKey)
+        defer {
+            if let previousAddr {
+                AppConstants.sharedDefaults.set(previousAddr, forKey: AppConstants.externalControllerAddrKey)
+            }
+        }
+
+        do {
+            _ = try MihomoAPI.makeURL(pathSegments: ["rules"])
+            #expect(Bool(false), "Expected notConnected")
+        } catch MihomoAPIError.notConnected {
+            #expect(Bool(true))
+        } catch {
+            #expect(Bool(false), "Expected notConnected, got \(error)")
+        }
+    }
+
+    @Test("Path segments escape reserved characters")
+    func pathSegmentsEscapeReservedCharacters() throws {
+        let url = try #require(AppConstants.externalControllerURL(
+            controllerAddr: "127.0.0.1:12345",
+            pathSegments: ["proxies", "HK/01?fast#primary"]
+        ))
+
+        #expect(url.absoluteString == "http://127.0.0.1:12345/proxies/HK%2F01%3Ffast%23primary")
+    }
+
+    @Test("Query items preserve URL values")
+    func queryItemsPreserveURLValues() throws {
+        let probeURL = "https://example.com/generate_204?a=1&b=2"
+        let url = try #require(AppConstants.externalControllerURL(
+            controllerAddr: "127.0.0.1:12345",
+            pathSegments: ["group", "PROXY", "delay"],
+            queryItems: [
+                URLQueryItem(name: "url", value: probeURL),
+                URLQueryItem(name: "timeout", value: "5000"),
+            ]
+        ))
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let queryItems = components.queryItems ?? []
+
+        #expect(url.path == "/group/PROXY/delay")
+        #expect(queryItems.first(where: { $0.name == "url" })?.value == probeURL)
+        #expect(queryItems.first(where: { $0.name == "timeout" })?.value == "5000")
     }
 }
 

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -221,7 +221,7 @@ final class ConfigManager {
             var i = pgIdx + 1
             while i < lines.count {
                 let trimmed = lines[i].trimmingCharacters(in: .whitespaces)
-                if trimmed == "- name: GLOBAL" {
+                if trimmed == "- name: GLOBAL" || trimmed == "- name: \"GLOBAL\"" {
                     // Remove this group entry until the next group or end of section
                     let start = i
                     i += 1
@@ -252,12 +252,12 @@ final class ConfigManager {
         }) else { return lines.joined(separator: "\n") }
 
         var globalGroup = [
-            "  - name: GLOBAL",
+            "  - name: \(Self.yamlQuotedString("GLOBAL"))",
             "    type: select",
             "    proxies:",
         ]
         if let node = selectedNode, !node.isEmpty {
-            globalGroup.append("      - \(node)")
+            globalGroup.append("      - \(Self.yamlQuotedString(node))")
         } else {
             globalGroup.append("      - DIRECT")
         }
@@ -459,6 +459,83 @@ final class ConfigManager {
             }
             return line
         }.joined(separator: "\n")
+    }
+
+    private static func yamlQuotedString(_ s: String) -> String {
+        let escaped = s
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\t", with: "\\t")
+        return "\"\(escaped)\""
+    }
+
+    static func rewriteProxyServerHostnames(
+        in yaml: String,
+        hostToIP: [String: String]
+    ) -> String {
+        guard !hostToIP.isEmpty else { return yaml }
+        return yaml.components(separatedBy: "\n")
+            .map { rewriteServerLine($0, hostToIP: hostToIP) }
+            .joined(separator: "\n")
+    }
+
+    private static func rewriteServerLine(_ line: String, hostToIP: [String: String]) -> String {
+        let indent = line.prefix { $0 == " " || $0 == "\t" }
+        let rest = line.dropFirst(indent.count)
+        guard rest.hasPrefix("server:") else { return line }
+
+        let afterColon = rest.dropFirst("server:".count)
+        let valueStart = afterColon.prefix { $0 == " " || $0 == "\t" }
+        let valueAndComment = String(afterColon.dropFirst(valueStart.count))
+        guard !valueAndComment.isEmpty else { return line }
+
+        let parsed = parseYAMLScalarWithComment(valueAndComment)
+        guard let replacement = hostToIP[parsed.value] else { return line }
+
+        let quotedReplacement: String
+        switch parsed.quote {
+        case "\"":
+            quotedReplacement = yamlQuotedString(replacement)
+        case "'":
+            quotedReplacement = "'\(replacement.replacingOccurrences(of: "'", with: "''"))'"
+        default:
+            quotedReplacement = replacement
+        }
+        return "\(indent)server:\(valueStart)\(quotedReplacement)\(parsed.comment)"
+    }
+
+    private static func parseYAMLScalarWithComment(_ s: String) -> (value: String, quote: Character?, comment: String) {
+        guard let first = s.first else { return ("", nil, "") }
+        if first == "\"" || first == "'" {
+            var escaped = false
+            var value = ""
+            var index = s.index(after: s.startIndex)
+            while index < s.endIndex {
+                let character = s[index]
+                if first == "\"" && escaped {
+                    value.append(character)
+                    escaped = false
+                } else if first == "\"" && character == "\\" {
+                    escaped = true
+                } else if character == first {
+                    let comment = String(s[s.index(after: index)...])
+                    return (value, first, comment)
+                } else {
+                    value.append(character)
+                }
+                index = s.index(after: index)
+            }
+            return (value, first, "")
+        }
+
+        if let commentRange = s.range(of: #"(\s+#.*)$"#, options: .regularExpression) {
+            let value = String(s[..<commentRange.lowerBound])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return (value, nil, String(s[commentRange.lowerBound...]))
+        }
+        return (s.trimmingCharacters(in: .whitespacesAndNewlines), nil, "")
     }
 
     /// Extract top-level YAML sections by name.
@@ -726,10 +803,10 @@ extension ConfigManager {
         if groups.isEmpty { return ["proxy-groups: []"] }
         var result = ["proxy-groups:"]
         for group in groups {
-            result.append("  - name: \(group.name)")
+            result.append("  - name: \(Self.yamlQuotedString(group.name))")
             result.append("    type: \(group.type)")
             if let url = group.url, !url.isEmpty {
-                result.append("    url: \(url)")
+                result.append("    url: \(Self.yamlQuotedString(url))")
             }
             if let interval = group.interval {
                 result.append("    interval: \(interval)")
@@ -739,7 +816,7 @@ extension ConfigManager {
             } else {
                 result.append("    proxies:")
                 for proxy in group.proxies {
-                    result.append("      - \(proxy)")
+                    result.append("      - \(Self.yamlQuotedString(proxy))")
                 }
             }
         }
@@ -750,13 +827,15 @@ extension ConfigManager {
         if rules.isEmpty { return ["rules: []"] }
         var result = ["rules:"]
         for rule in rules {
+            let ruleLine: String
             if rule.type == "MATCH" {
-                result.append("  - MATCH,\(rule.target)")
+                ruleLine = "MATCH,\(rule.target)"
             } else {
-                var line = "  - \(rule.type),\(rule.value),\(rule.target)"
+                var line = "\(rule.type),\(rule.value),\(rule.target)"
                 if rule.noResolve { line += ",no-resolve" }
-                result.append(line)
+                ruleLine = line
             }
+            result.append("  - \(Self.yamlQuotedString(ruleLine))")
         }
         return result
     }

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -19,6 +19,9 @@ enum AppConstants {
     static let appGroupIdentifier: String? = nil
     static let tunnelBundleIdentifier = "io.github.baoliandeng.macos.TransparentProxy"
     static let configFileName = "config.yaml"
+    static var isRunningUnitTests: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
     /// UserDefaults key. The extension writes the live `host:port` of the
     /// mihomo REST controller here at startup; the main app reads it when
     /// hitting `/proxies`, `/connections`, etc. Updated each tunnel start
@@ -37,6 +40,31 @@ enum AppConstants {
         sharedDefaults.string(forKey: externalControllerAddrKey)
     }
 
+    static func externalControllerURL(pathSegments: [String], queryItems: [URLQueryItem] = []) -> URL? {
+        guard let addr = externalControllerAddr, !addr.isEmpty else {
+            return nil
+        }
+        return externalControllerURL(controllerAddr: addr, pathSegments: pathSegments, queryItems: queryItems)
+    }
+
+    static func externalControllerURL(
+        controllerAddr addr: String,
+        pathSegments: [String],
+        queryItems: [URLQueryItem] = []
+    ) -> URL? {
+        guard !addr.isEmpty,
+              var components = URLComponents(string: "http://\(addr)") else {
+            return nil
+        }
+        components.percentEncodedPath = "/" + pathSegments
+            .map { $0.addingPercentEncoding(withAllowedCharacters: controllerPathSegmentAllowed) ?? $0 }
+            .joined(separator: "/")
+        if !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
+        return components.url
+    }
+
     /// Shared UserDefaults via app group suite.
     static var sharedDefaults: UserDefaults {
         if let group = appGroupIdentifier {
@@ -44,6 +72,12 @@ enum AppConstants {
         }
         return .standard
     }
+
+    private static let controllerPathSegmentAllowed: CharacterSet = {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "%/?#[]@!$&'()*+,;=")
+        return allowed
+    }()
 }
 
 /// Pick a free 127.0.0.1 port by binding a SOCK_STREAM socket to port 0,

--- a/Shared/VPNManager.swift
+++ b/Shared/VPNManager.swift
@@ -65,7 +65,7 @@ final class VPNManager: NSObject, ObservableObject {
         super.init()
         // Don't touch the system extension or the user's real NE preferences
         // when the app is only hosting unit tests.
-        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+        if AppConstants.isRunningUnitTests {
             return
         }
         #if canImport(SystemExtensions)
@@ -131,6 +131,7 @@ final class VPNManager: NSObject, ObservableObject {
 
     /// Check if the system extension is enabled by re-probing activation status.
     func checkExtensionStatus(forceRetry: Bool = false) {
+        guard !AppConstants.isRunningUnitTests else { return }
         #if canImport(SystemExtensions)
         if Self.providerIsAppExtension {
             updateInstallState(.active)
@@ -205,6 +206,7 @@ final class VPNManager: NSObject, ObservableObject {
     // MARK: - Manager Lifecycle
 
     func loadManager() {
+        guard !AppConstants.isRunningUnitTests else { return }
         guard !isLoadingManager else { return }
         isLoadingManager = true
         dbg("loadManager called")
@@ -513,8 +515,7 @@ final class VPNManager: NSObject, ObservableObject {
     }
 
     private func selectNodeViaRestAPI(_ nodeName: String, retriesLeft: Int = 0) {
-        guard let addr = AppConstants.externalControllerAddr,
-              let url = URL(string: "http://\(addr)/proxies") else {
+        guard let url = AppConstants.externalControllerURL(pathSegments: ["proxies"]) else {
             // Controller addr not yet published by the extension; retry.
             if retriesLeft > 0 {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
@@ -569,8 +570,7 @@ final class VPNManager: NSObject, ObservableObject {
             }
             self?.dbg("selectNode: \(nodeName) -> \(targets.map { "\($0.group)=\($0.selection)" })")
             for (groupName, selection) in targets {
-                guard let encoded = groupName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
-                      let putURL = URL(string: "http://\(addr)/proxies/\(encoded)"),
+                guard let putURL = AppConstants.externalControllerURL(pathSegments: ["proxies", groupName]),
                       let body = try? JSONSerialization.data(withJSONObject: ["name": selection]) else { continue }
                 var request = URLRequest(url: putURL)
                 request.httpMethod = "PUT"

--- a/TransparentProxy/TransparentProxyProvider.swift
+++ b/TransparentProxy/TransparentProxyProvider.swift
@@ -819,20 +819,7 @@ class TransparentProxyProvider: NETransparentProxyProvider {
         }
 
         if !hostToIP.isEmpty {
-            for (hostname, resolvedIP) in hostToIP {
-                yaml = yaml.replacingOccurrences(
-                    of: "server: \(hostname)",
-                    with: "server: \(resolvedIP)"
-                )
-                yaml = yaml.replacingOccurrences(
-                    of: "server: '\(hostname)'",
-                    with: "server: '\(resolvedIP)'"
-                )
-                yaml = yaml.replacingOccurrences(
-                    of: "server: \"\(hostname)\"",
-                    with: "server: \"\(resolvedIP)\""
-                )
-            }
+            yaml = ConfigManager.rewriteProxyServerHostnames(in: yaml, hostToIP: hostToIP)
             try? yaml.write(
                 toFile: configPath, atomically: true, encoding: .utf8
             )


### PR DESCRIPTION
## Summary

This PR fixes several audit findings around config/controller parsing and test isolation:

- centralizes Mihomo external-controller URL construction so path segments and query values are encoded correctly
- parses `/connections` totals across current and legacy field spellings, including numeric strings
- replaces fragile YAML fallback parsing with Yams for proxy/group data
- quotes generated YAML values for proxy groups, rules, subscription nodes, and URI-derived fields
- rewrites pre-resolved proxy `server:` hostnames only on exact scalar matches instead of broad string replacement
- rejects non-2xx subscription fetch responses before parsing bodies as valid subscriptions
- prevents app-hosted unit tests from touching Firebase startup, NetworkExtension preferences, VPN autostart, and HomeView controller polling

## Validation

- `git diff --check`
- `xcodebuild test -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Debug -destination platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:BaoLianDengTests -skip-testing:BaoLianDengTests/ProxyEngineIntegrationTests`
- `xcodebuild build -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Debug -destination generic/platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Release -destination generic/platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`