### PR TITLE
docs: add BaoLianDeng copyright notice to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,13 @@
+BaoLianDeng
+Copyright (C) 2026 Max Lv <max.c.lv@gmail.com>
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+
+----------------------------------------------------------------------
+
 GNU GENERAL PUBLIC LICENSE
 Version 3, 29 June 2007
 


### PR DESCRIPTION
Prepend a project copyright notice (Max Lv) above the verbatim GPL v3 text. The FSF copyright on the license document itself is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)