### PR TITLE
Fix IPv6 SOCKS5 CONNECT sending a garbage destination address

### DIFF
--- a/BaoLianDengTests/MihomoAPITests.swift
+++ b/BaoLianDengTests/MihomoAPITests.swift
@@ -44,6 +44,13 @@ struct SOCKS5ConnectRequestTests {
         #expect(Array(request.prefix(4)) == [0x05, 0x01, 0x00, 0x04])
         #expect(request.count == 22)
         #expect(Array(request.suffix(2)) == [0x03, 0x55])
+        // The 16 ATYP payload bytes must be the network-order address itself,
+        // not the layout of the `Data` struct wrapping it.
+        let addressBytes = Array(request[4..<20])
+        #expect(addressBytes == [
+            0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+        ])
     }
 
     @Test("Encodes domain destinations")

--- a/TransparentProxy/SOCKS5Client.swift
+++ b/TransparentProxy/SOCKS5Client.swift
@@ -175,7 +175,12 @@ enum SOCKS5Client {
             request.append(contentsOf: parts)
         } else if let ipv6 = IPv6Address(destHost) {
             request.append(0x04)
-            withUnsafeBytes(of: ipv6.rawValue) { request.append(contentsOf: $0) }
+            // `rawValue` is already the 16-byte network-order address. Using
+            // `withUnsafeBytes(of: ipv6.rawValue)` would instead reflect the
+            // `Data` struct's own memory layout (a pointer-sized header that
+            // merely happens to be 16 bytes on 64-bit), shipping a garbage
+            // destination that looks structurally valid.
+            request.append(ipv6.rawValue)
         } else {
             let domainBytes = Array(destHost.utf8)
             guard !domainBytes.isEmpty, domainBytes.count <= 255 else {


### PR DESCRIPTION
## Problem (HIGH)

The IPv6 branch of `SOCKS5Client.makeConnectRequest` encoded the address as:

```swift
withUnsafeBytes(of: ipv6.rawValue) { request.append(contentsOf: $0) }
```

`IPv6Address.rawValue` is a **`Data` value type**, so `withUnsafeBytes(of:)` reflects the in-memory layout of the `Data` struct itself — a pointer-sized header — **not the 16 address bytes it wraps**. On 64-bit that header happens to be 16 bytes, so the CONNECT request stayed a structurally valid 22 bytes while carrying a completely wrong destination.

Reproduced: for `2001:db8::1` the correct payload is `20 01 0d b8 00…00 01`, but the code shipped the `Data` struct internals (`00 00 00 00 10 00 00 00 …`).

**Reachable on every proxied IPv6 connection:** `createProxySettings()` only excludes `::1/128`, `fc00::/7`, `fe80::/10`, `ff00::/8`. Global-unicast IPv6 (`2000::/3`) is not excluded, so those flows reach `handleTCPFlow`, which passes the raw numeric IPv6 destination into this branch.

## Fix

Append `ipv6.rawValue` directly — it is already the 16-byte network-order address, mirroring the domain path. The existing unit test only asserted length + prefix/suffix (which is why the bug slipped through #47); strengthened it to assert the 16 ATYP payload bytes equal the expected network-order address.

## Verification
- `swiftlint --strict` clean
- `xcodebuild test -only-testing:…/SOCKS5ConnectRequestTests` — **TEST SUCCEEDED** (the strengthened assertion fails without the fix)

Found by an automated security/correctness audit of the proxy data path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)