### PR TITLE
[codex] Reuse bundled geodata files

### DIFF
--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -856,3 +856,35 @@ struct URISubscriptionE2ETests {
         #expect(!merged.contains("MATCH,PROXY"))
     }
 }
+
+// MARK: - Bundled Geodata
+
+@Suite("Bundled geodata")
+struct BundledGeodataTests {
+
+    @Test("Copies embedded provider geodata without network fallback")
+    func copiesEmbeddedProviderGeodata() throws {
+        let tempDir = NSTemporaryDirectory() + "bld-geodata-test-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        for file in ConfigManager.geodataFiles {
+            let bundled = try #require(
+                ConfigManager.bundledGeodataURL(name: file.name, ext: file.ext),
+                "Expected bundled \(file.name).\(file.ext) to be discoverable"
+            )
+            #expect(FileManager.default.fileExists(atPath: bundled.path))
+        }
+
+        ConfigManager.shared.ensureGeodataFiles(configDir: tempDir)
+
+        for file in ConfigManager.geodataFiles {
+            let copied = URL(fileURLWithPath: tempDir)
+                .appendingPathComponent("\(file.name).\(file.ext)")
+            #expect(FileManager.default.fileExists(atPath: copied.path))
+            let attributes = try FileManager.default.attributesOfItem(atPath: copied.path)
+            let size = try #require(attributes[.size] as? NSNumber)
+            #expect(size.intValue > 0)
+        }
+    }
+}

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -58,8 +58,10 @@ final class ConfigManager {
             let dest = (configDir as NSString).appendingPathComponent(filename)
             guard !fileManager.fileExists(atPath: dest) else { continue }
 
-            // Try bundled copy first
-            if let src = Bundle.main.path(forResource: file.name, ofType: file.ext) {
+            // Try bundled copy first. In the main app, geodata is packaged
+            // inside the embedded provider extension rather than as a top-level
+            // app resource.
+            if let src = Self.bundledGeodataURL(name: file.name, ext: file.ext)?.path {
                 do {
                     try fileManager.copyItem(atPath: src, toPath: dest)
                     AppLogger.config.notice("Copied bundled \(filename) to config dir")
@@ -96,6 +98,50 @@ final class ConfigManager {
             task.resume()
             semaphore.wait()
         }
+    }
+
+    static func bundledGeodataURL(name: String, ext: String, bundle: Bundle = .main) -> URL? {
+        let fileManager = FileManager.default
+        if let path = bundle.path(forResource: name, ofType: ext) {
+            return URL(fileURLWithPath: path)
+        }
+
+        let filename = "\(name).\(ext)"
+        var bundleDirs: [URL] = []
+        if let plugInsURL = bundle.builtInPlugInsURL {
+            bundleDirs.append(plugInsURL)
+        }
+        bundleDirs.append(
+            bundle.bundleURL
+                .appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("SystemExtensions", isDirectory: true)
+        )
+
+        for dir in bundleDirs {
+            guard let children = try? fileManager.contentsOfDirectory(
+                at: dir,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            ) else { continue }
+
+            for child in children {
+                let resourceURL = child
+                    .appendingPathComponent("Contents", isDirectory: true)
+                    .appendingPathComponent("Resources", isDirectory: true)
+                    .appendingPathComponent(filename)
+                if fileManager.fileExists(atPath: resourceURL.path) {
+                    return resourceURL
+                }
+
+                let flatURL = child.appendingPathComponent(filename)
+                if fileManager.fileExists(atPath: flatURL.path) {
+                    return flatURL
+                }
+            }
+        }
+
+        return nil
     }
 
     func saveConfig(_ yaml: String) throws {


### PR DESCRIPTION
This PR fixes an audit finding in geodata setup for subscription validation and tunnel startup.

What changed:
- `ConfigManager.ensureGeodataFiles` now searches the main bundle plus embedded provider `.appex` and `.systemextension` resource folders before falling back to jsDelivr.
- Added a regression test proving the app test host can discover and copy the embedded provider geodata files without using the network.

Why:
The geodata files are already bundled with the provider targets, but the main app/test host did not find them via `Bundle.main.path(forResource:)`. That made validation tests and main-app subscription validation fall back to real network downloads even though the app bundle already contained the required data.

Impact:
- Subscription validation can reuse shipped geodata while offline.
- CI and local tests avoid repeated jsDelivr downloads for GEOIP/GEOSITE validation paths.
- The network fallback remains available if a future package is missing bundled files.

Validation:
- `git diff --check`
- `xcodebuild test -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Debug -destination platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:BaoLianDengTests/BundledGeodataTests`
- `xcodebuild test -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Debug -destination platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:BaoLianDengTests -skip-testing:BaoLianDengTests/ProxyEngineIntegrationTests`
- `xcodebuild build -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Release -destination generic/platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`