### PR TITLE
docs: replace PKG download links with App Store links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 macOS VPN proxy app powered by [Mihomo](https://github.com/MetaCubeX/mihomo) (Clash Meta) core.
 
-**[Download PKG](https://github.com/madeye/BaoLianDeng/releases/latest)** · **[TestFlight Beta](https://testflight.apple.com/join/VpX3tHnS)** · **[Website](https://madeye.github.io/BaoLianDeng/)**
+**[App Store](https://apps.apple.com/app/baoliandeng/id6779101876)** · **[TestFlight Beta](https://testflight.apple.com/join/VpX3tHnS)** · **[Website](https://madeye.github.io/BaoLianDeng/)**
 
 ## Features
 
@@ -44,14 +44,11 @@ macOS VPN proxy app powered by [Mihomo](https://github.com/MetaCubeX/mihomo) (Cl
 
 ## Install
 
-### From PKG
+### From the App Store
 
-1. Download the latest PKG from [Releases](https://github.com/madeye/BaoLianDeng/releases/latest)
-2. Open the PKG installer and follow the prompts (installs to **/Applications**)
-3. Launch **BaoLianDeng** from Applications
-4. Enable the network extension: **System Settings → General → Login Items & Extensions → Network Extensions** → toggle on **BaoLianDeng**
-
-The PKG is signed with Developer ID and notarized by Apple.
+1. Download from the [Mac App Store](https://apps.apple.com/app/baoliandeng/id6779101876)
+2. Launch **BaoLianDeng** from Applications
+3. Enable the network extension: **System Settings → General → Login Items & Extensions → Network Extensions** → toggle on **BaoLianDeng**
 
 ### Build from Source
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -522,9 +522,9 @@ footer .footer-links {
   <h1>BaoLianDeng <span class="hero-version"><a href="https://github.com/madeye/BaoLianDeng/releases/tag/v5.5">v5.5</a></span></h1>
   <p class="tagline">A macOS VPN proxy powered by Mihomo (Clash Meta), built on NETransparentProxyProvider for socket-level routing.</p>
   <div class="hero-buttons">
-    <a href="https://github.com/madeye/BaoLianDeng/releases/download/v5.5/BaoLianDeng-5.5.pkg" class="btn btn-primary">
-      <svg viewBox="0 0 16 16"><path d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14ZM7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06l1.97 1.969Z"/></svg>
-      Download PKG
+    <a href="https://apps.apple.com/app/baoliandeng/id6779101876" class="btn btn-primary">
+      <svg viewBox="0 0 16 16"><path d="M11.182.008C11.148-.03 9.923.023 8.857 1.18c-1.066 1.156-.902 2.482-.878 2.516.024.034 1.52.087 2.475-1.258.955-1.345.762-2.391.728-2.43Zm3.314 11.733c-.048-.096-2.325-1.234-2.113-3.422.212-2.189 1.675-2.789 1.698-2.854.023-.065-.597-.79-1.254-1.157a3.692 3.692 0 0 0-1.563-.434c-.108-.003-.483-.095-1.254.116-.508.139-1.653.589-1.968.607-.316.018-1.256-.522-2.267-.665-.647-.125-1.333.131-1.824.328-.49.196-1.422.754-2.074 2.237-.652 1.482-.311 3.83-.067 4.56.244.729.625 1.924 1.273 2.796.576.984 1.34 1.667 1.659 1.899.319.232 1.219.386 1.843.067.502-.308 1.408-.485 1.766-.472.357.013 1.061.154 1.782.539.571.197 1.111.115 1.652-.105.541-.221 1.324-1.059 2.238-2.758.347-.79.505-1.217.473-1.282Z"/></svg>
+      App Store
     </a>
     <a href="https://testflight.apple.com/join/VpX3tHnS" class="btn btn-outline">
       <svg viewBox="0 0 16 16"><path d="M8 0a.75.75 0 0 1 .53.22l3.25 3.25a.75.75 0 0 1-1.06 1.06L8.75 2.56v8.69a.75.75 0 0 1-1.5 0V2.56L5.28 4.53a.75.75 0 0 1-1.06-1.06L7.47.22A.75.75 0 0 1 8 0ZM3.5 7.25a.75.75 0 0 0-1.5 0v5A2.75 2.75 0 0 0 4.75 15h6.5A2.75 2.75 0 0 0 14 12.25v-5a.75.75 0 0 0-1.5 0v5c0 .69-.56 1.25-1.25 1.25h-6.5c-.69 0-1.25-.56-1.25-1.25Z"/></svg>
@@ -597,8 +597,16 @@ footer .footer-links {
 <div class="section-alt">
 <section id="install" class="section">
   <h2 class="section-title">Installation</h2>
-  <p class="section-subtitle">Three paths — grab the signed installer, join the beta, or build it from source.</p>
+  <p class="section-subtitle">Three paths — get it on the App Store, join the beta, or build it from source.</p>
   <div class="install-methods">
+    <div class="install-card">
+      <h3>&#x1F4E5; App Store</h3>
+      <ol>
+        <li>Download from the <a href="https://apps.apple.com/app/baoliandeng/id6779101876">Mac App Store</a></li>
+        <li>Launch from Applications</li>
+        <li>Enable the network extension: <strong>System Settings &rarr; General &rarr; Login Items &amp; Extensions &rarr; Network Extensions</strong> &rarr; toggle on <strong>BaoLianDeng</strong></li>
+      </ol>
+    </div>
     <div class="install-card">
       <h3>&#x2708;&#xFE0F; TestFlight Beta</h3>
       <ol>
@@ -606,15 +614,6 @@ footer .footer-links {
         <li>Join the beta: <a href="https://testflight.apple.com/join/VpX3tHnS">testflight.apple.com/join/VpX3tHnS</a></li>
         <li>Install BaoLianDeng from TestFlight and launch it</li>
         <li>Enable the network extension when prompted</li>
-      </ol>
-    </div>
-    <div class="install-card">
-      <h3>&#x1F4E5; Download PKG</h3>
-      <ol>
-        <li>Download <a href="https://github.com/madeye/BaoLianDeng/releases/download/v5.5/BaoLianDeng-5.5.pkg"><code>BaoLianDeng-5.5.pkg</code></a></li>
-        <li>Open the PKG installer and follow the prompts</li>
-        <li>Launch from Applications</li>
-        <li>Enable the network extension: <strong>System Settings &rarr; General &rarr; Login Items &amp; Extensions &rarr; Network Extensions</strong> &rarr; toggle on <strong>BaoLianDeng</strong></li>
       </ol>
     </div>
     <div class="install-card">


### PR DESCRIPTION
Updates user-facing docs to reflect current distribution status: the app ships on the Mac App Store, so the GitHub Releases PKG download links are replaced with the App Store listing.

## Changes
- **README.md** — hero link and Install section now point to the [Mac App Store](https://apps.apple.com/app/baoliandeng/id6779101876); removed the "From PKG" steps and the Developer ID / notarization note.
- **docs/index.html** — hero primary button and the install card now link to the App Store; reordered install cards (App Store → TestFlight → Build from Source) and refreshed the section subtitle.

No remaining PKG / `releases/download` references in user-facing docs.

## CI bypass — Path A (non-code)
Diff touches only `README.md` and `docs/index.html` — docs-only, no code, project.yml, or workflow files. Eligible for admin rebase-merge without waiting for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)