### PR TITLE
Route DNS queries through the default proxy group

### DIFF
--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -236,6 +236,197 @@ struct MergeSubscriptionTests {
     }
 }
 
+// MARK: - Proxy-Routed DNS Retargeting
+
+@Suite("retargetProxiedNameservers")
+struct RetargetProxiedNameserversTests {
+
+    static let taggedBase = """
+    mixed-port: 7890
+    mode: rule
+    dns:
+      enable: true
+      default-nameserver:
+        - 223.5.5.5
+      nameserver:
+        - 'tcp://1.1.1.1:53#PROXY'
+        - 'tcp://8.8.8.8:53#PROXY'
+    proxies: []
+    proxy-groups:
+      - name: PROXY
+        type: select
+        proxies: []
+    rules:
+      - MATCH,PROXY
+    """
+
+    @Test("Merge retargets #PROXY to the subscription's first select group")
+    func retargetsToFirstSelectGroup() {
+        let sub = """
+        proxies:
+          - {name: node, type: vless, server: 1.2.3.4, port: 443}
+        proxy-groups:
+          - name: '🚀 节点选择'
+            type: select
+            proxies:
+              - node
+        """
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: Self.taggedBase, defaultConfig: Self.taggedBase
+        )
+        #expect(merged.contains("- 'tcp://1.1.1.1:53#🚀 节点选择'"))
+        #expect(merged.contains("- 'tcp://8.8.8.8:53#🚀 节点选择'"))
+        #expect(!merged.contains("#PROXY'"))
+    }
+
+    @Test("Non-select groups are skipped in favor of the first select group")
+    func prefersSelectOverAutoGroups() {
+        let sub = """
+        proxies:
+          - {name: node, type: vless, server: 1.2.3.4, port: 443}
+        proxy-groups:
+          - name: Auto
+            type: url-test
+            url: http://www.gstatic.com/generate_204
+            interval: 300
+            proxies:
+              - node
+          - name: Manual
+            type: select
+            proxies:
+              - node
+        """
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: Self.taggedBase, defaultConfig: Self.taggedBase
+        )
+        #expect(merged.contains("- 'tcp://1.1.1.1:53#Manual'"))
+    }
+
+    @Test("Falls back to first group when subscription has no select group")
+    func fallsBackToFirstGroup() {
+        let sub = """
+        proxies:
+          - {name: node, type: vless, server: 1.2.3.4, port: 443}
+        proxy-groups:
+          - name: Auto
+            type: url-test
+            url: http://www.gstatic.com/generate_204
+            interval: 300
+            proxies:
+              - node
+        """
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: Self.taggedBase, defaultConfig: Self.taggedBase
+        )
+        #expect(merged.contains("- 'tcp://1.1.1.1:53#Auto'"))
+    }
+
+    @Test("Strips tag when subscription defines no proxy-groups")
+    func stripsTagWithoutGroups() {
+        let sub = """
+        proxies:
+          - {name: node, type: vless, server: 1.2.3.4, port: 443}
+        """
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: Self.taggedBase, defaultConfig: Self.taggedBase
+        )
+        #expect(merged.contains("- 'tcp://1.1.1.1:53'"))
+        #expect(merged.contains("- 'tcp://8.8.8.8:53'"))
+        #expect(!merged.contains("#PROXY"))
+    }
+
+    @Test("default-nameserver entries are never tagged")
+    func defaultNameserverUntouched() {
+        let sub = """
+        proxies:
+          - {name: node, type: vless, server: 1.2.3.4, port: 443}
+        proxy-groups:
+          - name: Group
+            type: select
+            proxies:
+              - node
+        """
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: Self.taggedBase, defaultConfig: Self.taggedBase
+        )
+        #expect(merged.contains("- 223.5.5.5"))
+        #expect(!merged.contains("223.5.5.5#"))
+    }
+
+    @Test("Re-merge retargets a previously retargeted header")
+    func remergeRetargetsStaleTag() {
+        let firstSub = """
+        proxies:
+          - {name: a, type: vless, server: 1.2.3.4, port: 443}
+        proxy-groups:
+          - name: OldGroup
+            type: select
+            proxies:
+              - a
+        """
+        let secondSub = """
+        proxies:
+          - {name: b, type: vless, server: 5.6.7.8, port: 443}
+        proxy-groups:
+          - name: NewGroup
+            type: select
+            proxies:
+              - b
+        """
+        let first = ConfigManager.mergeSubscription(
+            firstSub, baseConfig: Self.taggedBase, defaultConfig: Self.taggedBase
+        )
+        // Second merge uses the first merge's output as base, the same way
+        // applySelectedSubscription reuses the on-disk config as base.
+        let second = ConfigManager.mergeSubscription(
+            secondSub, baseConfig: first, defaultConfig: Self.taggedBase
+        )
+        #expect(second.contains("- 'tcp://1.1.1.1:53#NewGroup'"))
+        #expect(!second.contains("OldGroup'"))
+    }
+
+    @Test("tls:// nameserver fragments (SNI) are left untouched")
+    func tlsSNIFragmentUntouched() {
+        let base = """
+        dns:
+          enable: true
+          nameserver:
+            - 'tls://1.1.1.1:853#cloudflare-dns.com'
+        proxies: []
+        """
+        let sub = """
+        proxies:
+          - {name: node, type: vless, server: 1.2.3.4, port: 443}
+        proxy-groups:
+          - name: Group
+            type: select
+            proxies:
+              - node
+        """
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: base, defaultConfig: base
+        )
+        #expect(merged.contains("- 'tls://1.1.1.1:853#cloudflare-dns.com'"))
+    }
+
+    @Test("Group names containing single quotes are YAML-escaped")
+    func escapesSingleQuotesInGroupName() {
+        let sub = """
+        proxies:
+          - {name: node, type: vless, server: 1.2.3.4, port: 443}
+        proxy-groups:
+          - name: "It's Fast"
+            type: select
+            proxies:
+              - node
+        """
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: Self.taggedBase, defaultConfig: Self.taggedBase
+        )
+        #expect(merged.contains("- 'tcp://1.1.1.1:53#It''s Fast'"))
+    }
+}
+
 @Suite("Proxy group serialization")
 struct ProxyGroupSerializationTests {
 

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -565,7 +565,16 @@ final class ConfigManager {
         // 2. Header from base config (everything before proxies:) preserves user edits to ports, DNS, etc.
         let baseLines = baseConfig.components(separatedBy: "\n")
         let proxiesCut = baseLines.firstIndex(where: { !$0.hasPrefix(" ") && !$0.hasPrefix("\t") && $0.hasPrefix("proxies:") }) ?? baseLines.count
-        let header = baseLines[0..<proxiesCut].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        var header = baseLines[0..<proxiesCut].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // The header's proxy-routed dns entries (`tcp://…#GROUP`) must
+        // reference a group that exists after the merge replaces all groups
+        // with the subscription's — a dangling reference is a hard config-load
+        // error in the engine, not a warning.
+        header = retargetProxiedNameservers(
+            in: header,
+            to: defaultProxyGroupName(inProxyGroupsSection: sub["proxy-groups"])
+        )
 
         // 3. Build merged config — pass through raw sections from subscription
         var result = header
@@ -580,6 +589,71 @@ final class ConfigManager {
         result += "\n\n" + (sub["rules"] ?? defaultRules["rules"] ?? "rules:\n  - MATCH,DIRECT")
 
         return result
+    }
+
+    /// Rewrite the `#GROUP` tag on proxy-routed entries in the header's
+    /// `dns.nameserver:` list to `target`, or strip the tag when `target` is
+    /// nil so the entry degrades to a plain upstream instead of a dangling
+    /// reference. Only single-quoted `tcp://` / `udp://` list items are
+    /// touched — on `tls:///https://` upstreams the fragment is SNI, and
+    /// `default-nameserver` entries may not carry proxy tags at all.
+    static func retargetProxiedNameservers(in header: String, to target: String?) -> String {
+        var lines = header.components(separatedBy: "\n")
+        var inNameserverList = false
+        var keyIndent = 0
+        for i in lines.indices {
+            let line = lines[i]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            let indent = line.prefix(while: { $0 == " " }).count
+            if trimmed == "nameserver:" {
+                inNameserverList = true
+                keyIndent = indent
+                continue
+            }
+            guard inNameserverList else { continue }
+            if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+            if indent <= keyIndent {
+                inNameserverList = false
+                continue
+            }
+            lines[i] = retargetNameserverEntry(line, to: target)
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func retargetNameserverEntry(_ line: String, to target: String?) -> String {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("- 'tcp://") || trimmed.hasPrefix("- 'udp://"),
+              trimmed.hasSuffix("'"),
+              let openQuote = line.firstIndex(of: "'"),
+              let closeQuote = line.lastIndex(of: "'"),
+              openQuote < closeQuote else {
+            return line
+        }
+        var url = String(line[line.index(after: openQuote)..<closeQuote])
+        if let hash = url.firstIndex(of: "#") {
+            url = String(url[..<hash])
+        }
+        if let target {
+            url += "#" + target.replacingOccurrences(of: "'", with: "''")
+        }
+        return String(line[..<openQuote]) + "'" + url + "'"
+    }
+
+    /// Default proxy group of a raw `proxy-groups:` section: the first
+    /// select-type group (the conventional main selector in subscription
+    /// configs), falling back to the first named group of any type.
+    static func defaultProxyGroupName(inProxyGroupsSection section: String?) -> String? {
+        guard let section,
+              let dict = (try? Yams.load(yaml: section)) as? [String: Any],
+              let groups = dict["proxy-groups"] as? [[String: Any]] else {
+            return nil
+        }
+        let named = groups.compactMap { group -> (name: String, type: String)? in
+            guard let name = group["name"] as? String, !name.isEmpty else { return nil }
+            return (name, group["type"] as? String ?? "")
+        }
+        return (named.first(where: { $0.type == "select" }) ?? named.first)?.name
     }
 
     /// Set interval to 0 in provider sections so Mihomo won't auto-refresh subscription URLs.
@@ -821,9 +895,22 @@ final class ConfigManager {
           enable: true
           listen: 127.0.0.1:0
           enhanced-mode: redir-host
-          nameserver:
-            - 114.114.114.114
+          # Bootstrap-only resolvers: proxy-server hostnames must resolve
+          # without going through a proxy (dial cycle otherwise), and the
+          # engine rejects #PROXY tags on default-nameserver entries.
+          default-nameserver:
             - 223.5.5.5
+            - 114.114.114.114
+          # Public resolvers routed through the default proxy group so answers
+          # can't be poisoned locally. DNS-over-TCP, not tls:// — meow-rs
+          # treats the # fragment on tls:///https:// upstreams as SNI and has
+          # no proxy-routing for encrypted upstreams (EncryptedProxyUnsupported);
+          # the query still rides inside the proxy's encrypted transport.
+          # mergeSubscription retargets the #PROXY tag to the subscription's
+          # default select group.
+          nameserver:
+            - 'tcp://1.1.1.1:53#PROXY'
+            - 'tcp://8.8.8.8:53#PROXY'
 
         proxies: []
 


### PR DESCRIPTION
## Summary
- Default config now sends DNS queries to public resolvers (`1.1.1.1`, `8.8.8.8`) over DNS-over-TCP **through the default proxy group** (`#PROXY` tag), so answers can't be poisoned locally. Bootstrap resolvers (`223.5.5.5`, `114.114.114.114`) move to `default-nameserver`, which must stay direct — proxy-server hostnames have to resolve without a proxy, and the engine rejects proxy tags there.
- Since a subscription merge replaces all proxy groups, a dangling `#PROXY` tag would be a hard config-load error in meow-rs. `mergeSubscription` now retargets tagged `tcp://`/`udp://` nameserver entries in the preserved header to the subscription's first `select` group, falling back to the first group of any type, or stripping the tag when the subscription defines no groups.
- `tls://`/`https://` upstreams are untouched: their `#` fragment is SNI, and meow-rs has no proxy routing for encrypted upstreams. `default-nameserver` entries are never tagged.

## Test plan
- [x] 8 new unit tests covering retarget-to-select-group, fallback ordering, tag stripping, re-merge of a previously retargeted header, TLS SNI fragments, and YAML quote escaping
- [x] Full unit suite (191 tests) and ProxyEngineIntegrationTests pass locally
- [x] SwiftLint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)