### PR TITLE
Bump version to 6.0 (20260712)

### DIFF
--- a/BaoLianDeng.xcodeproj/project.pbxproj
+++ b/BaoLianDeng.xcodeproj/project.pbxproj
@@ -696,7 +696,7 @@
 				CODE_SIGN_ENTITLEMENTS = TransparentProxyMac/TransparentProxyMac.entitlements;
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 64;
+				CURRENT_PROJECT_VERSION = 20260712;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -709,7 +709,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 5.5;
+				MARKETING_VERSION = 6.0;
 				NE_PROVIDER_SUFFIX = "";
 				OTHER_LDFLAGS = (
 					"-lresolv",
@@ -734,7 +734,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 64;
+				CURRENT_PROJECT_VERSION = 20260712;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -747,7 +747,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 5.5;
+				MARKETING_VERSION = 6.0;
 				NE_PROVIDER_SUFFIX = "";
 				OTHER_LDFLAGS = (
 					"-lresolv",
@@ -781,7 +781,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 5.5;
+				MARKETING_VERSION = 6.0;
 				NE_PROVIDER_SUFFIX = "";
 				OTHER_LDFLAGS = (
 					"-lresolv",
@@ -819,7 +819,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 5.5;
+				MARKETING_VERSION = 6.0;
 				NE_PROVIDER_SUFFIX = "";
 				OTHER_LDFLAGS = (
 					"-lresolv",
@@ -850,7 +850,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = TransparentProxyAppex/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 5.5;
+				MARKETING_VERSION = 6.0;
 				NE_PROVIDER_SUFFIX = "";
 				OTHER_LDFLAGS = (
 					"-lresolv",
@@ -872,7 +872,7 @@
 				CODE_SIGN_ENTITLEMENTS = TransparentProxyMac/TransparentProxyMac.entitlements;
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 64;
+				CURRENT_PROJECT_VERSION = 20260712;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -881,7 +881,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = TransparentProxyAppex/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 5.5;
+				MARKETING_VERSION = 6.0;
 				NE_PROVIDER_SUFFIX = "";
 				OTHER_LDFLAGS = (
 					"-lresolv",

--- a/BaoLianDeng/Info.plist
+++ b/BaoLianDeng/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.5</string>
+	<string>6.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/TransparentProxyAppex/Info.plist
+++ b/TransparentProxyAppex/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.5</string>
+	<string>6.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>

--- a/TransparentProxyMac/Info.plist
+++ b/TransparentProxyMac/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.5</string>
+	<string>6.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Marketing version 5.5 → 6.0; Release build number → 20260712. For the next TestFlight build distributed to the "public testers" external group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)