### PR TITLE
Harden Go mihomo bridge: diagnostics port, version race, dead extern

### DIFF
--- a/Go/mihomo-bridge/bridge.go
+++ b/Go/mihomo-bridge/bridge.go
@@ -32,6 +32,7 @@ var (
 	logSubOnce sync.Once
 
 	versionCStr *C.char // cached, never freed
+	versionOnce sync.Once
 
 	// Ports/addr actually bound by mihomo this run. Reset on stop.
 	// Picked dynamically (port 0) to avoid colliding with other mihomo
@@ -292,9 +293,9 @@ func bridge_update_log_level(level *C.char) {
 
 //export bridge_version
 func bridge_version() *C.char {
-	if versionCStr == nil {
+	versionOnce.Do(func() {
 		versionCStr = C.CString("mihomo-go " + constant.Version)
-	}
+	})
 	return versionCStr
 }
 

--- a/Go/mihomo-bridge/diagnostics.go
+++ b/Go/mihomo-bridge/diagnostics.go
@@ -48,7 +48,14 @@ func bridge_test_proxy_http(target *C.char) *C.char {
 	}
 	t := C.GoString(target)
 
-	dialer, err := proxy.SOCKS5("tcp", "127.0.0.1:7890", nil, &net.Dialer{Timeout: diagConnectTimeout})
+	stateMu.Lock()
+	socksPort := runtimeSocksPort
+	stateMu.Unlock()
+	if socksPort == 0 {
+		return C.CString("FAIL: proxy not running (socks port unset)")
+	}
+
+	dialer, err := proxy.SOCKS5("tcp", fmt.Sprintf("127.0.0.1:%d", socksPort), nil, &net.Dialer{Timeout: diagConnectTimeout})
 	if err != nil {
 		return C.CString(fmt.Sprintf("FAIL: socks5 dialer: %v", err))
 	}

--- a/Go/mihomo-bridge/objc/MihomoCore.m
+++ b/Go/mihomo-bridge/objc/MihomoCore.m
@@ -1,7 +1,7 @@
 #import "MihomoCore.h"
 #include <stdbool.h>
 
-// C FFI declarations (from Rust staticlib)
+// C FFI declarations (from the Go c-archive)
 extern void bridge_set_home_dir(const char *dir);
 extern int32_t bridge_set_log_file(const char *path);
 extern int32_t bridge_start_with_ports(int32_t socks_port, int32_t dns_port, const char *controller_addr, const char *secret);
@@ -10,7 +10,6 @@ extern int32_t bridge_get_dns_port(void);
 extern char *bridge_get_external_controller_addr(void);
 extern void bridge_stop_proxy(void);
 extern bool bridge_is_running(void);
-extern char *bridge_read_config(void);
 extern int32_t bridge_validate_config(const char *yaml);
 extern void bridge_update_log_level(const char *level);
 extern int64_t bridge_get_upload_traffic(void);


### PR DESCRIPTION
Three independent defects found by an automated audit of the cgo bridge boundary.

## 1. `bridge_test_proxy_http` dialed a hardcoded `127.0.0.1:7890` (correctness)
The SOCKS port is now ephemeral, picked by the main app at tunnel start — there is no fixed `7890` anymore. The "Test Proxy HTTP" diagnostic therefore dialed a port nothing listens on and could never reach the real proxy. Now reads `runtimeSocksPort` under `stateMu` and returns a clear `FAIL: proxy not running` when unset.

## 2. `bridge_version` data race (concurrency)
The cached `versionCStr` was lazily initialised with an unsynchronised nil-check + assignment — a data race under concurrent calls. Switched to `sync.Once`.

## 3. Dead `bridge_read_config` extern (cleanup)
The ObjC wrapper still declared `extern char *bridge_read_config(void);` for a symbol removed from the Go side, and carried a stale "from Rust staticlib" comment. Removed the declaration and corrected the comment to "from the Go c-archive".

## Verification
- `go vet ./Go/mihomo-bridge` — clean
- `make framework` — builds (arm64 + x86_64)
- `xcodebuild build` (Debug, macOS) against the rebuilt framework — **BUILD SUCCEEDED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)