### PR TITLE
Bump meow-rs kernel to a234015 (0.17.0 + provider connect timeout)

### DIFF
--- a/Rust/meow-ffi/Cargo.lock
+++ b/Rust/meow-ffi/Cargo.lock
@@ -311,9 +311,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camellia"
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -523,10 +523,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
+name = "crossbeam-channel"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -534,18 +543,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -834,11 +843,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -848,9 +855,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1000,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1010,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1093,7 +1102,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -1314,11 +1323,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -1449,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -1464,8 +1473,8 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs.git?rev=453ba6738465dff272578e38f53a1e9b3d6d1b24#453ba6738465dff272578e38f53a1e9b3d6d1b24"
+version = "0.17.0"
+source = "git+https://github.com/madeye/meow-rs.git?rev=a234015b34dc4b0ef8f436309b3fc451ded968d2#a234015b34dc4b0ef8f436309b3fc451ded968d2"
 dependencies = [
  "axum",
  "base64",
@@ -1496,10 +1505,11 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs.git?rev=453ba6738465dff272578e38f53a1e9b3d6d1b24#453ba6738465dff272578e38f53a1e9b3d6d1b24"
+version = "0.17.0"
+source = "git+https://github.com/madeye/meow-rs.git?rev=a234015b34dc4b0ef8f436309b3fc451ded968d2#a234015b34dc4b0ef8f436309b3fc451ded968d2"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
  "dashmap",
  "libc",
@@ -1516,13 +1526,16 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
+ "windows-service",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "meow-common"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs.git?rev=453ba6738465dff272578e38f53a1e9b3d6d1b24#453ba6738465dff272578e38f53a1e9b3d6d1b24"
+version = "0.17.0"
+source = "git+https://github.com/madeye/meow-rs.git?rev=a234015b34dc4b0ef8f436309b3fc451ded968d2#a234015b34dc4b0ef8f436309b3fc451ded968d2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1540,16 +1553,18 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "meow-config"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs.git?rev=453ba6738465dff272578e38f53a1e9b3d6d1b24#453ba6738465dff272578e38f53a1e9b3d6d1b24"
+version = "0.17.0"
+source = "git+https://github.com/madeye/meow-rs.git?rev=a234015b34dc4b0ef8f436309b3fc451ded968d2#a234015b34dc4b0ef8f436309b3fc451ded968d2"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "futures-util",
  "hickory-proto",
  "httparse",
  "ipnet",
@@ -1577,8 +1592,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs.git?rev=453ba6738465dff272578e38f53a1e9b3d6d1b24#453ba6738465dff272578e38f53a1e9b3d6d1b24"
+version = "0.17.0"
+source = "git+https://github.com/madeye/meow-rs.git?rev=a234015b34dc4b0ef8f436309b3fc451ded968d2#a234015b34dc4b0ef8f436309b3fc451ded968d2"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -1590,7 +1605,7 @@ dependencies = [
  "meow-common",
  "meow-trie",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustls",
  "serde",
  "serde_json",
@@ -1605,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "meow-ffi"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -1628,8 +1643,8 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs.git?rev=453ba6738465dff272578e38f53a1e9b3d6d1b24#453ba6738465dff272578e38f53a1e9b3d6d1b24"
+version = "0.17.0"
+source = "git+https://github.com/madeye/meow-rs.git?rev=a234015b34dc4b0ef8f436309b3fc451ded968d2#a234015b34dc4b0ef8f436309b3fc451ded968d2"
 dependencies = [
  "base64",
  "libc",
@@ -1643,8 +1658,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs.git?rev=453ba6738465dff272578e38f53a1e9b3d6d1b24#453ba6738465dff272578e38f53a1e9b3d6d1b24"
+version = "0.17.0"
+source = "git+https://github.com/madeye/meow-rs.git?rev=a234015b34dc4b0ef8f436309b3fc451ded968d2#a234015b34dc4b0ef8f436309b3fc451ded968d2"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1668,7 +1683,7 @@ dependencies = [
  "meow-transport",
  "parking_lot",
  "quinn",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustls",
  "serde_json",
  "sha2",
@@ -1685,8 +1700,8 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs.git?rev=453ba6738465dff272578e38f53a1e9b3d6d1b24#453ba6738465dff272578e38f53a1e9b3d6d1b24"
+version = "0.17.0"
+source = "git+https://github.com/madeye/meow-rs.git?rev=a234015b34dc4b0ef8f436309b3fc451ded968d2#a234015b34dc4b0ef8f436309b3fc451ded968d2"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1702,8 +1717,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs.git?rev=453ba6738465dff272578e38f53a1e9b3d6d1b24#453ba6738465dff272578e38f53a1e9b3d6d1b24"
+version = "0.17.0"
+source = "git+https://github.com/madeye/meow-rs.git?rev=a234015b34dc4b0ef8f436309b3fc451ded968d2#a234015b34dc4b0ef8f436309b3fc451ded968d2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1714,7 +1729,7 @@ dependencies = [
  "hmac",
  "http",
  "httparse",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustls",
  "sha2",
  "thiserror",
@@ -1727,13 +1742,13 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs.git?rev=453ba6738465dff272578e38f53a1e9b3d6d1b24#453ba6738465dff272578e38f53a1e9b3d6d1b24"
+version = "0.17.0"
+source = "git+https://github.com/madeye/meow-rs.git?rev=a234015b34dc4b0ef8f436309b3fc451ded968d2#a234015b34dc4b0ef8f436309b3fc451ded968d2"
 
 [[package]]
 name = "meow-tunnel"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs.git?rev=453ba6738465dff272578e38f53a1e9b3d6d1b24#453ba6738465dff272578e38f53a1e9b3d6d1b24"
+version = "0.17.0"
+source = "git+https://github.com/madeye/meow-rs.git?rev=a234015b34dc4b0ef8f436309b3fc451ded968d2#a234015b34dc4b0ef8f436309b3fc451ded968d2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1780,9 +1795,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -2026,7 +2041,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "thiserror",
  "tokio",
  "tracing",
@@ -2035,14 +2050,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2056,16 +2072,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2091,9 +2107,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2145,6 +2161,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2187,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2211,6 +2236,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2230,12 +2256,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.8",
 ]
@@ -2284,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "log",
  "once_cell",
@@ -2320,9 +2348,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -2453,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -2492,14 +2520,14 @@ dependencies = [
  "lru_time_cache",
  "percent-encoding",
  "pin-project",
- "rand 0.9.4",
+ "rand 0.9.5",
  "sealed",
  "sendfd",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "shadowsocks-crypto",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "spin",
  "thiserror",
  "tokio",
@@ -2526,7 +2554,7 @@ dependencies = [
  "ctr",
  "hkdf",
  "md-5",
- "rand 0.9.4",
+ "rand 0.9.5",
  "ring-compat",
  "sha1",
 ]
@@ -2570,9 +2598,9 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -2621,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2631,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
 ]
@@ -2667,10 +2695,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "syn"
-version = "2.0.118"
+name = "symlink"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2733,9 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -2782,9 +2816,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2807,7 +2841,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2845,7 +2879,7 @@ dependencies = [
  "log",
  "once_cell",
  "pin-project",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tokio",
  "windows-sys 0.60.2",
 ]
@@ -2943,6 +2977,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3033,7 +3080,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "sha1",
  "thiserror",
 ]
@@ -3104,9 +3151,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -3216,6 +3263,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,6 +3312,12 @@ checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -3341,6 +3407,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-service"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "857224b3b211c6f3616921f081ee54721ee3ad2ace2fac6a6337e032f7b4dcf2"
+dependencies = [
+ "bitflags",
+ "widestring",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3536,18 +3613,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3616,9 +3693,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Rust/meow-ffi/Cargo.toml
+++ b/Rust/meow-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meow-ffi"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 rust-version = "1.89"
 license = "GPL-3.0"
@@ -18,17 +18,17 @@ crate-type = ["staticlib"]
 # feature. `boring-tls` is likewise left off (BoringSSL needs cmake/C++ per
 # arch, breaking the universal-lipo build). Trade-off: no ech-tls-tunnel
 # outbound and no Reality/uTLS fingerprinting — accepted for now.
-meow-common = { git = "https://github.com/madeye/meow-rs.git", rev = "453ba6738465dff272578e38f53a1e9b3d6d1b24" }
-meow-config = { git = "https://github.com/madeye/meow-rs.git", rev = "453ba6738465dff272578e38f53a1e9b3d6d1b24", default-features = false, features = ["ss", "trojan", "vless", "vless-vision", "vmess", "snell", "hysteria2"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs.git", rev = "453ba6738465dff272578e38f53a1e9b3d6d1b24" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs.git", rev = "453ba6738465dff272578e38f53a1e9b3d6d1b24" }
-meow-listener = { git = "https://github.com/madeye/meow-rs.git", rev = "453ba6738465dff272578e38f53a1e9b3d6d1b24", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs.git", rev = "453ba6738465dff272578e38f53a1e9b3d6d1b24" }
+meow-common = { git = "https://github.com/madeye/meow-rs.git", rev = "a234015b34dc4b0ef8f436309b3fc451ded968d2" }
+meow-config = { git = "https://github.com/madeye/meow-rs.git", rev = "a234015b34dc4b0ef8f436309b3fc451ded968d2", default-features = false, features = ["ss", "trojan", "vless", "vless-vision", "vmess", "snell", "hysteria2"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs.git", rev = "a234015b34dc4b0ef8f436309b3fc451ded968d2" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs.git", rev = "a234015b34dc4b0ef8f436309b3fc451ded968d2" }
+meow-listener = { git = "https://github.com/madeye/meow-rs.git", rev = "a234015b34dc4b0ef8f436309b3fc451ded968d2", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs.git", rev = "a234015b34dc4b0ef8f436309b3fc451ded968d2" }
 # meow-app is pulled in ONLY for its `health_check` lib helpers (url-test /
 # fallback group probing). default-features = false drops its `full` +
 # `boring-tls` bundle so no ech/aws-lc/BoringSSL leaks in; protocol features
 # come from meow-config above and unify onto the shared crate instances.
-meow-app = { git = "https://github.com/madeye/meow-rs.git", rev = "453ba6738465dff272578e38f53a1e9b3d6d1b24", default-features = false }
+meow-app = { git = "https://github.com/madeye/meow-rs.git", rev = "a234015b34dc4b0ef8f436309b3fc451ded968d2", default-features = false }
 
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "net", "time", "sync", "io-util", "macros"] }
 parking_lot = "0.12"


### PR DESCRIPTION
## What

Bumps the pinned meow-rs rev `453ba673` → `a234015` (kernel 0.16.0 → 0.17.0).

## Why

Completes the config-update-hang fix from #79. That PR made *validation* offline in meow-ffi, but tunnel start (`engine::assemble` → `load_config`) still fetched rule-providers through the config's first proxy with **no connect timeout** — a fresh config with no provider cache could stall tunnel startup indefinitely. meow-rs#334 (merged upstream) bounds the dial and TLS handshake with a 15 s connect timeout.

The rev jump also picks up 0.17.0 kernel fixes: vmess AEAD wire format (server interop), VLESS/Snell UDP-over-TCP read/write starvation, relay group + DIRECT hops, mihomo compat improvements, and geo-key scanning for sub-rules/rule-provider payloads. (Windows-platform additions are inert for this build.)

## Verification

- `cargo fmt --check` / `clippy --all-targets -D warnings` / `cargo test --lib`: 18/18 (includes the offline-validation regression tests from #79)
- `make framework-macos` rebuilt against 0.17.0 — no FFI API changes needed
- Full Swift suite against the rebuilt framework: 191/191 (unit + engine integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)