### PR TITLE
[codex] Encode Mihomo controller path segments

### DIFF
--- a/BaoLianDeng/Models/MihomoAPI.swift
+++ b/BaoLianDeng/Models/MihomoAPI.swift
@@ -168,7 +168,10 @@ enum MihomoAPI {
     }
 
     static func closeConnection(_ id: String) async throws {
-        try await delete("/connections/\(id)")
+        guard let encoded = MihomoURL.pathSegment(id) else {
+            throw MihomoAPIError.invalidURL
+        }
+        try await delete("/connections/\(encoded)")
     }
 
     static func closeAllConnections() async throws {
@@ -211,7 +214,7 @@ enum MihomoAPI {
 
     /// Select a proxy node within a group via PUT /proxies/{group}
     static func selectProxy(group: String, name: String) async throws {
-        guard let encoded = group.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+        guard let encoded = MihomoURL.pathSegment(group),
               let url = URL(string: "\(baseURL)/proxies/\(encoded)") else {
             throw MihomoAPIError.invalidURL
         }
@@ -229,7 +232,7 @@ enum MihomoAPI {
     // MARK: - Delay Testing
 
     static func testGroupDelay(group: String, url: String = "https://www.gstatic.com/generate_204", timeout: Int = 5000) async throws -> [MihomoDelayResult] {
-        guard let encoded = group.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+        guard let encoded = MihomoURL.pathSegment(group),
               let url = URL(string: "\(baseURL)/group/\(encoded)/delay?url=\(url)&timeout=\(timeout)") else {
             throw MihomoAPIError.invalidURL
         }
@@ -255,7 +258,7 @@ enum MihomoAPI {
     }
 
     static func testProxyDelay(proxy: String, url: String = "https://www.gstatic.com/generate_204", timeout: Int = 5000) async throws -> Int {
-        guard let encoded = proxy.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+        guard let encoded = MihomoURL.pathSegment(proxy),
               let url = URL(string: "\(baseURL)/proxies/\(encoded)/delay?url=\(url)&timeout=\(timeout)") else {
             throw MihomoAPIError.invalidURL
         }

--- a/BaoLianDengTests/MihomoAPITests.swift
+++ b/BaoLianDengTests/MihomoAPITests.swift
@@ -187,6 +187,25 @@ struct MihomoAPIErrorTests {
     }
 }
 
+@Suite("Mihomo URL Encoding")
+struct MihomoURLEncodingTests {
+
+    @Test("Path segment encoding escapes slash in proxy names")
+    func pathSegmentEscapesSlash() {
+        let encoded = MihomoURL.pathSegment("Auto/Asia #1")
+
+        #expect(encoded == "Auto%2FAsia%20%231")
+    }
+
+    @Test("Path segment encoding preserves a single route component")
+    func pathSegmentPreservesSingleRouteComponent() {
+        let encoded = MihomoURL.pathSegment("HK/US 100%")
+        let url = URL(string: "http://127.0.0.1:9090/proxies/\(encoded ?? "")")
+
+        #expect(url?.absoluteString == "http://127.0.0.1:9090/proxies/HK%2FUS%20100%25")
+    }
+}
+
 // MARK: - Delay Color Tests
 
 @Suite("Delay Color Logic")

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -46,6 +46,18 @@ enum AppConstants {
     }
 }
 
+enum MihomoURL {
+    private static let pathSegmentAllowed: CharacterSet = {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/")
+        return allowed
+    }()
+
+    static func pathSegment(_ value: String) -> String? {
+        value.addingPercentEncoding(withAllowedCharacters: pathSegmentAllowed)
+    }
+}
+
 /// Pick a free 127.0.0.1 port by binding a SOCK_STREAM socket to port 0,
 /// reading the assigned port, then closing. There's a small TOCTOU
 /// window before the next consumer binds, but the ephemeral port space

--- a/Shared/VPNManager.swift
+++ b/Shared/VPNManager.swift
@@ -569,7 +569,7 @@ final class VPNManager: NSObject, ObservableObject {
             }
             self?.dbg("selectNode: \(nodeName) -> \(targets.map { "\($0.group)=\($0.selection)" })")
             for (groupName, selection) in targets {
-                guard let encoded = groupName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+                guard let encoded = MihomoURL.pathSegment(groupName),
                       let putURL = URL(string: "http://\(addr)/proxies/\(encoded)"),
                       let body = try? JSONSerialization.data(withJSONObject: ["name": selection]) else { continue }
                 var request = URLRequest(url: putURL)


### PR DESCRIPTION
## Summary

- add a shared Mihomo path-segment encoder that percent-encodes `/` inside controller keys
- use it for proxy group selection, group delay tests, proxy delay tests, connection close paths, and saved-selection replay
- add regression coverage for slash and percent characters in proxy/group names

## Root cause

Controller API path parameters were encoded with `CharacterSet.urlPathAllowed`, which leaves `/` unescaped. Proxy group and node names can contain slashes, so those names were split into additional URL path components instead of being sent as one Mihomo controller key.

## Validation

- `git diff --check`
- `xcodebuild test -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Debug -destination platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:BaoLianDengTests/MihomoURLEncodingTests`
- `xcodebuild test -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Debug -destination platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:BaoLianDengTests -skip-testing:BaoLianDengTests/ProxyEngineIntegrationTests`
- `xcodebuild build -project BaoLianDeng.xcodeproj -scheme BaoLianDeng -configuration Release -destination generic/platform=macOS CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`