### PR TITLE
[codex] Anchor config scalar rewrites

### DIFF
--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -503,6 +503,58 @@ struct SanitizeConfigStringTests {
     }
 }
 
+// MARK: - Config Scalar Updates
+
+@Suite("Config top-level scalar replacement")
+struct ConfigTopLevelScalarReplacementTests {
+
+    @Test("Updates only the top-level mode key")
+    func updatesOnlyTopLevelMode() {
+        let yaml = """
+        mode: rule
+        dns:
+          enhanced-mode: redir-host
+        proxies:
+          - name: obfs-node
+            type: ss
+            server: 1.2.3.4
+            port: 8388
+            plugin: obfs
+            plugin-opts:
+              mode: websocket
+        """
+
+        let updated = ConfigManager.replacingTopLevelScalar(
+            in: yaml, key: "mode", value: "global"
+        )
+
+        #expect(updated.contains("mode: global"))
+        #expect(updated.contains("enhanced-mode: redir-host"))
+        #expect(updated.contains("mode: websocket"))
+        #expect(!updated.contains("mode: rule"))
+    }
+
+    @Test("Updates only the top-level log-level key")
+    func updatesOnlyTopLevelLogLevel() {
+        let yaml = """
+        log-level: info
+        proxy-providers:
+          demo:
+            type: http
+            log-level: debug
+            url: https://example.com/sub.yaml
+        """
+
+        let updated = ConfigManager.replacingTopLevelScalar(
+            in: yaml, key: "log-level", value: "error"
+        )
+
+        #expect(updated.hasPrefix("log-level: error"))
+        #expect(updated.contains("    log-level: debug"))
+        #expect(!updated.contains("log-level: info"))
+    }
+}
+
 // MARK: - Subscription Parser (URI Lists)
 
 @Suite("Subscription Fetch Response")

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -128,10 +128,7 @@ final class ConfigManager {
         let level = AppConstants.sharedDefaults
             .string(forKey: "logLevel") ?? "info"
         guard var config = try? loadConfig() else { return }
-        let levels = ["debug", "info", "warning", "error", "silent"]
-        for l in levels {
-            config = config.replacingOccurrences(of: "log-level: \(l)", with: "log-level: \(level)")
-        }
+        config = Self.replacingTopLevelScalar(in: config, key: "log-level", value: level)
         try? saveConfig(config)
     }
 
@@ -140,10 +137,7 @@ final class ConfigManager {
         let mode = AppConstants.sharedDefaults
             .string(forKey: "proxyMode") ?? "rule"
         guard var config = try? loadConfig() else { return }
-        let modes = ["rule", "global", "direct"]
-        for m in modes {
-            config = config.replacingOccurrences(of: "mode: \(m)", with: "mode: \(mode)")
-        }
+        config = Self.replacingTopLevelScalar(in: config, key: "mode", value: mode)
         config = updateGlobalProxyGroup(config, enabled: mode == "global")
         try? saveConfig(config)
     }
@@ -350,6 +344,21 @@ final class ConfigManager {
         var filtered = Array(lines[0..<start])
         filtered.append(contentsOf: lines[end...])
         config = filtered.joined(separator: "\n")
+    }
+
+    static func replacingTopLevelScalar(in yaml: String, key: String, value: String) -> String {
+        let normalized = yaml
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        let lines = normalized.components(separatedBy: "\n").map { line -> String in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !line.hasPrefix(" "), !line.hasPrefix("\t"),
+                  trimmed.hasPrefix("\(key):") else {
+                return line
+            }
+            return "\(key): \(value)"
+        }
+        return lines.joined(separator: "\n")
     }
 
     /// Merge a Clash subscription YAML into our base config.

--- a/Shared/VPNManager.swift
+++ b/Shared/VPNManager.swift
@@ -619,17 +619,14 @@ final class VPNManager: NSObject, ObservableObject {
 
         // Apply user settings
         if let logLevel = defaults.string(forKey: "logLevel") {
-            yaml = yaml.replacingOccurrences(
-                of: #"log-level:\s*\w+"#, with: "log-level: \(logLevel)",
-                options: .regularExpression)
+            yaml = ConfigManager.replacingTopLevelScalar(
+                in: yaml, key: "log-level", value: logLevel
+            )
         }
         if let mode = defaults.string(forKey: "proxyMode") {
-            // Anchor to a word boundary so we don't rewrite `enhanced-mode:`
-            // (mihomo's DNS parser rejects `enhanced-mode: rule` with
-            // "hub.Parse: invalid mode").
-            yaml = yaml.replacingOccurrences(
-                of: #"(?<![\w-])mode:\s*\w+"#, with: "mode: \(mode)",
-                options: .regularExpression)
+            yaml = ConfigManager.replacingTopLevelScalar(
+                in: yaml, key: "mode", value: mode
+            )
         }
 
         // Compress with zlib and store in providerConfiguration


### PR DESCRIPTION
## Summary
- Restrict saved `mode` and `log-level` rewrites to top-level YAML scalar keys.
- Reuse the same top-level scalar helper from `ConfigManager.applyMode`, `ConfigManager.applyLogLevel`, and `VPNManager.passSettingsToProvider`.
- Add regression tests proving nested keys such as `dns.enhanced-mode`, proxy `plugin-opts.mode`, and nested provider `log-level` are preserved.

## Bug fixed
`VPNManager.passSettingsToProvider` already avoided `enhanced-mode`, but its regex could still rewrite any nested indented `mode:` field when applying the saved proxy mode. That could corrupt proxy plugin configuration such as `plugin-opts: mode: websocket` by changing it to `mode: global` or `mode: direct`.

## Validation
- `xcodebuild test -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Debug -destination platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:BaoLianDengTests/ConfigTopLevelScalarReplacementTests`
- `git diff --check`
- `xcodebuild test -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Debug -destination platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:BaoLianDengTests -skip-testing:BaoLianDengTests/ProxyEngineIntegrationTests`
- `xcodebuild build -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Release -destination generic/platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`