### PR TITLE
Preserve manual proxy group selections across config reloads

### DIFF
--- a/BaoLianDeng.xcodeproj/project.pbxproj
+++ b/BaoLianDeng.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		T10033 /* MihomoCoreIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T10032 /* MihomoCoreIntegrationTests.swift */; };
 		T10035 /* MihomoAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T10034 /* MihomoAPITests.swift */; };
 		T10041 /* ProxyEngineIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T10040 /* ProxyEngineIntegrationTests.swift */; };
+		T10053 /* ProxyGroupsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T10052 /* ProxyGroupsViewModelTests.swift */; };
 		T10045 /* TestConfigs.swift in Sources */ = {isa = PBXBuildFile; fileRef = T10044 /* TestConfigs.swift */; };
 		T10047 /* ProxyEngineHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = T10046 /* ProxyEngineHelper.swift */; };
 		GEO002 /* Country.mmdb in Resources */ = {isa = PBXBuildFile; fileRef = GEO001 /* Country.mmdb */; };
@@ -195,6 +196,7 @@
 		T10032 /* MihomoCoreIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MihomoCoreIntegrationTests.swift; sourceTree = "<group>"; };
 		T10034 /* MihomoAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MihomoAPITests.swift; sourceTree = "<group>"; };
 		T10040 /* ProxyEngineIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyEngineIntegrationTests.swift; sourceTree = "<group>"; };
+		T10052 /* ProxyGroupsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyGroupsViewModelTests.swift; sourceTree = "<group>"; };
 		T10044 /* TestConfigs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConfigs.swift; sourceTree = "<group>"; };
 		T10046 /* ProxyEngineHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyEngineHelper.swift; sourceTree = "<group>"; };
 		GEO001 /* Country.mmdb */ = {isa = PBXFileReference; lastKnownFileType = file; path = Country.mmdb; sourceTree = "<group>"; };
@@ -409,6 +411,7 @@
 				T10032 /* MihomoCoreIntegrationTests.swift */,
 				T10034 /* MihomoAPITests.swift */,
 				T10040 /* ProxyEngineIntegrationTests.swift */,
+				T10052 /* ProxyGroupsViewModelTests.swift */,
 			);
 			path = BaoLianDengTests;
 			sourceTree = "<group>";
@@ -656,6 +659,7 @@
 				T10033 /* MihomoCoreIntegrationTests.swift in Sources */,
 				T10035 /* MihomoAPITests.swift in Sources */,
 				T10041 /* ProxyEngineIntegrationTests.swift in Sources */,
+				T10053 /* ProxyGroupsViewModelTests.swift in Sources */,
 				T10045 /* TestConfigs.swift in Sources */,
 				T10047 /* ProxyEngineHelper.swift in Sources */,
 			);

--- a/BaoLianDeng/Models/ProxyGroupsViewModel.swift
+++ b/BaoLianDeng/Models/ProxyGroupsViewModel.swift
@@ -55,10 +55,8 @@ final class ProxyGroupsViewModel {
                 }
             }
 
-            // Initialize selections from current group state
-            for group in groups {
-                selections[group.name] = group.now
-            }
+            // Merge group state into selections, preserving valid saved choices
+            mergeLoadedGroups(groups)
         } catch {
             // Engine unreachable (typically VPN off). Fall back to YAML parsing.
             isOffline = true
@@ -68,9 +66,7 @@ final class ProxyGroupsViewModel {
                 if !parsed.groups.isEmpty {
                     groups = parsed.groups.values.sorted { $0.name < $1.name }
                     proxies = parsed.proxies
-                    for group in groups {
-                        selections[group.name] = group.now
-                    }
+                    mergeLoadedGroups(groups)
                 }
             }
 
@@ -129,6 +125,45 @@ final class ProxyGroupsViewModel {
         }
 
         testingGroups.remove(group)
+    }
+
+    // MARK: - Selection Merging
+
+    /// Merge freshly loaded group state into `selections`. A saved selection
+    /// survives as long as the group still contains it — the engine resets to
+    /// the config's first node on every tunnel restart, so `group.now` must
+    /// not clobber a valid user choice (issue #56).
+    private func mergeLoadedGroups(_ groups: [MihomoProxyGroup]) {
+        let merged = Self.mergedSelections(selections, groups: groups)
+        if merged != selections {
+            selections = merged
+            saveSelections()
+        }
+    }
+
+    /// Pure core of `mergeLoadedGroups`, separated for unit testing.
+    ///
+    /// Only `Selector` groups carry user choices. Engine-managed groups
+    /// (URLTest, Fallback, LoadBalance, Relay) are dropped from `selections`
+    /// so the UI always falls back to the live `group.now` and
+    /// `replaySelectionsToEngine()` never pins them. Groups absent from the
+    /// loaded config (e.g. another subscription's) are left untouched.
+    static func mergedSelections(
+        _ existing: [String: String],
+        groups: [MihomoProxyGroup]
+    ) -> [String: String] {
+        var result = existing
+        for group in groups {
+            guard group.type == "Selector" else {
+                result[group.name] = nil
+                continue
+            }
+            if let current = existing[group.name], group.all.contains(current) {
+                continue
+            }
+            result[group.name] = group.now
+        }
+        return result
     }
 
     // MARK: - Persistence

