### PR TITLE
test: cover sanitizeProviders

### DIFF
--- a/BaoLianDeng/Models/MihomoAPI.swift
+++ b/BaoLianDeng/Models/MihomoAPI.swift
@@ -132,8 +132,17 @@ enum MihomoAPI {
         let uploadTotal = int64Value(json["uploadTotal"] ?? json["upload_total"])
         let downloadTotal = int64Value(json["downloadTotal"] ?? json["download_total"])
 
+        let isoFormatterWithFractionalSeconds = ISO8601DateFormatter()
+        isoFormatterWithFractionalSeconds.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
         let isoFormatter = ISO8601DateFormatter()
-        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        isoFormatter.formatOptions = [.withInternetDateTime]
+
+        func parseStart(_ string: String) -> Date {
+            isoFormatterWithFractionalSeconds.date(from: string)
+                ?? isoFormatter.date(from: string)
+                ?? Date()
+        }
 
         let parsed = connections.compactMap { conn -> MihomoConnection? in
             let id = conn["id"] as? String ?? UUID().uuidString
@@ -150,7 +159,7 @@ enum MihomoAPI {
             let upload = int64Value(conn["upload"])
             let download = int64Value(conn["download"])
             let startStr = conn["start"] as? String ?? ""
-            let start = isoFormatter.date(from: startStr) ?? Date()
+            let start = parseStart(startStr)
 
             return MihomoConnection(
                 id: id,
@@ -220,8 +229,7 @@ enum MihomoAPI {
     /// Select a proxy node within a group via PUT /proxies/{group}
     static func selectProxy(group: String, name: String) async throws {
         let url = try makeURL(pathSegments: ["proxies", group])
-        var request = URLRequest(url: url)
-        request.httpMethod = "PUT"
+        var request = AppConstants.authorizedControllerRequest(url: url, method: "PUT")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try? JSONSerialization.data(withJSONObject: ["name": name])
 
@@ -242,7 +250,8 @@ enum MihomoAPI {
             ]
         )
 
-        let (data, response) = try await URLSession.shared.data(from: url)
+        let request = AppConstants.authorizedControllerRequest(url: url)
+        let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
             throw MihomoAPIError.requestFailed("Delay test failed")
         }
@@ -271,7 +280,8 @@ enum MihomoAPI {
             ]
         )
 
-        let (data, response) = try await URLSession.shared.data(from: url)
+        let request = AppConstants.authorizedControllerRequest(url: url)
+        let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
             throw MihomoAPIError.requestFailed("Delay test failed")
         }
@@ -288,8 +298,7 @@ enum MihomoAPI {
 
     static func patchConfig(_ config: [String: Any]) async throws {
         let url = try makeURL(pathSegments: ["configs"])
-        var request = URLRequest(url: url)
-        request.httpMethod = "PATCH"
+        var request = AppConstants.authorizedControllerRequest(url: url, method: "PATCH")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try? JSONSerialization.data(withJSONObject: config)
 
@@ -334,7 +343,8 @@ enum MihomoAPI {
                 URLQueryItem(name: "type", value: type),
             ]
         )
-        let (data, _) = try await URLSession.shared.data(from: url)
+        let request = AppConstants.authorizedControllerRequest(url: url)
+        let (data, _) = try await URLSession.shared.data(for: request)
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw MihomoAPIError.decodingFailed
         }
@@ -356,7 +366,8 @@ enum MihomoAPI {
 
     private static func get(_ path: String) async throws -> Data {
         let url = try makeURL(pathSegments: pathSegments(from: path))
-        let (data, response) = try await URLSession.shared.data(from: url)
+        let request = AppConstants.authorizedControllerRequest(url: url)
+        let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             throw MihomoAPIError.requestFailed("GET \(path) failed")
         }
@@ -373,8 +384,7 @@ enum MihomoAPI {
 
     private static func delete(pathSegments: [String], errorPath: String) async throws {
         let url = try makeURL(pathSegments: pathSegments)
-        var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
+        let request = AppConstants.authorizedControllerRequest(url: url, method: "DELETE")
         let (_, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             throw MihomoAPIError.requestFailed("DELETE \(errorPath) failed")

--- a/BaoLianDeng/Models/ProxyGroupsViewModel.swift
+++ b/BaoLianDeng/Models/ProxyGroupsViewModel.swift
@@ -121,7 +121,14 @@ final class ProxyGroupsViewModel {
                 }
             }
         } catch {
-            // Silently swallow errors (same pattern as meow-go)
+            // The whole delay-test call failed (e.g. controller unreachable).
+            // Clear this group's stale per-proxy delays rather than leaving
+            // old results displayed as if they were just refreshed.
+            if let testedGroup = groups.first(where: { $0.name == group }) {
+                for proxyName in testedGroup.all {
+                    delays[proxyName] = nil
+                }
+            }
         }
 
         testingGroups.remove(group)
@@ -148,6 +155,23 @@ final class ProxyGroupsViewModel {
     /// so the UI always falls back to the live `group.now` and
     /// `replaySelectionsToEngine()` never pins them. Groups absent from the
     /// loaded config (e.g. another subscription's) are left untouched.
+    ///
+    /// Known limitation (issue #75 item 6): `selections` is keyed only by
+    /// group *name*, with no per-subscription/config scoping. The
+    /// `group.all.contains(current)` check below guards against replaying a
+    /// selection that no longer exists in the group, but it cannot detect
+    /// cross-subscription contamination: if two different subscriptions both
+    /// define a same-named `Selector` group and happen to share a node name,
+    /// a selection saved under one subscription will pass this containment
+    /// check and be silently replayed into the other subscription's
+    /// same-named group, even though the user never chose that node there.
+    /// TODO(#75): fix properly by keying `selections` (and the persisted
+    /// `proxyGroupSelections` blob) by a composite key of subscription/config
+    /// ID + group name instead of group name alone, so selections from one
+    /// subscription can never leak into a same-named group in another. This
+    /// requires new storage (tracking the active subscription ID alongside
+    /// selections) and touches `saveSelections`/`loadSelections`/
+    /// `replaySelectionsToEngine` as well as this merge function.
     static func mergedSelections(
         _ existing: [String: String],
         groups: [MihomoProxyGroup]

--- a/BaoLianDeng/Models/TrafficStore.swift
+++ b/BaoLianDeng/Models/TrafficStore.swift
@@ -74,6 +74,15 @@ final class TrafficStore: ObservableObject {
     // we resolve group membership directly from the on-disk config.
     private var groupMembersCache: [String: [String]] = [:]
     private var lastGroupRefresh: Date = .distantPast
+    // Serializes all UserDefaults writes for dailyTrafficKey /
+    // subscriptionUsageKey so an older tick's write can never land after a
+    // newer one, and so resetSubscriptionUsages() can't be overtaken by an
+    // already-queued save that would resurrect the cleared data.
+    private let persistQueue = DispatchQueue(label: "io.github.baoliandeng.trafficstore.persist")
+    // Bumped on every fetchConnections() call; a completion handler discards
+    // its response if a newer request has since been issued, so a reordered
+    // stale response can't be misread as an engine counter reset.
+    private var fetchGeneration: Int = 0
 
     private static let dateFormatter: DateFormatter = {
         let f = DateFormatter()
@@ -180,6 +189,8 @@ final class TrafficStore: ObservableObject {
 
     private func fetchConnections() {
         guard let url = AppConstants.externalControllerURL(pathSegments: ["connections"]) else { return }
+        fetchGeneration += 1
+        let gen = fetchGeneration
         URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
             guard let data = data, error == nil else { return }
             guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -192,7 +203,8 @@ final class TrafficStore: ObservableObject {
             let uploadTotal = Self.int64Value(json["upload_total"] ?? json["uploadTotal"])
             let downloadTotal = Self.int64Value(json["download_total"] ?? json["downloadTotal"])
             Task { @MainActor [weak self] in
-                self?.processConnections(connections, uploadTotal: uploadTotal, downloadTotal: downloadTotal)
+                guard let self, gen == self.fetchGeneration else { return }
+                self.processConnections(connections, uploadTotal: uploadTotal, downloadTotal: downloadTotal)
             }
         }.resume()
     }
@@ -307,9 +319,12 @@ final class TrafficStore: ObservableObject {
     }
 
     private func pruneOldRecords() {
-        guard dailyRecords.count > 30 else { return }
+        // Keep at least 62 days (two months) so day 1 of a 31-day month is
+        // never dropped from the current-month rollup.
+        let retentionDays = 62
+        guard dailyRecords.count > retentionDays else { return }
         let sorted = dailyRecords.sorted { $0.date > $1.date }
-        dailyRecords = Array(sorted.prefix(30))
+        dailyRecords = Array(sorted.prefix(retentionDays))
     }
 
     private func loadRecords() {
@@ -323,7 +338,7 @@ final class TrafficStore: ObservableObject {
 
     private func saveRecords() {
         let snapshot = dailyRecords
-        Task.detached(priority: .background) {
+        persistQueue.async {
             guard let data = try? JSONEncoder().encode(snapshot) else { return }
             AppConstants.sharedDefaults
                 .set(data, forKey: AppConstants.dailyTrafficKey)
@@ -364,7 +379,7 @@ final class TrafficStore: ObservableObject {
 
     private func saveSubscriptionUsages() {
         let snapshot = subscriptionUsages
-        Task.detached(priority: .background) {
+        persistQueue.async {
             guard let data = try? JSONEncoder().encode(snapshot) else { return }
             AppConstants.sharedDefaults
                 .set(data, forKey: AppConstants.subscriptionUsageKey)
@@ -373,7 +388,12 @@ final class TrafficStore: ObservableObject {
 
     func resetSubscriptionUsages() {
         subscriptionUsages.removeAll()
-        defaults.removeObject(forKey: AppConstants.subscriptionUsageKey)
+        // Clear on persistQueue (not synchronously here) so this ordering is
+        // enforced relative to any save already queued: the clear runs after
+        // saves enqueued before this call, and before any enqueued after.
+        persistQueue.async {
+            AppConstants.sharedDefaults.removeObject(forKey: AppConstants.subscriptionUsageKey)
+        }
         refreshSubscriptionCache()
     }
 

--- a/BaoLianDeng/Views/HomeView.swift
+++ b/BaoLianDeng/Views/HomeView.swift
@@ -599,7 +599,7 @@ struct HomeView: View {
         var request = URLRequest(url: url)
         request.setValue("ClashMetaForAndroid/2.11.1.Meta", forHTTPHeaderField: "User-Agent")
         let (data, response) = try await URLSession.shared.data(for: request)
-        AppLogger.log(AppLogger.network, category: "network", "fetchSubscription URL=\(urlString) status=\((response as? HTTPURLResponse)?.statusCode ?? -1) bytes=\(data.count)")
+        AppLogger.log(AppLogger.network, category: "network", "fetchSubscription host=\(url.host ?? "?") status=\((response as? HTTPURLResponse)?.statusCode ?? -1) bytes=\(data.count)")
         return try Self.parseFetchedSubscription(data: data, response: response)
     }
 
@@ -613,7 +613,7 @@ struct HomeView: View {
             AppLogger.log(AppLogger.network, category: "network", "ERROR: fetchSubscription cannot decode as UTF-8")
             throw URLError(.cannotDecodeContentData)
         }
-        AppLogger.log(AppLogger.network, category: "network", "fetchSubscription raw preview (first 500 chars): \(String(text.prefix(500)))")
+        AppLogger.log(AppLogger.network, category: "network", "fetchSubscription received \(text.count) bytes")
         let result = SubscriptionParser.parseWithYAML(text)
         let rawContent = result.generatedYAML ?? text
         AppLogger.log(AppLogger.network, category: "network", "fetchSubscription parsed \(result.nodes.count) nodes (generated YAML: \(result.generatedYAML != nil))")

--- a/BaoLianDeng/Views/SubscriptionModels.swift
+++ b/BaoLianDeng/Views/SubscriptionModels.swift
@@ -230,7 +230,7 @@ enum SubscriptionParser {
             }
             // Top-level key ends the proxies section
             if inProxies, !line.hasPrefix(" "), !line.isEmpty, line.contains(":") {
-                AppLogger.log(AppLogger.parser, category: "parser", "proxies section ended at line \(lineNum): '\(String(line.prefix(80)))'")
+                AppLogger.log(AppLogger.parser, category: "parser", "proxies section ended at line \(lineNum)")
                 if let node = makeNode(from: current) { nodes.append(node) }
                 current = [:]
                 inProxies = false
@@ -259,22 +259,14 @@ enum SubscriptionParser {
         if let node = makeNode(from: current) { nodes.append(node) }
         AppLogger.log(AppLogger.parser, category: "parser", "result: \(nodes.count) nodes parsed")
         if nodes.isEmpty {
-            // Dump first few proxies-section lines for debugging
             var proxiesStart = -1
             for (i, l) in lines.enumerated() {
                 if l.hasPrefix("proxies:") { proxiesStart = i; break }
             }
             if proxiesStart >= 0 {
-                let end = min(proxiesStart + 10, lines.count)
-                for i in proxiesStart..<end {
-                    AppLogger.log(AppLogger.parser, category: "parser", "line \(i): '\(lines[i])'")
-                }
+                AppLogger.log(AppLogger.parser, category: "parser", "WARNING: 'proxies:' found at line \(proxiesStart) but no nodes parsed")
             } else {
                 AppLogger.log(AppLogger.parser, category: "parser", "WARNING: no 'proxies:' section found in text")
-                // Log first 10 lines to see what we got
-                for i in 0..<min(10, lines.count) {
-                    AppLogger.log(AppLogger.parser, category: "parser", "line \(i): '\(lines[i])'")
-                }
             }
         }
         return nodes

--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -503,6 +503,123 @@ struct SanitizeConfigStringTests {
     }
 }
 
+// MARK: - Provider sanitization (untrusted subscription input)
+
+@Suite("sanitizeProviders")
+struct SanitizeProvidersTests {
+
+    @Test("Preserves a valid https provider with a safe relative path")
+    func preservesValidProvider() {
+        let section = """
+        proxy-providers:
+          provider1:
+            type: http
+            url: https://example.com/sub.yaml
+            path: ./providers/provider1.yaml
+            interval: 3600
+        """
+        let result = ConfigManager.sanitizeProviders(section)
+        #expect(result.contains("provider1:"))
+        #expect(result.contains("url: https://example.com/sub.yaml"))
+        // A safe relative path (no `..`, not absolute/home) is left untouched.
+        #expect(result.contains("path: ./providers/provider1.yaml"))
+        #expect(result.contains("interval: 3600"))
+    }
+
+    @Test("Drops a provider whose url scheme isn't https")
+    func dropsNonHttpsUrl() {
+        let section = """
+        proxy-providers:
+          bad:
+            type: http
+            url: http://evil.com/sub.yaml
+            path: ./providers/bad.yaml
+        """
+        let result = ConfigManager.sanitizeProviders(section)
+        #expect(!result.contains("evil.com"))
+        #expect(!result.contains("bad:"))
+        // Only the (now childless) section header remains.
+        #expect(result.contains("proxy-providers:"))
+    }
+
+    @Test("Drops a provider with a file:// url")
+    func dropsFileUrl() {
+        let section = """
+        proxy-providers:
+          exfil:
+            url: file:///etc/passwd
+            path: ./providers/exfil.yaml
+        """
+        let result = ConfigManager.sanitizeProviders(section)
+        #expect(!result.contains("file://"))
+        #expect(!result.contains("exfil"))
+    }
+
+    @Test("Rewrites a path-traversal path to a safe basename")
+    func rewritesPathTraversal() {
+        let section = """
+        proxy-providers:
+          trav:
+            url: https://example.com/sub.yaml
+            path: ../../Library/LaunchAgents/evil.plist
+        """
+        let result = ConfigManager.sanitizeProviders(section)
+        // Provider survives (url is https) but the escaping path is neutralized.
+        #expect(result.contains("trav:"))
+        #expect(result.contains("url: https://example.com/sub.yaml"))
+        #expect(!result.contains(".."))
+        #expect(!result.contains("LaunchAgents"))
+        #expect(result.contains("path: \"evil.plist\""))
+    }
+
+    @Test("Rewrites an absolute path to a safe basename")
+    func rewritesAbsolutePath() {
+        let section = """
+        proxy-providers:
+          abs:
+            url: https://example.com/sub.yaml
+            path: /Library/LaunchAgents/x.plist
+        """
+        let result = ConfigManager.sanitizeProviders(section)
+        #expect(result.contains("abs:"))
+        #expect(!result.contains("/Library/LaunchAgents"))
+        #expect(result.contains("path: \"x.plist\""))
+    }
+
+    @Test("Keeps the good provider and drops the malicious one")
+    func keepsGoodDropsBad() {
+        let section = """
+        proxy-providers:
+          good:
+            url: https://example.com/good.yaml
+            path: ./providers/good.yaml
+          bad:
+            url: http://attacker/steal
+            path: ./providers/bad.yaml
+        """
+        let result = ConfigManager.sanitizeProviders(section)
+        #expect(result.contains("good:"))
+        #expect(result.contains("https://example.com/good.yaml"))
+        #expect(!result.contains("attacker"))
+        #expect(!result.contains("bad:"))
+    }
+
+    @Test("Applies to rule-providers sections too")
+    func sanitizesRuleProviders() {
+        let section = """
+        rule-providers:
+          rules1:
+            type: http
+            url: http://insecure/rules.yaml
+            path: ./ruleset/rules1.yaml
+        """
+        let result = ConfigManager.sanitizeProviders(section)
+        #expect(!result.contains("insecure"))
+        #expect(!result.contains("rules1:"))
+        #expect(result.contains("rule-providers:"))
+    }
+}
+
 // MARK: - Config Scalar Updates
 
 @Suite("Config top-level scalar replacement")

--- a/Rust/meow-ffi/src/diagnostics.rs
+++ b/Rust/meow-ffi/src/diagnostics.rs
@@ -103,13 +103,22 @@ pub fn test_selected_proxy(api_addr: &str) -> String {
         return "FAIL: api addr is null".to_string();
     }
     let base = format!("http://{api_addr}");
+    let secret = crate::current_controller_secret();
     crate::runtime().block_on(async move {
         let client = match reqwest::Client::builder().timeout(IO_TIMEOUT).build() {
             Ok(c) => c,
             Err(e) => return format!("FAIL: build client: {e}"),
         };
+        // Attach the controller's Bearer secret (matches the Swift REST
+        // clients); the controller rejects unauthenticated calls when a
+        // secret is configured.
+        let auth = |req: reqwest::RequestBuilder| match &secret {
+            Some(s) => req.bearer_auth(s),
+            None => req,
+        };
 
-        let top: serde_json::Value = match client.get(format!("{base}/proxies")).send().await {
+        let top: serde_json::Value = match auth(client.get(format!("{base}/proxies"))).send().await
+        {
             Ok(r) => match r.json().await {
                 Ok(v) => v,
                 Err(e) => return format!("FAIL: decode /proxies: {e}"),
@@ -149,8 +158,7 @@ pub fn test_selected_proxy(api_addr: &str) -> String {
             .to_string();
 
         let delay_url = format!("{base}/proxies/{}/delay", encode_path_segment(&selected));
-        let delay: serde_json::Value = match client
-            .get(&delay_url)
+        let delay: serde_json::Value = match auth(client.get(&delay_url))
             .query(&[
                 ("url", "http://www.gstatic.com/generate_204"),
                 ("timeout", "5000"),

--- a/Rust/meow-ffi/src/engine.rs
+++ b/Rust/meow-ffi/src/engine.rs
@@ -22,7 +22,7 @@ use meow_tunnel::Tunnel;
 use parking_lot::RwLock;
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 /// Live engine instance. Dropping it (via [`crate` stop]) releases the tunnel
 /// and its statistics; the tokio runtime itself is process-global and reused.
@@ -50,9 +50,22 @@ pub async fn assemble(
     // Force inbound / DNS / controller endpoints regardless of the YAML.
     let socks_addr: SocketAddr = format!("127.0.0.1:{socks_port}").parse()?;
     let dns_addr: SocketAddr = format!("127.0.0.1:{dns_port}").parse()?;
-    let api_addr: SocketAddr = controller_addr
+    let parsed_api_addr: SocketAddr = controller_addr
         .parse()
         .map_err(|e| anyhow::anyhow!("controller_addr '{controller_addr}': {e}"))?;
+    // Defense-in-depth: a compromised/buggy caller must never be able to bind
+    // the (possibly unauthenticated) controller API to a non-loopback address
+    // and expose it to the LAN. Force the IP to loopback while preserving the
+    // caller-supplied port.
+    let api_addr = if parsed_api_addr.ip().is_loopback() {
+        parsed_api_addr
+    } else {
+        warn!("controller_addr '{parsed_api_addr}' is not loopback; overriding IP to 127.0.0.1");
+        SocketAddr::new(
+            IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            parsed_api_addr.port(),
+        )
+    };
 
     config.listeners.named = vec![NamedListener {
         name: "mixed".to_string(),

--- a/Rust/meow-ffi/src/geodata.rs
+++ b/Rust/meow-ffi/src/geodata.rs
@@ -15,15 +15,24 @@
 //! So rather than trust the `OnceLock`, we inject explicit `geodata.*-path`
 //! overrides (which take precedence over discovery) sourced from the bridge
 //! home dir the caller most recently set, into every config we parse — for
-//! both validation and engine start. User-specified paths are never
-//! overwritten; on any YAML error we return the input untouched so validation
-//! still sees (and rejects) malformed configs.
+//! both validation and engine start.
+//!
+//! A user (or a merged subscription config) MAY set these paths explicitly,
+//! but we only honor a value that stays inside the bridge home dir — passing
+//! it straight to meow-config would otherwise let an arbitrary subscription
+//! payload make the kernel mmap-open any file readable by the process (path
+//! injection). A path that is relative, escapes `home` via `..`, or resolves
+//! outside `home` entirely is treated as absent and replaced by the pinned
+//! in-home path instead. On any YAML error we return the input untouched so
+//! validation still sees (and rejects) malformed configs.
 
 use serde_yaml::{Mapping, Value};
+use std::path::{Component, Path};
 
 /// Insert `geodata.{mmdb-path,asn-path,geosite-path}` pointing at `<home>/…`
-/// unless the user already set them. Returns the (possibly rewritten) YAML, or
-/// the original string unchanged if it isn't a YAML mapping.
+/// unless the user already set them to a path that is safely contained within
+/// `home`. Returns the (possibly rewritten) YAML, or the original string
+/// unchanged if it isn't a YAML mapping.
 pub fn pin_geodata_paths(yaml: &str, home: &str) -> String {
     let mut root: Value = match serde_yaml::from_str(yaml) {
         Ok(v) => v,
@@ -46,17 +55,51 @@ pub fn pin_geodata_paths(yaml: &str, home: &str) -> String {
         return yaml.to_string();
     };
 
-    set_if_absent(geodata, "mmdb-path", &format!("{home}/Country.mmdb"));
-    set_if_absent(geodata, "asn-path", &format!("{home}/GeoLite2-ASN.mmdb"));
-    set_if_absent(geodata, "geosite-path", &format!("{home}/geosite.dat"));
+    set_if_absent_or_unsafe(geodata, "mmdb-path", &format!("{home}/Country.mmdb"), home);
+    set_if_absent_or_unsafe(
+        geodata,
+        "asn-path",
+        &format!("{home}/GeoLite2-ASN.mmdb"),
+        home,
+    );
+    set_if_absent_or_unsafe(
+        geodata,
+        "geosite-path",
+        &format!("{home}/geosite.dat"),
+        home,
+    );
 
     serde_yaml::to_string(&root).unwrap_or_else(|_| yaml.to_string())
 }
 
-fn set_if_absent(map: &mut Mapping, key: &str, value: &str) {
-    let key = Value::String(key.to_string());
-    if !map.contains_key(&key) {
-        map.insert(key, Value::String(value.to_string()));
+/// Conservative allow-list check for a user-supplied geodata path: only an
+/// absolute path with no `..` traversal component that lexically resolves
+/// inside `home` is trusted. Everything else (relative paths, `..`
+/// traversal, or an absolute path outside `home`) is rejected — meow-config
+/// mmap-opens this path verbatim, so honoring an attacker-controlled value
+/// here would be an arbitrary-file-read primitive.
+fn is_safe_geodata_path(existing: &str, home: &str) -> bool {
+    let path = Path::new(existing);
+    if !path.is_absolute() {
+        return false;
+    }
+    if path.components().any(|c| matches!(c, Component::ParentDir)) {
+        return false;
+    }
+    path.starts_with(Path::new(home))
+}
+
+/// Set `map[key] = value` unless `map[key]` is already present AND is a safe
+/// in-home path (see [`is_safe_geodata_path`]). An absent key, a non-string
+/// value, or an unsafe path are all overridden with the pinned `value`.
+fn set_if_absent_or_unsafe(map: &mut Mapping, key: &str, value: &str, home: &str) {
+    let key_v = Value::String(key.to_string());
+    let is_safe = map
+        .get(&key_v)
+        .and_then(Value::as_str)
+        .is_some_and(|existing| is_safe_geodata_path(existing, home));
+    if !is_safe {
+        map.insert(key_v, Value::String(value.to_string()));
     }
 }
 
@@ -72,10 +115,35 @@ mod tests {
     }
 
     #[test]
-    fn preserves_user_paths() {
+    fn preserves_user_path_inside_home() {
+        let out = pin_geodata_paths("geodata:\n  mmdb-path: /home/x/custom.mmdb\n", "/home/x");
+        assert!(out.contains("/home/x/custom.mmdb"));
+        assert!(!out.contains("mmdb-path: /home/x/Country.mmdb"));
+    }
+
+    #[test]
+    fn overrides_user_path_outside_home() {
+        // A path outside the bridge home dir must never be trusted — it would
+        // let meow-config mmap-open an arbitrary file on disk.
         let out = pin_geodata_paths("geodata:\n  mmdb-path: /custom/C.mmdb\n", "/home/x");
-        assert!(out.contains("/custom/C.mmdb"));
-        assert!(!out.contains("/home/x/Country.mmdb"));
+        assert!(!out.contains("/custom/C.mmdb"), "{out}");
+        assert!(out.contains("mmdb-path: /home/x/Country.mmdb"), "{out}");
+    }
+
+    #[test]
+    fn overrides_path_traversal_escaping_home() {
+        let out = pin_geodata_paths(
+            "geodata:\n  mmdb-path: /home/x/../../etc/passwd\n",
+            "/home/x",
+        );
+        assert!(!out.contains("/etc/passwd"), "{out}");
+        assert!(out.contains("mmdb-path: /home/x/Country.mmdb"), "{out}");
+    }
+
+    #[test]
+    fn overrides_relative_user_path() {
+        let out = pin_geodata_paths("geodata:\n  mmdb-path: Country.mmdb\n", "/home/x");
+        assert!(out.contains("mmdb-path: /home/x/Country.mmdb"), "{out}");
     }
 
     #[test]

--- a/Rust/meow-ffi/src/lib.rs
+++ b/Rust/meow-ffi/src/lib.rs
@@ -54,6 +54,11 @@ pub(crate) fn runtime() -> &'static Runtime {
 
 static ENGINE: Mutex<Option<EngineState>> = Mutex::new(None);
 static HOME_DIR: Mutex<Option<String>> = Mutex::new(None);
+/// Controller REST secret for the currently-running engine, so in-process
+/// diagnostics that hit the controller (see `diagnostics::test_selected_proxy`)
+/// can send the same `Authorization: Bearer` the Swift REST clients do.
+/// `None`/empty means the controller was started without auth (legacy).
+static CONTROLLER_SECRET: Mutex<Option<String>> = Mutex::new(None);
 
 // Traffic is cumulative for the whole PROCESS lifetime (Go semantics: not reset
 // by stop/start). meow-tunnel's Statistics is per-engine-instance, so on stop
@@ -64,6 +69,12 @@ static TRAFFIC_DOWN_BASE: AtomicI64 = AtomicI64::new(0);
 
 pub(crate) fn current_socks_port() -> i32 {
     ENGINE.lock().as_ref().map(|s| s.socks_port).unwrap_or(0)
+}
+
+/// The running controller's REST secret, if one was set at start. Used by
+/// in-process diagnostics to authenticate against the controller.
+pub(crate) fn current_controller_secret() -> Option<String> {
+    CONTROLLER_SECRET.lock().clone().filter(|s| !s.is_empty())
 }
 
 // ---------------------------------------------------------------------------
@@ -84,7 +95,12 @@ pub(crate) fn set_error(msg: impl Into<String>) {
 
 #[no_mangle]
 pub extern "C" fn bridge_get_last_error() -> *const c_char {
-    LAST_ERROR.with(|e| e.borrow().as_ptr())
+    match catch_unwind(AssertUnwindSafe(|| {
+        LAST_ERROR.with(|e| e.borrow().as_ptr())
+    })) {
+        Ok(ptr) => ptr,
+        Err(_) => std::ptr::null(),
+    }
 }
 
 #[no_mangle]
@@ -117,11 +133,16 @@ fn guard_cstr(f: impl FnOnce() -> String) -> *mut c_char {
     }
 }
 
-unsafe fn cstr<'a>(ptr: *const c_char) -> Option<&'a str> {
+/// Reads a caller-supplied C string into an owned `String`. Returns an owned
+/// copy (rather than a borrowed `&str`) so we never hand back a reference
+/// into caller-owned memory whose lifetime the Rust borrow checker can't
+/// actually track across the C ABI boundary — every call site needs the
+/// bytes only transiently, so copying up front is both simpler and sound.
+unsafe fn cstr(ptr: *const c_char) -> Option<String> {
     if ptr.is_null() {
         None
     } else {
-        CStr::from_ptr(ptr).to_str().ok()
+        CStr::from_ptr(ptr).to_str().ok().map(str::to_string)
     }
 }
 
@@ -142,7 +163,7 @@ pub unsafe extern "C" fn bridge_set_home_dir(dir: *const c_char) {
         if d.is_empty() {
             return;
         }
-        *HOME_DIR.lock() = Some(d.to_string());
+        *HOME_DIR.lock() = Some(d.clone());
         // meow's home dir is a first-write-wins OnceLock used by geodata path
         // helpers. Config loading uses HOME_DIR (last-wins) so restarting with
         // a different dir still finds the right config.yaml; only geodata
@@ -162,7 +183,7 @@ pub unsafe extern "C" fn bridge_set_log_file(path: *const c_char) -> i32 {
             set_error("log file path is null");
             return -1;
         };
-        match logging::set_log_file(p) {
+        match logging::set_log_file(&p) {
             Ok(()) => 0,
             Err(e) => {
                 set_error(e);
@@ -176,7 +197,7 @@ pub unsafe extern "C" fn bridge_set_log_file(path: *const c_char) -> i32 {
 pub unsafe extern "C" fn bridge_update_log_level(level: *const c_char) {
     guard((), || {
         if let Some(l) = cstr(level) {
-            logging::set_level(l);
+            logging::set_level(&l);
         }
     });
 }
@@ -222,8 +243,8 @@ pub unsafe extern "C" fn bridge_validate_config(yaml: *const c_char) -> i32 {
         // rather than meow's OnceLock-discovered default. Owned String so the
         // borrow doesn't tie into the parsed future.
         let pinned = match HOME_DIR.lock().as_deref() {
-            Some(home) => geodata::pin_geodata_paths(y, home),
-            None => y.to_string(),
+            Some(home) => geodata::pin_geodata_paths(&y, home),
+            None => y.clone(),
         };
         match runtime().block_on(meow_config::load_config_from_str(&pinned)) {
             Ok(config) => {
@@ -268,7 +289,7 @@ pub unsafe extern "C" fn bridge_start_with_ports(
             set_error("controller_addr is null");
             return -1;
         };
-        let secret_s = cstr(secret).unwrap_or("").to_string();
+        let secret_s = cstr(secret).unwrap_or_default();
 
         let Some(home) = HOME_DIR.lock().clone() else {
             set_error("home dir not set");
@@ -281,12 +302,15 @@ pub unsafe extern "C" fn bridge_start_with_ports(
         }
 
         logging::ensure_subscriber();
+        // Publish the secret so in-process diagnostics can authenticate against
+        // the controller; cleared again if start fails or on stop.
+        *CONTROLLER_SECRET.lock() = Some(secret_s.clone());
         match runtime().block_on(engine::assemble(
             config_path,
             home,
             socks_port,
             dns_port,
-            addr.to_string(),
+            addr,
             secret_s,
         )) {
             Ok(state) => {
@@ -294,6 +318,7 @@ pub unsafe extern "C" fn bridge_start_with_ports(
                 0
             }
             Err(e) => {
+                *CONTROLLER_SECRET.lock() = None;
                 set_error(format!("start proxy: {e}"));
                 -1
             }
@@ -305,7 +330,8 @@ pub unsafe extern "C" fn bridge_start_with_ports(
 pub extern "C" fn bridge_stop_proxy() {
     guard((), || {
         let mut engine = ENGINE.lock();
-        if let Some(state) = engine.take() {
+        *CONTROLLER_SECRET.lock() = None;
+        if let Some(mut state) = engine.take() {
             // Fold the final traffic snapshot into the process-lifetime base
             // before dropping the engine (and its per-instance Statistics).
             let (up, down) = state.tunnel.statistics().snapshot();
@@ -314,7 +340,24 @@ pub extern "C" fn bridge_stop_proxy() {
             for handle in &state.handles {
                 handle.abort();
             }
-            // `state` drops here: tunnel, handles, listeners all released.
+            // abort() only *requests* cancellation; the task (and its
+            // listener socket) isn't guaranteed to be dropped until the
+            // runtime actually polls it again. Wait for every handle to
+            // finish so the sockets are released before we return — otherwise
+            // an immediate restart on the same ports can race and fail with
+            // "address in use". Bounded per-handle so a stuck task can't hang
+            // shutdown forever; we're called from an external (non-runtime)
+            // thread, so block_on here is safe and won't deadlock a worker.
+            let handles = std::mem::take(&mut state.handles);
+            runtime().block_on(async {
+                for handle in handles {
+                    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+                    // Ok(Err(JoinError)) is expected (task was cancelled);
+                    // Err(Elapsed) means the task didn't wind down in time —
+                    // nothing more we can safely do from here, so proceed.
+                }
+            });
+            // `state` drops here: tunnel, listeners all released.
         }
     });
 }
@@ -381,9 +424,14 @@ static VERSION: OnceLock<CString> = OnceLock::new();
 #[no_mangle]
 pub extern "C" fn bridge_version() -> *const c_char {
     // meow crate version at the pinned rev; cosmetic (Swift never parses it).
-    VERSION
-        .get_or_init(|| CString::new("meow-rs 0.16.0").unwrap())
-        .as_ptr()
+    match catch_unwind(AssertUnwindSafe(|| {
+        VERSION
+            .get_or_init(|| CString::new("meow-rs 0.16.0").unwrap())
+            .as_ptr()
+    })) {
+        Ok(ptr) => ptr,
+        Err(_) => std::ptr::null(),
+    }
 }
 
 /// No-op — Rust manages its own memory. The symbol MUST exist (Swift calls it
@@ -397,26 +445,37 @@ pub extern "C" fn bridge_force_gc() {}
 
 #[no_mangle]
 pub unsafe extern "C" fn bridge_test_direct_tcp(host: *const c_char, port: i32) -> *mut c_char {
-    let host = cstr(host).unwrap_or("").to_string();
-    guard_cstr(move || diagnostics::test_direct_tcp(&host, port))
+    // SAFETY: `host` is read (and copied to an owned String) only inside the
+    // guarded closure, so a panic while reading a malformed/dangling pointer
+    // is caught by catch_unwind rather than unwinding across the C ABI.
+    guard_cstr(move || {
+        let host = cstr(host).unwrap_or_default();
+        diagnostics::test_direct_tcp(&host, port)
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn bridge_test_proxy_http(target: *const c_char) -> *mut c_char {
-    let target = cstr(target).unwrap_or("").to_string();
-    guard_cstr(move || diagnostics::test_proxy_http(&target))
+    guard_cstr(move || {
+        let target = cstr(target).unwrap_or_default();
+        diagnostics::test_proxy_http(&target)
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn bridge_test_dns_resolver(dns_addr: *const c_char) -> *mut c_char {
-    let dns_addr = cstr(dns_addr).unwrap_or("").to_string();
-    guard_cstr(move || diagnostics::test_dns_resolver(&dns_addr))
+    guard_cstr(move || {
+        let dns_addr = cstr(dns_addr).unwrap_or_default();
+        diagnostics::test_dns_resolver(&dns_addr)
+    })
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn bridge_test_selected_proxy(api_addr: *const c_char) -> *mut c_char {
-    let api_addr = cstr(api_addr).unwrap_or("").to_string();
-    guard_cstr(move || diagnostics::test_selected_proxy(&api_addr))
+    guard_cstr(move || {
+        let api_addr = cstr(api_addr).unwrap_or_default();
+        diagnostics::test_selected_proxy(&api_addr)
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/Shared/AppLogger.swift
+++ b/Shared/AppLogger.swift
@@ -26,10 +26,14 @@ enum AppLogger {
     static let parser  = Logger(subsystem: subsystem, category: "parser")
     static let network = Logger(subsystem: subsystem, category: "network")
 
-    /// Log to both os.Logger and NSLog so messages appear in system log.
-    /// Uses .notice level so messages are persisted and visible via `log show`.
+    /// Logs via os.Logger only, at default privacy (redacted in release builds).
+    ///
+    /// The NSLog mirror was removed: NSLog always writes plaintext to the
+    /// persistent system log, which previously leaked proxy credentials
+    /// (Shadowsocks passwords, VMess/VLESS UUIDs, Trojan passwords) whenever a
+    /// call site logged raw subscription content. Callers MUST NOT pass
+    /// secrets or raw credential material to this function.
     static func log(_ logger: Logger, category: String, _ message: String) {
-        logger.notice("\(message, privacy: .public)")
-        NSLog("[%@] %@", category, message)
+        logger.notice("\(message)")
     }
 }

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -53,13 +53,33 @@ final class ConfigManager {
         }
     }
 
+    /// Sanity threshold (bytes) a downloaded geodata file must exceed to be
+    /// considered valid rather than truncated. Country.mmdb/geosite.dat are
+    /// both well over 1MB in practice; 1KB just rules out empty/truncated
+    /// responses (e.g. an error page or a connection cut mid-transfer).
+    private static let minGeodataFileSize = 1024
+
     /// Ensure geodata files (Country.mmdb, geosite.dat) exist in the given directory.
     /// Tries the app bundle first, then downloads from jsDelivr.
     func ensureGeodataFiles(configDir: String) {
+        // Bound how long a stalled/slow download can block this call — it
+        // runs synchronously (semaphore-gated) on the tunnel startup path.
+        let sessionConfig = URLSessionConfiguration.ephemeral
+        sessionConfig.timeoutIntervalForResource = 15
+        let session = URLSession(configuration: sessionConfig)
+
         for file in Self.geodataFiles {
             let filename = "\(file.name).\(file.ext)"
             let dest = (configDir as NSString).appendingPathComponent(filename)
-            guard !fileManager.fileExists(atPath: dest) else { continue }
+
+            // Treat an existing-but-truncated file (e.g. left over from a
+            // prior interrupted download) as absent so it gets replaced,
+            // rather than being mistaken for a valid, already-present file.
+            if let attrs = try? fileManager.attributesOfItem(atPath: dest),
+               let size = attrs[.size] as? Int,
+               size > Self.minGeodataFileSize {
+                continue
+            }
 
             // Try bundled copy first. In the main app, geodata is packaged
             // inside the embedded provider extension rather than as a top-level
@@ -79,7 +99,7 @@ final class ConfigManager {
             guard let url = URL(string: file.url) else { continue }
 
             let semaphore = DispatchSemaphore(value: 0)
-            let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            let task = session.dataTask(with: url) { data, response, error in
                 defer { semaphore.signal() }
                 if let error = error {
                     AppLogger.config.warning("Failed to download \(filename): \(error.localizedDescription)")
@@ -91,8 +111,12 @@ final class ConfigManager {
                     AppLogger.config.warning("Bad response downloading \(filename)")
                     return
                 }
+                guard data.count > Self.minGeodataFileSize else {
+                    AppLogger.config.warning("Downloaded \(filename) looks truncated (\(data.count) bytes), discarding")
+                    return
+                }
                 do {
-                    try data.write(to: URL(fileURLWithPath: dest))
+                    try data.write(to: URL(fileURLWithPath: dest), options: .atomic)
                     AppLogger.config.notice("Downloaded \(filename) (\(data.count) bytes)")
                 } catch {
                     AppLogger.config.warning("Failed to write \(filename): \(error.localizedDescription)")
@@ -147,12 +171,22 @@ final class ConfigManager {
         return nil
     }
 
+    /// The single writer of config.yaml. Always runs `sanitizeConfigString`
+    /// so raw-editor and subscription-merge callers can't bypass the TUN /
+    /// geo-auto-update / subscriptions-section invariants by writing
+    /// directly — sanitization is idempotent, so re-sanitizing an
+    /// already-sanitized config is a no-op. Also locks the file down to
+    /// owner-only permissions since it can hold subscription-derived proxy
+    /// credentials.
     func saveConfig(_ yaml: String) throws {
         try ensureConfigDirectory()
         guard let fileURL = configFileURL else {
             throw ConfigError.sharedContainerUnavailable
         }
-        try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+        var content = yaml
+        Self.sanitizeConfigString(&content)
+        try content.write(to: fileURL, atomically: true, encoding: .utf8)
+        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
     }
 
     func loadConfig() throws -> String {
@@ -309,6 +343,34 @@ final class ConfigManager {
         return lines.joined(separator: "\n")
     }
 
+    /// If `trimmed` (an already-whitespace-trimmed line) sets `key:` to a
+    /// truthy `true` value, returns its trailing whitespace/comment suffix
+    /// (possibly empty) so the caller can preserve it when rewriting the
+    /// line. Returns nil if the line doesn't set `key` to `true`.
+    /// Tolerates extra internal whitespace, optional single/double quoting
+    /// around the value, and a trailing comment — e.g. `enable:true`,
+    /// `enable:   true`, `enable: "true"`, `enable: 'true'  # note`.
+    /// A plain substring match on `"\(key): true"` misses the whitespace/
+    /// quoting variants, which would let a subscription-supplied config
+    /// re-enable TUN despite the sanitizer running.
+    private static func truthySuffix(_ trimmed: String, key: String) -> String? {
+        let pattern = "^\(NSRegularExpression.escapedPattern(for: key)):\\s*(?:\"true\"|'true'|true)(\\s*(?:#.*)?)$"
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let range = NSRange(trimmed.startIndex..., in: trimmed)
+        guard let match = regex.firstMatch(in: trimmed, range: range),
+              let suffixRange = Range(match.range(at: 1), in: trimmed) else {
+            return nil
+        }
+        return String(trimmed[suffixRange])
+    }
+
+    /// Rewrites `line`'s `key:` value to `newValue`, preserving the line's
+    /// original indentation and any trailing comment.
+    private static func replacingScalarValue(_ line: String, key: String, newValue: String, suffix: String = "") -> String {
+        let indent = line.prefix { $0 == " " || $0 == "\t" }
+        return "\(indent)\(key): \(newValue)\(suffix)"
+    }
+
     /// Patch the on-disk config.yaml to disable geo data downloads, which would
     /// block the Network Extension during startup. Safe to call on every launch.
     func sanitizeConfig() {
@@ -324,13 +386,15 @@ final class ConfigManager {
                 inTunBlock = trimmed.hasPrefix("tun:")
             }
             // Disable TUN mode — transparent proxy intercepts at socket level, no TUN needed
-            if inTunBlock && trimmed.hasPrefix("enable:") {
-                return line.replacingOccurrences(of: "enable: true", with: "enable: false")
+            if inTunBlock && trimmed.hasPrefix("enable:"), let suffix = Self.truthySuffix(trimmed, key: "enable") {
+                return Self.replacingScalarValue(line, key: "enable", newValue: "false", suffix: suffix)
             }
             // Disable automatic geo database updates
             if trimmed.hasPrefix("geo-auto-update:") {
                 hasGeoAutoUpdate = true
-                return line.replacingOccurrences(of: "geo-auto-update: true", with: "geo-auto-update: false")
+                if let suffix = Self.truthySuffix(trimmed, key: "geo-auto-update") {
+                    return Self.replacingScalarValue(line, key: "geo-auto-update", newValue: "false", suffix: suffix)
+                }
             }
             return line
         }
@@ -351,10 +415,11 @@ final class ConfigManager {
     }
 
     /// Sanitize a config string in-place (same rules as sanitizeConfig but on a String).
+    /// Idempotent: re-running on an already-sanitized config is a no-op, since
+    /// `saveConfig` calls this unconditionally on every write.
     static func sanitizeConfigString(_ config: inout String) {
-        config = config
-            .replacingOccurrences(of: "geo-auto-update: true", with: "geo-auto-update: false")
-        // Disable TUN — transparent proxy intercepts at socket level.
+        // Disable TUN and geo-auto-update — transparent proxy intercepts at
+        // socket level, and geo downloads would block tunnel startup.
         var lines = config.components(separatedBy: "\n")
         var inTunBlock = false
         lines = lines.map { line in
@@ -362,8 +427,11 @@ final class ConfigManager {
             if !trimmed.isEmpty && !line.hasPrefix(" ") && !line.hasPrefix("\t") {
                 inTunBlock = trimmed.hasPrefix("tun:")
             }
-            if inTunBlock && trimmed.hasPrefix("enable:") {
-                return line.replacingOccurrences(of: "enable: true", with: "enable: false")
+            if inTunBlock && trimmed.hasPrefix("enable:"), let suffix = truthySuffix(trimmed, key: "enable") {
+                return replacingScalarValue(line, key: "enable", newValue: "false", suffix: suffix)
+            }
+            if trimmed.hasPrefix("geo-auto-update:"), let suffix = truthySuffix(trimmed, key: "geo-auto-update") {
+                return replacingScalarValue(line, key: "geo-auto-update", newValue: "false", suffix: suffix)
             }
             return line
         }
@@ -454,7 +522,9 @@ final class ConfigManager {
     /// Returns nil if valid, or an error message string if invalid.
     func validateSubscriptionConfig(_ yaml: String) -> String? {
         let merged = mergeSubscription(yaml)
-        AppLogger.config.notice("merged config length: \(merged.count), preview: \(String(merged.prefix(300)), privacy: .public)")
+        // Do not log config content here — it can contain plaintext proxy
+        // passwords/UUIDs from the subscription's proxies section.
+        AppLogger.config.notice("merged config length: \(merged.count)")
 
         // The engine needs HomeDir set so it can find geodata files
         // (Country.mmdb, geosite.dat) when validating GEOIP/GEOSITE rules.
@@ -498,8 +568,8 @@ final class ConfigManager {
         result += "\n\n" + (sub["proxies"] ?? "proxies: []")
         result += "\n\n" + (sub["proxy-groups"] ?? "proxy-groups: []")
 
-        if let pp = sub["proxy-providers"] { result += "\n\n" + Self.disableProviderRefresh(pp) }
-        if let rp = sub["rule-providers"] { result += "\n\n" + Self.disableProviderRefresh(rp) }
+        if let pp = sub["proxy-providers"] { result += "\n\n" + Self.disableProviderRefresh(Self.sanitizeProviders(pp)) }
+        if let rp = sub["rule-providers"] { result += "\n\n" + Self.disableProviderRefresh(Self.sanitizeProviders(rp)) }
 
         let defaultRules = extractYAMLSections(from: defaultConfig, named: ["rules"])
         result += "\n\n" + (sub["rules"] ?? defaultRules["rules"] ?? "rules:\n  - MATCH,DIRECT")
@@ -517,6 +587,100 @@ final class ConfigManager {
             }
             return line
         }.joined(separator: "\n")
+    }
+
+    /// Validate/sanitize subscription-controlled provider entries
+    /// (proxy-providers / rule-providers) before they're merged into
+    /// config.yaml. Subscriptions are untrusted input:
+    ///  - a provider whose `url:` scheme isn't https is dropped entirely, so
+    ///    a malicious subscription can't point mihomo at a `file://` path (
+    ///    local file exfiltration) or a plaintext `http://` endpoint;
+    ///  - a provider whose `path:` tries to escape the app's config
+    ///    directory (contains `..`, or is an absolute/home-relative path)
+    ///    has its path rewritten to a safe basename under the config dir
+    ///    instead of being honored verbatim, so it can't be used to read or
+    ///    overwrite arbitrary files on disk.
+    /// This manipulates provider YAML as text (matching the rest of this
+    /// file's line-based approach, not a parsed tree), so it only
+    /// special-cases the `url:`/`path:` keys and otherwise passes provider
+    /// blocks through untouched. Valid providers are preserved as-is.
+    static func sanitizeProviders(_ section: String) -> String {
+        var lines = section.components(separatedBy: "\n")
+        guard lines.count > 1 else { return section }
+        let header = lines.removeFirst()
+
+        // The indentation of the first provider-name line (e.g. 2 spaces)
+        // marks the start of each subsequent provider entry.
+        guard let baseIndent = lines
+            .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty })
+            .map({ line in line.prefix(while: { $0 == " " }).count })
+        else {
+            return section
+        }
+
+        func isBlockStart(_ line: String) -> Bool {
+            let indent = line.prefix(while: { $0 == " " }).count
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            return indent == baseIndent && !trimmed.isEmpty && trimmed.hasSuffix(":")
+        }
+
+        var blocks: [[String]] = []
+        var current: [String] = []
+        for line in lines {
+            if isBlockStart(line) {
+                if !current.isEmpty { blocks.append(current) }
+                current = [line]
+            } else {
+                current.append(line)
+            }
+        }
+        if !current.isEmpty { blocks.append(current) }
+
+        let kept = blocks.compactMap { sanitizeProviderBlock($0) }
+        guard !kept.isEmpty else { return header }
+        return ([header] + kept.flatMap { $0 }).joined(separator: "\n")
+    }
+
+    /// Returns the (possibly rewritten) lines of a single provider block, or
+    /// nil if the whole block should be dropped (non-https `url:`).
+    private static func sanitizeProviderBlock(_ block: [String]) -> [String]? {
+        var result: [String] = []
+        for line in block {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("url:") {
+                let value = scalarValue(afterKey: "url", in: line)
+                guard value.lowercased().hasPrefix("https://") else { return nil }
+                result.append(line)
+                continue
+            }
+            if trimmed.hasPrefix("path:") {
+                let value = scalarValue(afterKey: "path", in: line)
+                if value.contains("..") || value.hasPrefix("/") || value.hasPrefix("~") {
+                    let indent = line.prefix { $0 == " " || $0 == "\t" }
+                    var safeName = (value as NSString).lastPathComponent
+                        .replacingOccurrences(of: "..", with: "_")
+                    if safeName.isEmpty || safeName == "/" {
+                        safeName = "provider.yaml"
+                    }
+                    result.append("\(indent)path: \(yamlQuotedString(safeName))")
+                    continue
+                }
+            }
+            result.append(line)
+        }
+        return result
+    }
+
+    /// Extracts the scalar value of `key:` from a raw config line, matching
+    /// `rewriteServerLine`'s indentation- and quote-aware parsing.
+    private static func scalarValue(afterKey key: String, in line: String) -> String {
+        let indent = line.prefix { $0 == " " || $0 == "\t" }
+        let rest = line.dropFirst(indent.count)
+        guard rest.hasPrefix("\(key):") else { return "" }
+        let afterColon = rest.dropFirst("\(key):".count)
+        let valueStart = afterColon.prefix { $0 == " " || $0 == "\t" }
+        let valueAndComment = String(afterColon.dropFirst(valueStart.count))
+        return parseYAMLScalarWithComment(valueAndComment).value
     }
 
     private static func yamlQuotedString(_ s: String) -> String {

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import Foundation
+import Security
 
 enum AppConstants {
     static let appGroupIdentifier: String? = nil
@@ -27,6 +28,13 @@ enum AppConstants {
     /// hitting `/proxies`, `/connections`, etc. Updated each tunnel start
     /// because the port is auto-picked.
     static let externalControllerAddrKey = "externalControllerAddr"
+    /// UserDefaults key. The main app generates a random per-session secret
+    /// when it picks the controller port and stores it here; the extension
+    /// reads it from `providerConfiguration` and starts mihomo's REST API
+    /// with it, and the app's REST clients send it as `Authorization: Bearer`.
+    /// Empty/absent means "no auth" (legacy behaviour) — callers should still
+    /// send whatever is present.
+    static let externalControllerSecretKey = "externalControllerSecret"
     static let dailyTrafficKey = "dailyTrafficRecords"
     static let subscriptionUsageKey = "subscriptionUsageRecords"
     static let perAppProxySettingsKey = "perAppProxySettings"
@@ -38,6 +46,37 @@ enum AppConstants {
     /// which would just hit whatever foreign mihomo happens to own 9090.
     static var externalControllerAddr: String? {
         sharedDefaults.string(forKey: externalControllerAddrKey)
+    }
+
+    /// Live mihomo REST controller secret, or nil when none has been
+    /// generated yet. Paired with `externalControllerAddr`.
+    static var externalControllerSecret: String? {
+        let secret = sharedDefaults.string(forKey: externalControllerSecretKey)
+        return (secret?.isEmpty ?? true) ? nil : secret
+    }
+
+    /// Generate a fresh cryptographically-random controller secret (32 hex
+    /// chars from 16 random bytes). Returns a non-empty string on success,
+    /// or nil if the system RNG fails.
+    static func generateControllerSecret() -> String? {
+        var bytes = [UInt8](repeating: 0, count: 16)
+        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+            return nil
+        }
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Build a URLRequest for the controller, attaching the `Authorization:
+    /// Bearer <secret>` header when a secret is available. All REST clients
+    /// (`MihomoAPI`, `VPNManager`, `ProxyGroupsViewModel`) must route through
+    /// this so the header is applied uniformly.
+    static func authorizedControllerRequest(url: URL, method: String = "GET") -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        if let secret = externalControllerSecret {
+            request.setValue("Bearer \(secret)", forHTTPHeaderField: "Authorization")
+        }
+        return request
     }
 
     static func externalControllerURL(pathSegments: [String], queryItems: [URLQueryItem] = []) -> URL? {

--- a/Shared/VPNManager.swift
+++ b/Shared/VPNManager.swift
@@ -524,7 +524,7 @@ final class VPNManager: NSObject, ObservableObject {
             }
             return
         }
-        URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
+        URLSession.shared.dataTask(with: AppConstants.authorizedControllerRequest(url: url)) { [weak self] data, _, error in
             guard let data = data,
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let proxies = json["proxies"] as? [String: Any] else {
@@ -572,8 +572,7 @@ final class VPNManager: NSObject, ObservableObject {
             for (groupName, selection) in targets {
                 guard let putURL = AppConstants.externalControllerURL(pathSegments: ["proxies", groupName]),
                       let body = try? JSONSerialization.data(withJSONObject: ["name": selection]) else { continue }
-                var request = URLRequest(url: putURL)
-                request.httpMethod = "PUT"
+                var request = AppConstants.authorizedControllerRequest(url: putURL, method: "PUT")
                 request.setValue("application/json", forHTTPHeaderField: "Content-Type")
                 request.httpBody = body
                 URLSession.shared.dataTask(with: request) { [weak self] _, response, putError in
@@ -657,6 +656,12 @@ final class VPNManager: NSObject, ObservableObject {
             providerConfig["dnsPort"] = Int(dns)
             providerConfig["controllerAddr"] = ctrlAddr
             defaults.set(ctrlAddr, forKey: AppConstants.externalControllerAddrKey)
+            if let secret = AppConstants.generateControllerSecret() {
+                providerConfig["secret"] = secret
+                defaults.set(secret, forKey: AppConstants.externalControllerSecretKey)
+            } else {
+                dbg("passSettings: WARN failed to generate controller secret")
+            }
             dbg("passSettings: ports socks=\(socks) dns=\(dns) ctrl=\(ctrl)")
         } else {
             dbg("passSettings: WARN failed to pick ephemeral ports")

--- a/TransparentProxy/SOCKS5Client.swift
+++ b/TransparentProxy/SOCKS5Client.swift
@@ -102,19 +102,37 @@ enum SOCKS5Client {
 
     static func readSome(connection: NWConnection) async throws -> Data {
         try await withCheckedThrowingContinuation { cont in
-            connection.receive(
-                minimumIncompleteLength: 1,
-                maximumLength: 65536
-            ) { data, _, isComplete, error in
-                if let error = error {
-                    cont.resume(throwing: error)
-                } else if let data = data, !data.isEmpty {
-                    cont.resume(returning: data)
-                } else if isComplete {
-                    cont.resume(returning: Data())
-                } else {
-                    cont.resume(returning: Data())
-                }
+            readSomeLoop(connection: connection, cont: cont)
+        }
+    }
+
+    /// Callback body for `readSome`, split out so the "no data yet" case can
+    /// re-arm the receive instead of resolving the continuation (#75). Only
+    /// `isComplete` (remote closed) or an error end the stream; callers such
+    /// as `relayTCP` treat an empty `Data()` result as "connection closed,"
+    /// so returning empty for a healthy connection with nothing to deliver
+    /// yet would end the relay prematurely.
+    private static func readSomeLoop(
+        connection: NWConnection,
+        cont: CheckedContinuation<Data, Error>
+    ) {
+        connection.receive(
+            minimumIncompleteLength: 1,
+            maximumLength: 65536
+        ) { data, _, isComplete, error in
+            if let error = error {
+                cont.resume(throwing: error)
+            } else if let data = data, !data.isEmpty {
+                cont.resume(returning: data)
+            } else if isComplete {
+                // Genuine remote close / end-of-stream.
+                cont.resume(returning: Data())
+            } else {
+                // No data, no error, not complete. `receive` with
+                // minimumIncompleteLength: 1 shouldn't invoke the callback in
+                // this shape, but if it ever does, keep waiting rather than
+                // reporting a false end-of-stream.
+                readSomeLoop(connection: connection, cont: cont)
             }
         }
     }

--- a/TransparentProxy/TransparentProxyProvider.swift
+++ b/TransparentProxy/TransparentProxyProvider.swift
@@ -32,6 +32,19 @@ class TransparentProxyProvider: NETransparentProxyProvider {
     private static let socksHost = "127.0.0.1"
     private static let mihomoDNSHost = "127.0.0.1"
 
+    /// Dedicated queue for the blocking POSIX socket round-trip in
+    /// `sendDNSToMihomo`. Swift's cooperative thread pool assumes tasks never
+    /// block a thread; running a blocking `recv()` there can starve other
+    /// async work, so it's dispatched here instead.
+    private let dnsQueue = DispatchQueue(
+        label: "io.github.baoliandeng.dns", attributes: .concurrent
+    )
+
+    /// Serializes all access to the tunnel log file (and its trimming) so
+    /// concurrent `log()` calls from many Tasks and the periodic trim timer
+    /// never interleave their exists-check/open/seek/write/close sequences.
+    private let logQueue = DispatchQueue(label: "io.github.baoliandeng.log")
+
     /// Ports the main app picked for this tunnel session, forwarded via
     /// providerConfiguration in setupConfigFromProvider(). Mihomo binds
     /// these in startProxy(). Defaulting to 0 / "" makes a stray flow
@@ -39,6 +52,7 @@ class TransparentProxyProvider: NETransparentProxyProvider {
     private var socksPort: UInt16 = 0
     private var mihomoDNSPort: UInt16 = 0
     private var controllerAddr: String = ""
+    private var controllerSecret: String = ""
 
     private lazy var logURL: URL = {
         let dir = ConfigManager.shared.configDirectoryURL?.deletingLastPathComponent()
@@ -50,14 +64,16 @@ class TransparentProxyProvider: NETransparentProxyProvider {
     private func log(_ message: String) {
         let line = "[\(Date())] \(message)\n"
         AppLogger.tunnel.notice("\(message, privacy: .public)")
-        if let data = line.data(using: .utf8) {
-            if FileManager.default.fileExists(atPath: logURL.path),
-               let handle = try? FileHandle(forWritingTo: logURL) {
+        guard let data = line.data(using: .utf8) else { return }
+        let url = logURL
+        logQueue.async {
+            if FileManager.default.fileExists(atPath: url.path),
+               let handle = try? FileHandle(forWritingTo: url) {
                 handle.seekToEndOfFile()
                 handle.write(data)
                 try? handle.close()
             } else {
-                try? data.write(to: logURL)
+                try? data.write(to: url)
             }
         }
     }
@@ -127,6 +143,7 @@ class TransparentProxyProvider: NETransparentProxyProvider {
             let socks = self?.socksPort ?? 0
             let dns = self?.mihomoDNSPort ?? 0
             let ctrl = self?.controllerAddr ?? ""
+            let secret = self?.controllerSecret ?? ""
             guard socks > 0, dns > 0, !ctrl.isEmpty else {
                 self?.log("ERROR: provider configuration missing ports/controllerAddr")
                 completionHandler(ProviderError.configNotFound)
@@ -137,7 +154,7 @@ class TransparentProxyProvider: NETransparentProxyProvider {
             )
             var startError: NSError?
             BridgeStartWithPorts(
-                Int32(socks), Int32(dns), ctrl, "", &startError
+                Int32(socks), Int32(dns), ctrl, secret, &startError
             )
             if let startError = startError {
                 self?.log("ERROR: BridgeStartWithPorts failed: \(startError)")
@@ -246,7 +263,21 @@ class TransparentProxyProvider: NETransparentProxyProvider {
         let destPort = endpoint.port
         log("TCP \(destHost):\(destPort)")
 
+        guard let destPortValue = UInt16(destPort) else {
+            log("ERROR: malformed TCP destination port \(destPort)")
+            flow.closeReadWithError(ProviderError.invalidDestination)
+            flow.closeWriteWithError(ProviderError.invalidDestination)
+            return
+        }
+
         Task {
+            // Open the flow first — if this fails there is nothing to close.
+            do {
+                try await openFlow(flow)
+            } catch {
+                return
+            }
+
             var socksConn: NWConnection?
             do {
                 // Connect to Mihomo's SOCKS5 proxy
@@ -262,11 +293,8 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                 try await SOCKS5Client.handshake(
                     connection: conn,
                     destHost: destHost,
-                    destPort: UInt16(destPort) ?? 0
+                    destPort: destPortValue
                 )
-
-                // Open the flow
-                try await openFlow(flow)
 
                 // Relay bidirectionally: flow ↔ SOCKS5 connection
                 await relayTCP(flow: flow, connection: conn)
@@ -358,7 +386,10 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                     continue
                 }
 
-                let port = UInt16(endpoint.port) ?? 0
+                guard let port = UInt16(endpoint.port) else {
+                    log("UDP: malformed destination port \(endpoint.port), dropping datagram")
+                    continue
+                }
 
                 if port == 53 {
                     await handleDNSQuery(
@@ -399,7 +430,12 @@ class TransparentProxyProvider: NETransparentProxyProvider {
         query: Data, flow: NEAppProxyUDPFlow, endpoint: NWHostEndpoint
     ) async {
         guard query.count >= 12 else { return }
-        guard let response = sendDNSToMihomo(query: query) else {
+        let response = await withCheckedContinuation { (cont: CheckedContinuation<Data?, Never>) in
+            dnsQueue.async { [weak self] in
+                cont.resume(returning: self?.sendDNSToMihomo(query: query))
+            }
+        }
+        guard let response = response else {
             log("DNS forward failed")
             return
         }
@@ -443,7 +479,7 @@ class TransparentProxyProvider: NETransparentProxyProvider {
         }
         guard sent == query.count else { return nil }
 
-        var respBuf = [UInt8](repeating: 0, count: 4096)
+        var respBuf = [UInt8](repeating: 0, count: 65535)
         let n = recv(sock, &respBuf, respBuf.count, 0)
         guard n > 0 else { return nil }
         return Data(respBuf[0..<n])
@@ -685,6 +721,9 @@ class TransparentProxyProvider: NETransparentProxyProvider {
         if let ctrl = providerConfig?["controllerAddr"] as? String {
             self.controllerAddr = ctrl
         }
+        if let secret = providerConfig?["secret"] as? String {
+            self.controllerSecret = secret
+        }
 
         return configDir
     }
@@ -747,12 +786,15 @@ class TransparentProxyProvider: NETransparentProxyProvider {
     private static let maxLogLines = 2000
 
     private func trimLogFile() {
-        trimLog(at: logURL)
-        let rustLogURL = logURL.deletingLastPathComponent()
-            .appendingPathComponent("rust_bridge.log")
-        trimLog(at: rustLogURL)
+        logQueue.sync {
+            trimLog(at: logURL)
+            let rustLogURL = logURL.deletingLastPathComponent()
+                .appendingPathComponent("rust_bridge.log")
+            trimLog(at: rustLogURL)
+        }
     }
 
+    /// Must only be called while running on `logQueue`.
     private func trimLog(at url: URL) {
         guard let content = try? String(
             contentsOf: url, encoding: .utf8
@@ -905,6 +947,7 @@ private func withOneShotFlowContinuation<T>(
 enum ProviderError: LocalizedError {
     case configNotFound
     case udpRelayFailed
+    case invalidDestination
 
     var errorDescription: String? {
         switch self {
@@ -912,6 +955,8 @@ enum ProviderError: LocalizedError {
             return "config.yaml not found. Please configure proxies first."
         case .udpRelayFailed:
             return "UDP relay socket creation failed"
+        case .invalidDestination:
+            return "Flow had a malformed destination port"
         }
     }
 }

--- a/TransparentProxy/UDPNATRelay.swift
+++ b/TransparentProxy/UDPNATRelay.swift
@@ -34,21 +34,25 @@ func isBroadcastOrMulticast(_ hostname: String) -> Bool {
 
 // MARK: - UDP NAT Relay (NAT2, Address-Restricted Cone)
 
-/// Relays non-DNS UDP traffic directly to the internet via a POSIX UDP socket.
-/// One socket per flow, bound to a single local port (NAT2 behavior).
+/// Relays non-DNS UDP traffic directly to the internet via POSIX UDP sockets.
+/// Dual-stack: one AF_INET socket and one AF_INET6 socket per flow, each bound
+/// to a single local port (NAT2 behavior per family).
 /// Only accepts responses from IPs we've previously sent to (address restriction).
 final class UDPNATRelay {
     private let fd: Int32
+    private let fd6: Int32?
     private var readSource: DispatchSourceRead?
+    private var readSource6: DispatchSourceRead?
     private let sentAddresses = NSMutableSet()  // Thread-safe via lock
+    private static let maxTrackedAddresses = 1024
     private let lock = NSLock()
-    private var closed = false  // guarded by `lock`; ensures fd is closed exactly once
+    private var closed = false  // guarded by `lock`; ensures fds are closed exactly once
     private weak var flow: NEAppProxyUDPFlow?
 
     init?(flow: NEAppProxyUDPFlow) {
         self.flow = flow
 
-        // Create UDP socket
+        // Create UDP socket (IPv4)
         let sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
         guard sock >= 0 else {
             AppLogger.tunnel.error("UDPNATRelay: socket() failed: \(errno)")
@@ -76,30 +80,103 @@ final class UDPNATRelay {
         // Set non-blocking
         let flags = fcntl(sock, F_GETFL)
         fcntl(sock, F_SETFL, flags | O_NONBLOCK)
+
+        // Create a second, IPv6-only UDP socket (#73). A single AF_INET
+        // socket can only send/receive IPv4 datagrams, so any destination
+        // that resolves to an IPv6 address was being silently dropped in
+        // `send(datagram:toHost:port:)`. Failure to create/bind this socket
+        // is non-fatal — IPv4 relaying still works — but IPv6 destinations
+        // will then be dropped with a logged reason instead of silently.
+        var fd6Local: Int32?
+        let sock6 = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)
+        if sock6 >= 0 {
+            var on: Int32 = 1
+            setsockopt(sock6, IPPROTO_IPV6, IPV6_V6ONLY, &on, socklen_t(MemoryLayout<Int32>.size))
+
+            var addr6 = sockaddr_in6()
+            addr6.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.size)
+            addr6.sin6_family = sa_family_t(AF_INET6)
+            addr6.sin6_port = 0
+            addr6.sin6_addr = in6addr_any
+            let bind6Result = withUnsafePointer(to: &addr6) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                    Darwin.bind(sock6, sockPtr, socklen_t(MemoryLayout<sockaddr_in6>.size))
+                }
+            }
+            if bind6Result < 0 {
+                AppLogger.tunnel.error(
+                    "UDPNATRelay: IPv6 bind() failed: \(errno); IPv6 destinations will be dropped"
+                )
+                close(sock6)
+            } else {
+                let flags6 = fcntl(sock6, F_GETFL)
+                fcntl(sock6, F_SETFL, flags6 | O_NONBLOCK)
+                fd6Local = sock6
+            }
+        } else {
+            AppLogger.tunnel.error(
+                "UDPNATRelay: IPv6 socket() failed: \(errno); IPv6 destinations will be dropped"
+            )
+        }
+        self.fd6 = fd6Local
     }
 
     /// Send a datagram to the destination and record the IP for NAT2 filtering.
+    /// Supports both IPv4 and IPv6 destinations (#73); falls back to a logged
+    /// drop if `host` isn't a parsable IP literal or the IPv6 socket is
+    /// unavailable.
     func send(datagram: Data, toHost host: String, port: UInt16) {
-        var destAddr = sockaddr_in()
-        destAddr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
-        destAddr.sin_family = sa_family_t(AF_INET)
-        destAddr.sin_port = port.bigEndian
+        var destAddr4 = sockaddr_in()
+        destAddr4.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        destAddr4.sin_family = sa_family_t(AF_INET)
+        destAddr4.sin_port = port.bigEndian
 
-        // Validate IPv4 address — drop non-IPv4 (e.g. IPv6) silently
-        guard inet_pton(AF_INET, host, &destAddr.sin_addr) == 1 else { return }
+        if inet_pton(AF_INET, host, &destAddr4.sin_addr) == 1 {
+            recordSentAddress(host)
+            datagram.withUnsafeBytes { buf in
+                withUnsafePointer(to: &destAddr4) { ptr in
+                    ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                        let sent = sendto(fd, buf.baseAddress, buf.count, 0,
+                                          sockPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
+                        if sent < 0 {
+                            AppLogger.tunnel.error(
+                                "UDPNATRelay: sendto (v4) failed: \(errno)"
+                            )
+                        }
+                    }
+                }
+            }
+            return
+        }
 
-        lock.lock()
-        sentAddresses.add(host)
-        lock.unlock()
+        var destAddr6 = sockaddr_in6()
+        destAddr6.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.size)
+        destAddr6.sin6_family = sa_family_t(AF_INET6)
+        destAddr6.sin6_port = port.bigEndian
 
+        guard inet_pton(AF_INET6, host, &destAddr6.sin6_addr) == 1 else {
+            AppLogger.tunnel.error(
+                "UDPNATRelay: dropping datagram to unparsable destination \(host, privacy: .public)"
+            )
+            return
+        }
+
+        guard let fd6 = fd6 else {
+            AppLogger.tunnel.error(
+                "UDPNATRelay: dropping IPv6 destination \(host, privacy: .public) — no IPv6 socket available"
+            )
+            return
+        }
+
+        recordSentAddress(host)
         datagram.withUnsafeBytes { buf in
-            withUnsafePointer(to: &destAddr) { ptr in
+            withUnsafePointer(to: &destAddr6) { ptr in
                 ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
-                    let sent = sendto(fd, buf.baseAddress, buf.count, 0,
-                                      sockPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
+                    let sent = sendto(fd6, buf.baseAddress, buf.count, 0,
+                                      sockPtr, socklen_t(MemoryLayout<sockaddr_in6>.size))
                     if sent < 0 {
                         AppLogger.tunnel.error(
-                            "UDPNATRelay: sendto failed: \(errno)"
+                            "UDPNATRelay: sendto (v6) failed: \(errno)"
                         )
                     }
                 }
@@ -107,29 +184,61 @@ final class UDPNATRelay {
         }
     }
 
-    /// Start the GCD read source to receive incoming datagrams and write them back to the flow.
+    /// Record a destination for NAT2 address-restriction filtering, capped
+    /// (#75) so a flow that talks to many distinct peers can't grow this set
+    /// unbounded for the life of the flow. Once the cap is hit, further new
+    /// peers simply won't pass the inbound filter — acceptable versus
+    /// unbounded memory growth for what should be a rare, chatty-flow case.
+    private func recordSentAddress(_ host: String) {
+        lock.lock()
+        if sentAddresses.count < Self.maxTrackedAddresses {
+            sentAddresses.add(host)
+        }
+        lock.unlock()
+    }
+
+    /// Start the GCD read sources (IPv4 and, if available, IPv6) to receive
+    /// incoming datagrams and write them back to the flow.
     func startReceiving() {
         let source = DispatchSource.makeReadSource(
             fileDescriptor: fd, queue: .global(qos: .userInitiated)
         )
         source.setEventHandler { [weak self] in
-            self?.receiveDatagrams()
+            self?.receiveDatagramsV4()
         }
         source.setCancelHandler { [fd = self.fd] in
             Darwin.close(fd)
         }
         source.resume()
-        // Publish under the lock so `cancel()` (which reads `readSource` under
-        // the same lock) sees a consistent value. The relay's lifecycle is
-        // single-Task — every `startReceiving()` completes before `cancel()`
-        // runs — so `closed` can't already be set here; the lock is purely for
-        // memory-visibility consistency with the teardown path.
+
+        var source6: DispatchSourceRead?
+        if let fd6 = fd6 {
+            let s6 = DispatchSource.makeReadSource(
+                fileDescriptor: fd6, queue: .global(qos: .userInitiated)
+            )
+            s6.setEventHandler { [weak self] in
+                self?.receiveDatagramsV6()
+            }
+            s6.setCancelHandler {
+                Darwin.close(fd6)
+            }
+            s6.resume()
+            source6 = s6
+        }
+
+        // Publish under the lock so `cancel()` (which reads `readSource`/
+        // `readSource6` under the same lock) sees a consistent value. The
+        // relay's lifecycle is single-Task — every `startReceiving()`
+        // completes before `cancel()` runs — so `closed` can't already be
+        // set here; the lock is purely for memory-visibility consistency
+        // with the teardown path.
         lock.lock()
         readSource = source
+        readSource6 = source6
         lock.unlock()
     }
 
-    private func receiveDatagrams() {
+    private func receiveDatagramsV4() {
         var buf = [UInt8](repeating: 0, count: 65536)
         var srcAddr = sockaddr_in()
         var addrLen = socklen_t(MemoryLayout<sockaddr_in>.size)
@@ -140,7 +249,22 @@ final class UDPNATRelay {
                     recvfrom(fd, &buf, buf.count, 0, sockPtr, &addrLen)
                 }
             }
-            guard n > 0 else { break }
+
+            if n < 0 {
+                let err = errno
+                if err == EINTR {
+                    continue  // interrupted syscall — retry immediately
+                }
+                if err != EAGAIN && err != EWOULDBLOCK {
+                    // A real socket error: log it and tear the relay down —
+                    // the socket is unlikely to recover, and looping here
+                    // would just spin re-logging the same failure (#73).
+                    AppLogger.tunnel.error("UDPNATRelay: recvfrom (v4) failed: \(err)")
+                    cancel()
+                }
+                break  // EAGAIN/EWOULDBLOCK: no more datagrams available right now
+            }
+            if n == 0 { break }  // zero-length datagram: treat as end of burst, as before
 
             // Extract source IP
             var ipBuf = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
@@ -149,34 +273,74 @@ final class UDPNATRelay {
             let sourceIP = String(cString: ipBuf)
             let sourcePort = UInt16(bigEndian: srcAddr.sin_port)
 
-            // NAT2: only accept from IPs we've sent to
-            lock.lock()
-            let allowed = sentAddresses.contains(sourceIP)
-            lock.unlock()
-            guard allowed else { continue }
+            deliverIfAllowed(data: Data(bytes: buf, count: n), sourceIP: sourceIP, sourcePort: sourcePort)
+        }
+    }
 
-            let data = Data(bytes: buf, count: n)
-            let endpoint = NWHostEndpoint(
-                hostname: sourceIP, port: "\(sourcePort)"
-            )
+    private func receiveDatagramsV6() {
+        guard let fd6 = fd6 else { return }
+        var buf = [UInt8](repeating: 0, count: 65536)
+        var srcAddr = sockaddr_in6()
+        var addrLen = socklen_t(MemoryLayout<sockaddr_in6>.size)
 
-            flow?.writeDatagrams([data], sentBy: [endpoint]) { error in
-                if let error = error {
-                    AppLogger.tunnel.error(
-                        "UDPNATRelay write error: \(error, privacy: .public)"
-                    )
+        while true {
+            let n = withUnsafeMutablePointer(to: &srcAddr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                    recvfrom(fd6, &buf, buf.count, 0, sockPtr, &addrLen)
                 }
+            }
+
+            if n < 0 {
+                let err = errno
+                if err == EINTR {
+                    continue  // interrupted syscall — retry immediately
+                }
+                if err != EAGAIN && err != EWOULDBLOCK {
+                    AppLogger.tunnel.error("UDPNATRelay: recvfrom (v6) failed: \(err)")
+                    cancel()
+                }
+                break
+            }
+            if n == 0 { break }
+
+            var ipBuf = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+            var addrCopy = srcAddr.sin6_addr
+            inet_ntop(AF_INET6, &addrCopy, &ipBuf, socklen_t(INET6_ADDRSTRLEN))
+            let sourceIP = String(cString: ipBuf)
+            let sourcePort = UInt16(bigEndian: srcAddr.sin6_port)
+
+            deliverIfAllowed(data: Data(bytes: buf, count: n), sourceIP: sourceIP, sourcePort: sourcePort)
+        }
+    }
+
+    private func deliverIfAllowed(data: Data, sourceIP: String, sourcePort: UInt16) {
+        // NAT2: only accept from IPs we've sent to
+        lock.lock()
+        let allowed = sentAddresses.contains(sourceIP)
+        lock.unlock()
+        guard allowed else { return }
+
+        let endpoint = NWHostEndpoint(
+            hostname: sourceIP, port: "\(sourcePort)"
+        )
+
+        flow?.writeDatagrams([data], sentBy: [endpoint]) { error in
+            if let error = error {
+                AppLogger.tunnel.error(
+                    "UDPNATRelay write error: \(error, privacy: .public)"
+                )
             }
         }
     }
 
     func cancel() {
-        // Close the fd exactly once. `cancel()` is reachable both from the
-        // provider's explicit teardown and from `deinit`; without this guard
-        // the fd would be closed twice. By the time the second close runs the
-        // kernel has often handed fd 26 (etc.) to a *guarded* descriptor opened
-        // by Network.framework/dispatch, so the stray close trips EXC_GUARD
-        // (GUARD_TYPE_FD / CLOSE) and the extension is killed.
+        // Close each fd exactly once. `cancel()` is reachable from the
+        // provider's explicit teardown, from `deinit`, and now also from a
+        // terminal recvfrom() error; without this guard the fds could be
+        // closed twice. By the time a second close runs the kernel has often
+        // handed the fd to a *guarded* descriptor opened by Network.framework
+        // /dispatch, so the stray close trips EXC_GUARD (GUARD_TYPE_FD /
+        // CLOSE) and the extension is killed.
         lock.lock()
         if closed {
             lock.unlock()
@@ -184,13 +348,21 @@ final class UDPNATRelay {
         }
         closed = true
         let source = readSource
+        let source6 = readSource6
         readSource = nil
+        readSource6 = nil
         lock.unlock()
 
         if let source = source {
             source.cancel()  // fd closed in cancel handler
         } else {
             Darwin.close(fd)  // No read source — close fd directly
+        }
+
+        if let source6 = source6 {
+            source6.cancel()  // fd6 closed in cancel handler
+        } else if let fd6 = fd6 {
+            Darwin.close(fd6)  // No read source — close fd6 directly
         }
     }
 

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -10,7 +10,9 @@ VM_NAME="bld-e2e-run-$$"
 TROJAN_PID=""
 FALLBACK_PID=""
 VM_PID=""
-TROJAN_CERT_DIR="/tmp/trojan-cert"
+# Use a mktemp dir (not a predictable /tmp path) so a co-resident user can't
+# pre-create it as a symlink and redirect the test TLS key we write into it.
+TROJAN_CERT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/trojan-cert.XXXXXX")"
 FALLBACK_PORT="18080"
 
 source "$SCRIPT_DIR/lib/vm-helpers.sh"
@@ -94,8 +96,9 @@ openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
     -days 1 -nodes -subj "/CN=e2e-trojan" 2>/dev/null
 echo "Generated trojan-go TLS certificate"
 
-# Start a minimal fallback HTTP server (trojan-go requires a valid fallback)
-python3 -m http.server "$FALLBACK_PORT" --directory /tmp &>/dev/null &
+# Start a minimal fallback HTTP server (trojan-go requires a valid fallback).
+# Bind to loopback only — the default 0.0.0.0 would expose /tmp to the LAN.
+python3 -m http.server "$FALLBACK_PORT" --bind 127.0.0.1 --directory /tmp &>/dev/null &
 FALLBACK_PID=$!
 sleep 1
 


### PR DESCRIPTION
Follow-up to PR #76 (audit fixes). The `sanitizeProviders` hardening from #66 — which drops non-https provider `url:` and neutralizes `..`/absolute `path:` in subscription-supplied proxy-providers/rule-providers — shipped without unit-test coverage. This adds a focused `SanitizeProvidersTests` suite.

Cases:
- valid https provider with a safe relative path is preserved unchanged
- provider with a non-https `url:` (`http://`, `file://`) is dropped entirely
- path-traversal (`../../…`) and absolute (`/Library/…`) `path:` are rewritten to a quoted safe basename
- mixed section: the good provider is kept, the malicious one dropped
- the same logic applies to `rule-providers`

## Verification
- `xcodebuild build-for-testing` — **TEST BUILD SUCCEEDED** (test bundle compiles).
- Each case's expectations were checked against a verbatim copy of the `ConfigManager` implementation (24/24 assertions pass). The app-hosted XCTest runner isn't executable in this headless environment (the VPN host hangs before connecting), so the suite should run green in CI / an interactive build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)