### PR TITLE
[codex] Escape URI proxy group names

### DIFF
--- a/BaoLianDeng/Views/SubscriptionModels.swift
+++ b/BaoLianDeng/Views/SubscriptionModels.swift
@@ -383,7 +383,8 @@ enum SubscriptionParser {
         }
 
         // Build complete YAML with proxies + proxy-groups (no leading indentation)
-        let nodeNames = nodes.map { "      - \"\($0.name)\"" }.joined(separator: "\n")
+        let nodeNames = nodes.map { "      - \"\(yamlEscape($0.name))\"" }
+            .joined(separator: "\n")
         var fullYAML = "proxies:\n"
         fullYAML += yamlProxies.joined(separator: "\n")
         fullYAML += "\n\nproxy-groups:\n"

--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -376,6 +376,19 @@ struct SubscriptionParserURITests {
         #expect(yaml.contains("type: select"))
     }
 
+    @Test("Generated YAML escapes URI names in proxy group members")
+    func generatedYAMLEscapesProxyGroupMemberNames() {
+        let uri = "vless://uuid@1.2.3.4:443?security=tls&type=ws#Quote%22Name%5CNode"
+        let base64 = Data(uri.utf8).base64EncodedString()
+        let result = SubscriptionParser.parseWithYAML(base64)
+        let yaml = result.generatedYAML!
+
+        #expect(result.nodes[0].name == "Quote\"Name\\Node")
+        #expect(yaml.contains("  - name: \"Quote\\\"Name\\\\Node\""))
+        #expect(yaml.contains("      - \"Quote\\\"Name\\\\Node\""))
+        #expect(!yaml.contains("      - \"Quote\"Name\\Node\""))
+    }
+
     @Test("Generated YAML sections extractable by extractYAMLSections")
     func generatedYAMLExtractable() {
         let uri = "vless://uuid@1.2.3.4:443?security=tls&type=ws#Node1"


### PR DESCRIPTION
## Summary
- Escape generated URI subscription node names when writing the `proxy-groups[].proxies` member list.
- Keep proxy entry names and group member references encoded consistently for double-quoted YAML scalars.
- Add regression coverage for URI fragments containing a quote and backslash.

## Root cause
URI subscription generation already escaped the proxy entry `name`, but inserted the decoded node name raw into the generated `PROXY` select group. A fragment such as `Quote%22Name%5CNode` could produce a valid escaped proxy name but an invalid or mismatched group member line.

## Validation
- `xcodebuild test -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Debug -destination platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:BaoLianDengTests/SubscriptionParserURITests`
- `git diff --check`
- `xcodebuild test -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Debug -destination platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:BaoLianDengTests -skip-testing:BaoLianDengTests/ProxyEngineIntegrationTests`
- `xcodebuild build -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Release -destination generic/platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`