### PR TITLE
[codex] Harden traffic counter resets

### DIFF
--- a/BaoLianDeng/Models/TrafficStore.swift
+++ b/BaoLianDeng/Models/TrafficStore.swift
@@ -59,6 +59,10 @@ final class TrafficStore: ObservableObject {
     private var lastAttributedDownload: Int64 = 0
     private var todayBaseUpload: Int64 = 0
     private var todayBaseDownload: Int64 = 0
+    private var dayCounterBaselineUpload: Int64 = 0
+    private var dayCounterBaselineDownload: Int64 = 0
+    private var awaitingInitialCounterSample = false
+    private var didResetForCurrentStart = false
     private var currentDate: String = ""
     private var timer: Timer?
     private let defaults = AppConstants.sharedDefaults
@@ -86,7 +90,7 @@ final class TrafficStore: ObservableObject {
 
     func startPolling() {
         stopPolling()
-        currentDate = Self.dateFormatter.string(from: Date())
+        prepareForPollingStart()
         refreshSubscriptionCache()
         refreshGroupMembers()
         fetchConnections()
@@ -137,12 +141,37 @@ final class TrafficStore: ObservableObject {
         activeTotalCount = 0
         lastAttributedUpload = 0
         lastAttributedDownload = 0
+        dayCounterBaselineUpload = 0
+        dayCounterBaselineDownload = 0
+        awaitingInitialCounterSample = false
+        didResetForCurrentStart = true
 
         loadRecords()
         currentDate = Self.dateFormatter.string(from: Date())
         if let todayRecord = dailyRecords.first(where: { $0.date == currentDate }) {
             todayBaseUpload = todayRecord.proxyUpload
             todayBaseDownload = todayRecord.proxyDownload
+        } else {
+            todayBaseUpload = 0
+            todayBaseDownload = 0
+        }
+    }
+
+    private func prepareForPollingStart() {
+        currentDate = Self.dateFormatter.string(from: Date())
+        syncTodayBaseFromRecords()
+        awaitingInitialCounterSample =
+            !didResetForCurrentStart && sessionProxyUpload == 0 && sessionProxyDownload == 0
+        didResetForCurrentStart = false
+    }
+
+    private func syncTodayBaseFromRecords() {
+        let countedUpload = max(0, sessionProxyUpload - dayCounterBaselineUpload)
+        let countedDownload = max(0, sessionProxyDownload - dayCounterBaselineDownload)
+
+        if let todayRecord = dailyRecords.first(where: { $0.date == currentDate }) {
+            todayBaseUpload = max(0, todayRecord.proxyUpload - countedUpload)
+            todayBaseDownload = max(0, todayRecord.proxyDownload - countedDownload)
         } else {
             todayBaseUpload = 0
             todayBaseDownload = 0
@@ -182,6 +211,8 @@ final class TrafficStore: ObservableObject {
             currentDate = today
             todayBaseUpload = 0
             todayBaseDownload = 0
+            dayCounterBaselineUpload = sessionProxyUpload
+            dayCounterBaselineDownload = sessionProxyDownload
         }
 
         // Refresh the group map at most every 30s so mid-session config
@@ -196,9 +227,19 @@ final class TrafficStore: ObservableObject {
             if !isDirect(chains: chains) { proxyCount += 1 }
         }
 
-        // Use tunnel-level totals for session traffic.
-        // The tunnel counts all traffic through the proxy engine; since tun2socks
-        // routes everything via SOCKS5, this is effectively all proxy traffic.
+        if awaitingInitialCounterSample {
+            dayCounterBaselineUpload = uploadTotal
+            dayCounterBaselineDownload = downloadTotal
+            lastAttributedUpload = uploadTotal
+            lastAttributedDownload = downloadTotal
+            awaitingInitialCounterSample = false
+        }
+
+        reconcileCounterResets(uploadTotal: uploadTotal, downloadTotal: downloadTotal)
+
+        // Use tunnel-level totals for session traffic. The tunnel counts all
+        // traffic through the proxy engine; since tun2socks routes everything
+        // via SOCKS5, this is effectively all proxy traffic.
         sessionProxyUpload = uploadTotal
         sessionProxyDownload = downloadTotal
         activeProxyCount = proxyCount
@@ -215,6 +256,19 @@ final class TrafficStore: ObservableObject {
         lastAttributedDownload = sessionProxyDownload
 
         persistToday()
+    }
+
+    private func reconcileCounterResets(uploadTotal: Int64, downloadTotal: Int64) {
+        if uploadTotal < sessionProxyUpload {
+            todayBaseUpload += max(0, sessionProxyUpload - dayCounterBaselineUpload)
+            dayCounterBaselineUpload = 0
+            lastAttributedUpload = 0
+        }
+        if downloadTotal < sessionProxyDownload {
+            todayBaseDownload += max(0, sessionProxyDownload - dayCounterBaselineDownload)
+            dayCounterBaselineDownload = 0
+            lastAttributedDownload = 0
+        }
     }
 
     private func isDirect(chains: [String]) -> Bool {
@@ -236,8 +290,8 @@ final class TrafficStore: ObservableObject {
     }
 
     private func persistToday() {
-        let todayUp = todayBaseUpload + sessionProxyUpload
-        let todayDown = todayBaseDownload + sessionProxyDownload
+        let todayUp = todayBaseUpload + max(0, sessionProxyUpload - dayCounterBaselineUpload)
+        let todayDown = todayBaseDownload + max(0, sessionProxyDownload - dayCounterBaselineDownload)
 
         if let idx = dailyRecords.firstIndex(where: { $0.date == currentDate }) {
             dailyRecords[idx].proxyUpload = todayUp
@@ -322,4 +376,48 @@ final class TrafficStore: ObservableObject {
         defaults.removeObject(forKey: AppConstants.subscriptionUsageKey)
         refreshSubscriptionCache()
     }
+
+    #if DEBUG
+    func preparePollingForTesting() {
+        prepareForPollingStart()
+    }
+
+    func resetTrafficStateForTesting(
+        dailyRecords: [DailyTraffic] = [],
+        subscriptionUsages: [SubscriptionUsage] = [],
+        sessionUpload: Int64 = 0,
+        sessionDownload: Int64 = 0,
+        todayBaseUpload: Int64 = 0,
+        todayBaseDownload: Int64 = 0,
+        dayCounterBaselineUpload: Int64 = 0,
+        dayCounterBaselineDownload: Int64 = 0,
+        lastAttributedUpload: Int64 = 0,
+        lastAttributedDownload: Int64 = 0,
+        didResetForCurrentStart: Bool = false
+    ) {
+        stopPolling()
+        self.dailyRecords = dailyRecords
+        self.subscriptionUsages = subscriptionUsages
+        sessionProxyUpload = sessionUpload
+        sessionProxyDownload = sessionDownload
+        activeProxyCount = 0
+        activeTotalCount = 0
+        self.todayBaseUpload = todayBaseUpload
+        self.todayBaseDownload = todayBaseDownload
+        self.dayCounterBaselineUpload = dayCounterBaselineUpload
+        self.dayCounterBaselineDownload = dayCounterBaselineDownload
+        self.lastAttributedUpload = lastAttributedUpload
+        self.lastAttributedDownload = lastAttributedDownload
+        awaitingInitialCounterSample = false
+        self.didResetForCurrentStart = didResetForCurrentStart
+        currentDate = Self.dateFormatter.string(from: Date())
+        defaults.removeObject(forKey: AppConstants.dailyTrafficKey)
+        defaults.removeObject(forKey: AppConstants.subscriptionUsageKey)
+        defaults.removeObject(forKey: "selectedSubscriptionID")
+    }
+
+    func processConnectionsForTesting(uploadTotal: Int64, downloadTotal: Int64) {
+        processConnections([], uploadTotal: uploadTotal, downloadTotal: downloadTotal)
+    }
+    #endif
 }

--- a/BaoLianDengTests/MihomoAPITests.swift
+++ b/BaoLianDengTests/MihomoAPITests.swift
@@ -841,3 +841,62 @@ struct ProxyModeTests {
         #expect(ProxyMode(rawValue: "invalid") == nil)
     }
 }
+
+// MARK: - TrafficStore Counter Accounting
+
+@MainActor
+@Suite("TrafficStore counter accounting", .serialized)
+struct TrafficStoreCounterAccountingTests {
+
+    private func today() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter.string(from: Date())
+    }
+
+    @Test("Counter reset preserves already persisted daily traffic")
+    func counterResetPreservesDailyTraffic() {
+        let store = TrafficStore.shared
+        let date = today()
+        store.resetTrafficStateForTesting(
+            dailyRecords: [
+                DailyTraffic(date: date, proxyUpload: 2_100, proxyDownload: 4_050)
+            ],
+            sessionUpload: 2_000,
+            sessionDownload: 4_000,
+            todayBaseUpload: 100,
+            todayBaseDownload: 50,
+            lastAttributedUpload: 2_000,
+            lastAttributedDownload: 4_000
+        )
+        defer { store.resetTrafficStateForTesting() }
+
+        store.processConnectionsForTesting(uploadTotal: 100, downloadTotal: 200)
+
+        let record = store.dailyRecords.first { $0.date == date }
+        #expect(record?.proxyUpload == 2_200)
+        #expect(record?.proxyDownload == 4_250)
+    }
+
+    @Test("Initial already-running counter sample does not overwrite persisted day")
+    func initialSampleKeepsPersistedDay() {
+        let store = TrafficStore.shared
+        let date = today()
+        store.resetTrafficStateForTesting(
+            dailyRecords: [
+                DailyTraffic(date: date, proxyUpload: 3_000, proxyDownload: 7_000)
+            ]
+        )
+        defer { store.resetTrafficStateForTesting() }
+
+        store.preparePollingForTesting()
+        store.processConnectionsForTesting(uploadTotal: 2_000, downloadTotal: 4_000)
+
+        let record = store.dailyRecords.first { $0.date == date }
+        #expect(record?.proxyUpload == 3_000)
+        #expect(record?.proxyDownload == 7_000)
+        #expect(store.sessionProxyUpload == 2_000)
+        #expect(store.sessionProxyDownload == 4_000)
+    }
+}


### PR DESCRIPTION
## Summary
- Track a per-day counter baseline for traffic persistence instead of assuming mihomo tunnel counters are day-local and monotonic forever.
- Seed the baseline when polling starts against an already-running tunnel so persisted daily totals are not overwritten downward by the first sample.
- Fold completed counter segments into the daily base when the reported tunnel counter drops after an engine restart.
- Add regression coverage for counter reset handling and initial already-running samples.

## Root cause
`TrafficStore` persisted daily records as `todayBase + sessionProxyUpload/sessionProxyDownload`, while `sessionProxyUpload` and `sessionProxyDownload` are raw tunnel counters. When polling began after a daily record already existed, or when the tunnel counter reset to a lower value, the next persistence pass could replace the day record with a smaller raw counter value.

## Validation
- `xcodebuild test -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Debug -destination platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:BaoLianDengTests/TrafficStoreCounterAccountingTests`
- `git diff --check`
- `xcodebuild test -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Debug -destination platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:BaoLianDengTests -skip-testing:BaoLianDengTests/ProxyEngineIntegrationTests`
- `xcodebuild build -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Release -destination generic/platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`