### PR TITLE
[codex] Harden SOCKS5 destination encoding

### DIFF
--- a/BaoLianDengTests/MihomoAPITests.swift
+++ b/BaoLianDengTests/MihomoAPITests.swift
@@ -17,6 +17,64 @@ import Foundation
 import Testing
 @testable import BaoLianDeng
 
+@Suite("SOCKS5 CONNECT request")
+struct SOCKS5ConnectRequestTests {
+
+    @Test("Encodes IPv4 destinations")
+    func encodesIPv4Destination() throws {
+        let request = try SOCKS5Client.makeConnectRequest(
+            destHost: "1.2.3.4",
+            destPort: 443
+        )
+
+        #expect(Array(request) == [
+            0x05, 0x01, 0x00, 0x01,
+            0x01, 0x02, 0x03, 0x04,
+            0x01, 0xbb
+        ])
+    }
+
+    @Test("Encodes IPv6 destinations")
+    func encodesIPv6Destination() throws {
+        let request = try SOCKS5Client.makeConnectRequest(
+            destHost: "2001:db8::1",
+            destPort: 853
+        )
+
+        #expect(Array(request.prefix(4)) == [0x05, 0x01, 0x00, 0x04])
+        #expect(request.count == 22)
+        #expect(Array(request.suffix(2)) == [0x03, 0x55])
+    }
+
+    @Test("Encodes domain destinations")
+    func encodesDomainDestination() throws {
+        let request = try SOCKS5Client.makeConnectRequest(
+            destHost: "example.com",
+            destPort: 80
+        )
+
+        #expect(Array(request.prefix(5)) == [0x05, 0x01, 0x00, 0x03, 11])
+        #expect(String(data: request[5..<16], encoding: .utf8) == "example.com")
+        #expect(Array(request.suffix(2)) == [0x00, 0x50])
+    }
+
+    @Test("Rejects empty domain destinations")
+    func rejectsEmptyDomainDestination() throws {
+        #expect(throws: SOCKS5Error.invalidDestinationHost) {
+            try SOCKS5Client.makeConnectRequest(destHost: "", destPort: 80)
+        }
+    }
+
+    @Test("Rejects domains longer than SOCKS5 allows")
+    func rejectsOverlongDomainDestination() throws {
+        let host = String(repeating: "a", count: 256)
+
+        #expect(throws: SOCKS5Error.invalidDestinationHost) {
+            try SOCKS5Client.makeConnectRequest(destHost: host, destPort: 80)
+        }
+    }
+}
+
 // MARK: - Response Model Tests
 
 @Suite("MihomoRule")

--- a/TransparentProxy/SOCKS5Client.swift
+++ b/TransparentProxy/SOCKS5Client.swift
@@ -22,6 +22,7 @@ enum SOCKS5Error: LocalizedError {
     case unexpectedEOF
     case socks5AuthFailed
     case socks5ConnectFailed
+    case invalidDestinationHost
 
     var errorDescription: String? {
         switch self {
@@ -29,6 +30,7 @@ enum SOCKS5Error: LocalizedError {
         case .unexpectedEOF:       return "Unexpected end of data"
         case .socks5AuthFailed:    return "SOCKS5 authentication failed"
         case .socks5ConnectFailed: return "SOCKS5 CONNECT failed"
+        case .invalidDestinationHost: return "Invalid SOCKS5 destination host"
         }
     }
 }
@@ -134,28 +136,10 @@ enum SOCKS5Client {
             throw SOCKS5Error.socks5AuthFailed
         }
 
-        // Step 2: CONNECT request
-        var request = Data([0x05, 0x01, 0x00])
-
-        if IPv4Address(destHost) != nil {
-            request.append(0x01)
-            let parts = destHost.split(separator: ".").compactMap { UInt8($0) }
-            request.append(contentsOf: parts)
-        } else if let ipv6 = IPv6Address(destHost) {
-            request.append(0x04)
-            withUnsafeBytes(of: ipv6.rawValue) { request.append(contentsOf: $0) }
-        } else {
-            request.append(0x03)
-            let domainBytes = Array(destHost.utf8)
-            request.append(UInt8(domainBytes.count))
-            request.append(contentsOf: domainBytes)
-        }
-
-        // Port (big-endian)
-        request.append(UInt8(destPort >> 8))
-        request.append(UInt8(destPort & 0xFF))
-
-        try await sendAll(connection: connection, data: request)
+        try await sendAll(
+            connection: connection,
+            data: try makeConnectRequest(destHost: destHost, destPort: destPort)
+        )
 
         // Read response: version, status, rsv, atyp
         let connResp = try await readExact(connection: connection, count: 4)
@@ -177,5 +161,33 @@ enum SOCKS5Client {
         default:
             break
         }
+    }
+
+    static func makeConnectRequest(destHost: String, destPort: UInt16) throws -> Data {
+        var request = Data([0x05, 0x01, 0x00])
+
+        if IPv4Address(destHost) != nil {
+            request.append(0x01)
+            let parts = destHost.split(separator: ".").compactMap { UInt8($0) }
+            guard parts.count == 4 else {
+                throw SOCKS5Error.invalidDestinationHost
+            }
+            request.append(contentsOf: parts)
+        } else if let ipv6 = IPv6Address(destHost) {
+            request.append(0x04)
+            withUnsafeBytes(of: ipv6.rawValue) { request.append(contentsOf: $0) }
+        } else {
+            let domainBytes = Array(destHost.utf8)
+            guard !domainBytes.isEmpty, domainBytes.count <= 255 else {
+                throw SOCKS5Error.invalidDestinationHost
+            }
+            request.append(0x03)
+            request.append(UInt8(domainBytes.count))
+            request.append(contentsOf: domainBytes)
+        }
+
+        request.append(UInt8(destPort >> 8))
+        request.append(UInt8(destPort & 0xFF))
+        return request
     }
 }


### PR DESCRIPTION
This PR fixes an audit finding in the SOCKS5 CONNECT request encoder used by the transparent proxy path.

What changed:
- Extracted SOCKS5 CONNECT request construction into a testable helper used by the handshake.
- Reject empty domain destinations and domains longer than the SOCKS5 one-byte domain length field allows.
- Keep IPv4 and IPv6 encoding behavior covered with byte-level tests.

Why:
The previous domain path appended `UInt8(domainBytes.count)` directly. A destination host longer than 255 bytes would truncate the advertised domain length and send a malformed CONNECT request, leaving the SOCKS5 peer to parse the extra bytes as port/request data.

Validation:
- `git diff --check`
- `xcodebuild test -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Debug -destination platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:BaoLianDengTests/SOCKS5ConnectRequestTests`
- `xcodebuild test -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Debug -destination platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:BaoLianDengTests -skip-testing:BaoLianDengTests/ProxyEngineIntegrationTests`
- `xcodebuild build -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Release -destination generic/platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`