### PR TITLE
Guard TCP relay continuations against double-resume during teardown

### DIFF
--- a/TransparentProxy/TransparentProxyProvider.swift
+++ b/TransparentProxy/TransparentProxyProvider.swift
@@ -456,12 +456,12 @@ class TransparentProxyProvider: NETransparentProxyProvider {
             // Flow → SOCKS5
             group.addTask {
                 while true {
-                    let data: Data? = await withCheckedContinuation { cont in
+                    let data: Data? = await withOneShotFlowContinuation { resume in
                         flow.readData(completionHandler: { data, error in
                             if error != nil || data == nil || data!.isEmpty {
-                                cont.resume(returning: nil)
+                                resume(nil)
                             } else {
-                                cont.resume(returning: data)
+                                resume(data)
                             }
                         })
                     }
@@ -484,9 +484,9 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                     do {
                         let data = try await SOCKS5Client.readSome(connection: connection)
                         guard !data.isEmpty else { break }
-                        let writeOK: Bool = await withCheckedContinuation { cont in
+                        let writeOK: Bool = await withOneShotFlowContinuation { resume in
                             flow.write(data) { error in
-                                cont.resume(returning: error == nil)
+                                resume(error == nil)
                             }
                         }
                         if !writeOK { break }
@@ -865,6 +865,38 @@ class TransparentProxyProvider: NETransparentProxyProvider {
 extension Collection {
     subscript(safe index: Index) -> Element? {
         indices.contains(index) ? self[index] : nil
+    }
+}
+
+// MARK: - Flow continuation helper
+
+/// Bridge a flow completion-handler callback to async, resuming the
+/// continuation exactly once even if the handler fires more than once during
+/// teardown races.
+///
+/// `NEAppProxyTCPFlow.readData`/`write` belong to the same flow family as
+/// `NEAppProxyFlow.open` (see `TransparentProxyProvider.openFlow`), whose
+/// completion handler can fire multiple times during teardown. A bare
+/// `withCheckedContinuation` would then call `cont.resume` twice and trap with
+/// "SWIFT TASK CONTINUATION MISUSE" (EXC_BREAKPOINT), killing the extension.
+/// The `resumed` flag (guarded by a lock, since the handler may fire on
+/// different threads) makes resumption happen exactly once.
+private func withOneShotFlowContinuation<T>(
+    _ body: (@escaping (T) -> Void) -> Void
+) async -> T {
+    await withCheckedContinuation { (cont: CheckedContinuation<T, Never>) in
+        let lock = NSLock()
+        var resumed = false
+        body { value in
+            lock.lock()
+            if resumed {
+                lock.unlock()
+                return
+            }
+            resumed = true
+            lock.unlock()
+            cont.resume(returning: value)
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

`relayTCP()` bridged `flow.readData` / `flow.write` to async with **bare** `withCheckedContinuation`, while the sibling `openFlow()` (and `handleUDPDatagrams()`) deliberately wrap the same `NEAppProxyFlow` completion-handler family in a lock-guarded one-shot `resumed` flag. The existing code carries an explicit comment:

> `NEAppProxy*Flow` … can invoke its completion handler more than once during teardown races. A bare `withCheckedThrowingContinuation` would then call `cont.resume` twice and trap with "SWIFT TASK CONTINUATION MISUSE" (EXC_BREAKPOINT), killing the extension.

The two `relayTCP` continuations run on **every proxied TCP connection's** read/write path — precisely active during the high-churn cancellation/teardown window — yet were left unguarded. A double-fired completion handler during flow teardown resumes a `CheckedContinuation` twice and crashes the `NETransparentProxyProvider` extension, dropping all active connections.

## Fix

Factor the lock-guarded one-shot resume pattern into a reusable `withOneShotFlowContinuation` helper and route both `relayTCP` continuations through it, matching the existing `openFlow` hardening exactly. No behavioral change on the happy path; the guard only suppresses a second (illegal) resume.

## Verification

- `xcodebuild build` (Debug, macOS) — **BUILD SUCCEEDED**
- `swiftlint --strict` clean on the changed file

Found by an automated security/correctness audit of the proxy data path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)