--- a/BaoLianDeng/Views/HomeView.swift
+++ b/BaoLianDeng/Views/HomeView.swift
@@ -124,11 +124,12 @@ struct HomeView: View {
         }
         .onChange(of: vpnManager.isConnected) { _, isConnected in
             if isConnected {
-                // Reload proxy groups from API when VPN connects
-                loadProxyGroups()
-                // Replay saved selections to the engine
                 Task {
+                    // The engine resets every group to its config default on
+                    // restart — push saved selections back first, then read
+                    // group state so `now` reflects the restored choices.
                     await proxyGroupsVM.replaySelectionsToEngine()
+                    loadProxyGroups()
                 }
             }
         }

--- a/BaoLianDengTests/ProxyGroupsViewModelTests.swift
+++ b/BaoLianDengTests/ProxyGroupsViewModelTests.swift
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Max Lv <max.c.lv@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import Foundation
+import Testing
+@testable import BaoLianDeng
+
+@Suite("Proxy group selection merging")
+struct ProxyGroupSelectionMergeTests {
+
+    private func selector(_ name: String, now: String, all: [String]) -> MihomoProxyGroup {
+        MihomoProxyGroup(name: name, type: "Selector", now: now, all: all)
+    }
+
+    @Test("Keeps a saved selection the group still contains")
+    func keepsValidSavedSelection() {
+        // Engine restarted and reset PROXY to the first node (HK)
+        let groups = [selector("PROXY", now: "HK", all: ["HK", "US", "JP"])]
+        let merged = ProxyGroupsViewModel.mergedSelections(["PROXY": "US"], groups: groups)
+        #expect(merged["PROXY"] == "US")
+    }
+
+    @Test("Replaces a saved selection the group no longer contains")
+    func replacesInvalidSavedSelection() {
+        let groups = [selector("PROXY", now: "HK", all: ["HK", "JP"])]
+        let merged = ProxyGroupsViewModel.mergedSelections(["PROXY": "US"], groups: groups)
+        #expect(merged["PROXY"] == "HK")
+    }
+
+    @Test("Initializes a missing selection from the group's current node")
+    func initializesMissingSelection() {
+        let groups = [selector("PROXY", now: "HK", all: ["HK", "US"])]
+        let merged = ProxyGroupsViewModel.mergedSelections([:], groups: groups)
+        #expect(merged["PROXY"] == "HK")
+    }
+
+    @Test("Drops engine-managed groups so the UI tracks live state")
+    func dropsEngineManagedGroups() {
+        let groups = [
+            MihomoProxyGroup(name: "AUTO", type: "URLTest", now: "JP", all: ["HK", "JP"]),
+            MihomoProxyGroup(name: "FALLBACK", type: "Fallback", now: "HK", all: ["HK", "JP"])
+        ]
+        let merged = ProxyGroupsViewModel.mergedSelections(
+            ["AUTO": "HK", "FALLBACK": "JP"],
+            groups: groups
+        )
+        #expect(merged["AUTO"] == nil)
+        #expect(merged["FALLBACK"] == nil)
+    }
+
+    @Test("Preserves selections for groups absent from the loaded config")
+    func preservesSelectionsForAbsentGroups() {
+        // Switching subscriptions must not erase the other profile's choices
+        let groups = [selector("PROXY", now: "HK", all: ["HK", "US"])]
+        let merged = ProxyGroupsViewModel.mergedSelections(
+            ["OTHER-SUB-GROUP": "SG"],
+            groups: groups
+        )
+        #expect(merged["OTHER-SUB-GROUP"] == "SG")
+        #expect(merged["PROXY"] == "HK")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #56 — after refreshing a subscription or reloading the config, manually selected Selector nodes were reset to the config's first node and the reset value was persisted, permanently losing the user's choice.

Two root causes, matching the issue's analysis (adapted to the current tunnel-restart reload flow):

1. **`ProxyGroupsViewModel.load()` clobbered saved selections** — it unconditionally copied `group.now` (the engine default right after a restart) into `selections`, which was then saved to UserDefaults.
2. **Reload paths never replayed selections** — after `applyConfigByRestartingTunnel()`, group state was read back before the saved selections were pushed to the engine.

## Changes

- `load()` now merges group state via a pure `mergedSelections` helper: a saved selection survives as long as the group still contains it; invalid/missing entries fall back to `group.now`.
- Engine-managed groups (URLTest / Fallback / LoadBalance / Relay) are dropped from `selections` entirely, so the UI always tracks the live `now` and `replaySelectionsToEngine()` never tries to pin them.
- Selections for groups absent from the loaded config are kept, so switching between subscriptions preserves each profile's choices.
- On VPN connect, `replaySelectionsToEngine()` now runs **before** the group reload, so the restored choices are what the UI reads back.

## Testing

- New `ProxyGroupSelectionMergeTests` suite (5 cases) covering keep-valid, replace-invalid, initialize-missing, drop-engine-managed, and preserve-absent-group behaviors.
- Full unit test run: 184 tests passed. `swiftlint lint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)