### PR TITLE
Switch DNS to fake-ip mode to fix DNS leaks

### DIFF
--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -188,6 +188,19 @@ struct MergeSubscriptionTests {
         #expect(merged.contains("dns:"))
     }
 
+    @Test("Merged config carries the managed fake-ip dns block")
+    func mergedHasManagedDNS() {
+        let sub = """
+        proxies:
+          - {name: node, type: vless, server: 1.2.3.4, port: 443}
+        """
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: Self.baseConfig, defaultConfig: Self.defaultConfig
+        )
+        #expect(merged.contains("enhanced-mode: fake-ip"))
+        #expect(merged.contains("fake-ip-range: 28.0.0.0/8"))
+    }
+
     @Test("Falls back to default rules when subscription has none")
     func fallsBackToDefaultRules() {
         let sub = """
@@ -236,194 +249,67 @@ struct MergeSubscriptionTests {
     }
 }
 
-// MARK: - Proxy-Routed DNS Retargeting
+// MARK: - Managed DNS
 
-@Suite("retargetProxiedNameservers")
-struct RetargetProxiedNameserversTests {
+@Suite("forceManagedDNS")
+struct ForceManagedDNSTests {
 
-    static let taggedBase = """
-    mixed-port: 7890
-    mode: rule
-    dns:
-      enable: true
-      default-nameserver:
-        - 223.5.5.5
-      nameserver:
-        - 'tcp://1.1.1.1:53#PROXY'
-        - 'tcp://8.8.8.8:53#PROXY'
-    proxies: []
-    proxy-groups:
-      - name: PROXY
-        type: select
-        proxies: []
-    rules:
-      - MATCH,PROXY
-    """
-
-    @Test("Merge retargets #PROXY to the subscription's first select group")
-    func retargetsToFirstSelectGroup() {
-        let sub = """
-        proxies:
-          - {name: node, type: vless, server: 1.2.3.4, port: 443}
-        proxy-groups:
-          - name: '🚀 节点选择'
-            type: select
-            proxies:
-              - node
-        """
-        let merged = ConfigManager.mergeSubscription(
-            sub, baseConfig: Self.taggedBase, defaultConfig: Self.taggedBase
-        )
-        #expect(merged.contains("- 'tcp://1.1.1.1:53#🚀 节点选择'"))
-        #expect(merged.contains("- 'tcp://8.8.8.8:53#🚀 节点选择'"))
-        #expect(!merged.contains("#PROXY'"))
-    }
-
-    @Test("Non-select groups are skipped in favor of the first select group")
-    func prefersSelectOverAutoGroups() {
-        let sub = """
-        proxies:
-          - {name: node, type: vless, server: 1.2.3.4, port: 443}
-        proxy-groups:
-          - name: Auto
-            type: url-test
-            url: http://www.gstatic.com/generate_204
-            interval: 300
-            proxies:
-              - node
-          - name: Manual
-            type: select
-            proxies:
-              - node
-        """
-        let merged = ConfigManager.mergeSubscription(
-            sub, baseConfig: Self.taggedBase, defaultConfig: Self.taggedBase
-        )
-        #expect(merged.contains("- 'tcp://1.1.1.1:53#Manual'"))
-    }
-
-    @Test("Falls back to first group when subscription has no select group")
-    func fallsBackToFirstGroup() {
-        let sub = """
-        proxies:
-          - {name: node, type: vless, server: 1.2.3.4, port: 443}
-        proxy-groups:
-          - name: Auto
-            type: url-test
-            url: http://www.gstatic.com/generate_204
-            interval: 300
-            proxies:
-              - node
-        """
-        let merged = ConfigManager.mergeSubscription(
-            sub, baseConfig: Self.taggedBase, defaultConfig: Self.taggedBase
-        )
-        #expect(merged.contains("- 'tcp://1.1.1.1:53#Auto'"))
-    }
-
-    @Test("Strips tag when subscription defines no proxy-groups")
-    func stripsTagWithoutGroups() {
-        let sub = """
-        proxies:
-          - {name: node, type: vless, server: 1.2.3.4, port: 443}
-        """
-        let merged = ConfigManager.mergeSubscription(
-            sub, baseConfig: Self.taggedBase, defaultConfig: Self.taggedBase
-        )
-        #expect(merged.contains("- 'tcp://1.1.1.1:53'"))
-        #expect(merged.contains("- 'tcp://8.8.8.8:53'"))
-        #expect(!merged.contains("#PROXY"))
-    }
-
-    @Test("default-nameserver entries are never tagged")
-    func defaultNameserverUntouched() {
-        let sub = """
-        proxies:
-          - {name: node, type: vless, server: 1.2.3.4, port: 443}
-        proxy-groups:
-          - name: Group
-            type: select
-            proxies:
-              - node
-        """
-        let merged = ConfigManager.mergeSubscription(
-            sub, baseConfig: Self.taggedBase, defaultConfig: Self.taggedBase
-        )
-        #expect(merged.contains("- 223.5.5.5"))
-        #expect(!merged.contains("223.5.5.5#"))
-    }
-
-    @Test("Re-merge retargets a previously retargeted header")
-    func remergeRetargetsStaleTag() {
-        let firstSub = """
-        proxies:
-          - {name: a, type: vless, server: 1.2.3.4, port: 443}
-        proxy-groups:
-          - name: OldGroup
-            type: select
-            proxies:
-              - a
-        """
-        let secondSub = """
-        proxies:
-          - {name: b, type: vless, server: 5.6.7.8, port: 443}
-        proxy-groups:
-          - name: NewGroup
-            type: select
-            proxies:
-              - b
-        """
-        let first = ConfigManager.mergeSubscription(
-            firstSub, baseConfig: Self.taggedBase, defaultConfig: Self.taggedBase
-        )
-        // Second merge uses the first merge's output as base, the same way
-        // applySelectedSubscription reuses the on-disk config as base.
-        let second = ConfigManager.mergeSubscription(
-            secondSub, baseConfig: first, defaultConfig: Self.taggedBase
-        )
-        #expect(second.contains("- 'tcp://1.1.1.1:53#NewGroup'"))
-        #expect(!second.contains("OldGroup'"))
-    }
-
-    @Test("tls:// nameserver fragments (SNI) are left untouched")
-    func tlsSNIFragmentUntouched() {
-        let base = """
+    @Test("Replaces a redir-host dns block with the managed fake-ip block")
+    func replacesRedirHostBlock() {
+        var config = """
+        mixed-port: 7890
+        mode: rule
         dns:
           enable: true
+          listen: 127.0.0.1:1053
+          enhanced-mode: redir-host
           nameserver:
-            - 'tls://1.1.1.1:853#cloudflare-dns.com'
+            - 'tcp://1.1.1.1:53#PROXY'
         proxies: []
+        rules:
+          - MATCH,DIRECT
         """
-        let sub = """
-        proxies:
-          - {name: node, type: vless, server: 1.2.3.4, port: 443}
-        proxy-groups:
-          - name: Group
-            type: select
-            proxies:
-              - node
-        """
-        let merged = ConfigManager.mergeSubscription(
-            sub, baseConfig: base, defaultConfig: base
-        )
-        #expect(merged.contains("- 'tls://1.1.1.1:853#cloudflare-dns.com'"))
+        ConfigManager.forceManagedDNS(&config)
+        #expect(config.contains("enhanced-mode: fake-ip"))
+        #expect(config.contains("fake-ip-range: 28.0.0.0/8"))
+        #expect(!config.contains("redir-host"))
+        #expect(!config.contains("#PROXY"))
+        // Managed block sits ahead of proxies:, keeping the header layout.
+        let dnsIdx = config.range(of: "dns:")!.lowerBound
+        let proxiesIdx = config.range(of: "proxies: []")!.lowerBound
+        #expect(dnsIdx < proxiesIdx)
     }
 
-    @Test("Group names containing single quotes are YAML-escaped")
-    func escapesSingleQuotesInGroupName() {
-        let sub = """
-        proxies:
-          - {name: node, type: vless, server: 1.2.3.4, port: 443}
-        proxy-groups:
-          - name: "It's Fast"
-            type: select
-            proxies:
-              - node
+    @Test("Inserts a dns block when the config has none")
+    func insertsWhenMissing() {
+        var config = "mode: rule\nproxies: []\nrules:\n  - MATCH,DIRECT"
+        ConfigManager.forceManagedDNS(&config)
+        #expect(config.contains("enhanced-mode: fake-ip"))
+    }
+
+    @Test("Idempotent on an already-managed config")
+    func idempotent() {
+        var config = "mixed-port: 7890\n\(ConfigManager.managedDNSSection)\nproxies: []\n"
+        ConfigManager.forceManagedDNS(&config)
+        let once = config
+        ConfigManager.forceManagedDNS(&config)
+        #expect(config == once)
+        #expect(config.components(separatedBy: "dns:").count - 1 == 1)
+    }
+
+    @Test("Top-level comments inside the dns section are removed with it")
+    func removesTopLevelCommentsInSection() {
+        var config = """
+        dns:
+          enable: true
+        # stray comment inside the section
+          enhanced-mode: redir-host
+        proxies: []
         """
-        let merged = ConfigManager.mergeSubscription(
-            sub, baseConfig: Self.taggedBase, defaultConfig: Self.taggedBase
-        )
-        #expect(merged.contains("- 'tcp://1.1.1.1:53#It''s Fast'"))
+        ConfigManager.forceManagedDNS(&config)
+        #expect(!config.contains("redir-host"))
+        #expect(!config.contains("stray comment"))
+        #expect(config.contains("enhanced-mode: fake-ip"))
     }
 }
 
@@ -670,16 +556,13 @@ struct SanitizeConfigStringTests {
         #expect(config.contains("dns:"))
     }
 
-    @Test("Config without TUN or geo-update is unchanged")
+    @Test("Sanitizing an already-sanitized config is a no-op")
     func noopWhenNothingToSanitize() {
-        var config = """
-        port: 7890
-        dns:
-          enable: true
-        """
-        let original = config
+        var config = "port: 7890\n\(ConfigManager.managedDNSSection)\n"
         ConfigManager.sanitizeConfigString(&config)
-        #expect(config == original)
+        let sanitized = config
+        ConfigManager.sanitizeConfigString(&config)
+        #expect(config == sanitized)
     }
 }
 
@@ -810,7 +693,7 @@ struct ConfigTopLevelScalarReplacementTests {
         let yaml = """
         mode: rule
         dns:
-          enhanced-mode: redir-host
+          enhanced-mode: fake-ip
         proxies:
           - name: obfs-node
             type: ss
@@ -826,7 +709,7 @@ struct ConfigTopLevelScalarReplacementTests {
         )
 
         #expect(updated.contains("mode: global"))
-        #expect(updated.contains("enhanced-mode: redir-host"))
+        #expect(updated.contains("enhanced-mode: fake-ip"))
         #expect(updated.contains("mode: websocket"))
         #expect(!updated.contains("mode: rule"))
     }

--- a/BaoLianDengTests/MihomoCoreIntegrationTests.swift
+++ b/BaoLianDengTests/MihomoCoreIntegrationTests.swift
@@ -94,7 +94,7 @@ struct MihomoCoreIntegrationTests {
         dns:
           enable: true
           listen: 127.0.0.1:1053
-          enhanced-mode: redir-host
+          enhanced-mode: fake-ip
           nameserver:
             - 114.114.114.114
         proxies: []

--- a/BaoLianDengTests/Utilities/TestConfigs.swift
+++ b/BaoLianDengTests/Utilities/TestConfigs.swift
@@ -16,7 +16,7 @@ enum TestConfigs {
         dns:
           enable: true
           listen: 127.0.0.1:1053
-          enhanced-mode: redir-host
+          enhanced-mode: fake-ip
           nameserver:
             - 114.114.114.114
         proxies: []

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ macOS VPN proxy app powered by [meow-rs](https://github.com/madeye/meow-rs), a C
 │  │    ┌──────────────────────────────┐   │  │
 │  │    │MihomoCore.xcframework (Rust) │   │  │
 │  │    │  - Proxy Engine              │   │  │
-│  │    │  - DNS (redir-host)          │   │  │
+│  │    │  - DNS (fake-ip)             │   │  │
 │  │    │  - Rules / Routing           │   │  │
 │  │    └──────────────────────────────┘   │  │
 │  └───────────────────────────────────────┘  │

--- a/Rust/meow-ffi/src/diagnostics.rs
+++ b/Rust/meow-ffi/src/diagnostics.rs
@@ -62,7 +62,7 @@ pub fn test_proxy_http(target: &str) -> String {
 }
 
 /// Hand-built UDP DNS A query for www.google.com; parses the first A record and
-/// flags 198.18.0.0/15 as a fake-ip address in the result.
+/// flags 28.0.0.0/8 as a fake-ip address in the result.
 pub fn test_dns_resolver(dns_addr: &str) -> String {
     if dns_addr.is_empty() {
         return "FAIL: dns addr is null".to_string();
@@ -83,8 +83,8 @@ pub fn test_dns_resolver(dns_addr: &str) -> String {
     match sock.recv(&mut buf) {
         Ok(n) => match first_a_record(&buf[..n]) {
             Some(ip) => {
-                // 198.18.0.0/15 == 198.18.x.x or 198.19.x.x.
-                let fake = ip[0] == 198 && (ip[1] == 18 || ip[1] == 19);
+                // fake-ip pool is 28.0.0.0/8 (see ConfigManager.managedDNSSection).
+                let fake = ip[0] == 28;
                 format!(
                     "OK: resolved {}.{}.{}.{} fake-ip={fake}",
                     ip[0], ip[1], ip[2], ip[3]

--- a/Rust/meow-ffi/src/engine.rs
+++ b/Rust/meow-ffi/src/engine.rs
@@ -123,7 +123,7 @@ pub async fn assemble(
 
     let mut handles: Vec<JoinHandle<()>> = Vec::new();
 
-    // DNS UDP server (redir-host reverse cache lives inside the resolver).
+    // DNS UDP server (fake-ip pool and reverse mapping live inside the resolver).
     {
         let dns_server = DnsServer::new(resolver, dns_addr);
         handles.push(tokio::spawn(async move {

--- a/Rust/meow-ffi/src/geodata.rs
+++ b/Rust/meow-ffi/src/geodata.rs
@@ -156,7 +156,7 @@ mod tests {
     fn injects_into_merged_subscription_config() {
         // Mirrors ConfigManager.mergeSubscription output (default header +
         // subscription proxies/groups + default rules incl. GEOIP,CN).
-        let merged = "mixed-port: 0\nmode: rule\nexternal-controller: 127.0.0.1:0\ngeo-auto-update: false\n\ndns:\n  enable: true\n  enhanced-mode: redir-host\n\nproxies:\n  - name: \"TestNode\"\n    type: vless\n    server: \"1.2.3.4\"\n    port: 443\n    network: ws\n    ws-opts:\n      path: \"/ws\"\n\nproxy-groups:\n  - name: PROXY\n    type: select\n    proxies:\n      - \"TestNode\"\n\nrules:\n  - GEOIP,CN,DIRECT\n  - MATCH,PROXY\n";
+        let merged = "mixed-port: 0\nmode: rule\nexternal-controller: 127.0.0.1:0\ngeo-auto-update: false\n\ndns:\n  enable: true\n  enhanced-mode: fake-ip\n\nproxies:\n  - name: \"TestNode\"\n    type: vless\n    server: \"1.2.3.4\"\n    port: 443\n    network: ws\n    ws-opts:\n      path: \"/ws\"\n\nproxy-groups:\n  - name: PROXY\n    type: select\n    proxies:\n      - \"TestNode\"\n\nrules:\n  - GEOIP,CN,DIRECT\n  - MATCH,PROXY\n";
         let out = pin_geodata_paths(merged, "/home/x");
         assert!(out.contains("mmdb-path: /home/x/Country.mmdb"), "{out}");
     }

--- a/Rust/meow-ffi/src/lib.rs
+++ b/Rust/meow-ffi/src/lib.rs
@@ -581,7 +581,8 @@ mode: rule
 dns:
   enable: true
   listen: 127.0.0.1:1053
-  enhanced-mode: redir-host
+  enhanced-mode: fake-ip
+  fake-ip-range: 28.0.0.0/8
   nameserver:
     - 127.0.0.1:5353
 proxies: []
@@ -763,7 +764,7 @@ rules:
     // Mirrors the Swift `uriListPassesValidation` merged config: default header
     // (mixed-port/dns/external-controller) + a vless node + default rules that
     // include GEOIP,CN,DIRECT — the exact shape that regressed.
-    const GEOIP_CFG: &str = "mixed-port: 0\nmode: rule\nlog-level: info\nallow-lan: false\nexternal-controller: 127.0.0.1:0\n\ngeo-auto-update: false\n\ndns:\n  enable: true\n  listen: 127.0.0.1:0\n  enhanced-mode: redir-host\n  nameserver:\n    - 114.114.114.114\n    - 223.5.5.5\n\nproxies:\n  - name: \"TestNode\"\n    type: vless\n    server: \"1.2.3.4\"\n    port: 443\n    uuid: \"00000000-0000-0000-0000-000000000000\"\n    udp: true\n    tls: true\n    servername: \"example.com\"\n    network: ws\n    ws-opts:\n      path: \"/ws\"\n      headers:\n        Host: \"example.com\"\n\nproxy-groups:\n  - name: PROXY\n    type: select\n    proxies:\n      - \"TestNode\"\n\nrules:\n  - DOMAIN-SUFFIX,google.com,PROXY\n  - GEOIP,CN,DIRECT\n  - MATCH,PROXY\n";
+    const GEOIP_CFG: &str = "mixed-port: 0\nmode: rule\nlog-level: info\nallow-lan: false\nexternal-controller: 127.0.0.1:0\n\ngeo-auto-update: false\n\ndns:\n  enable: true\n  listen: 127.0.0.1:0\n  enhanced-mode: fake-ip\n  nameserver:\n    - 114.114.114.114\n    - 223.5.5.5\n\nproxies:\n  - name: \"TestNode\"\n    type: vless\n    server: \"1.2.3.4\"\n    port: 443\n    uuid: \"00000000-0000-0000-0000-000000000000\"\n    udp: true\n    tls: true\n    servername: \"example.com\"\n    network: ws\n    ws-opts:\n      path: \"/ws\"\n      headers:\n        Host: \"example.com\"\n\nproxy-groups:\n  - name: PROXY\n    type: select\n    proxies:\n      - \"TestNode\"\n\nrules:\n  - DOMAIN-SUFFIX,google.com,PROXY\n  - GEOIP,CN,DIRECT\n  - MATCH,PROXY\n";
 
     // Regression for the Swift `uriListPassesValidation` failure: meow's home
     // dir is a first-write-wins OnceLock, so once test A pins it and deletes

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -426,6 +426,76 @@ final class ConfigManager {
         }
         config = lines.joined(separator: "\n")
         stripSubscriptionsSection(&config)
+        forceManagedDNS(&config)
+    }
+
+    /// DNS settings owned by the app/extension, mirroring meow-ios's
+    /// EffectiveConfigWriter: any user- or subscription-supplied `dns:` block
+    /// is replaced wholesale on every sanitize.
+    ///
+    /// fake-ip mode answers every A query with a synthetic 28.0.0.0/8 address,
+    /// so the engine — not a local upstream — resolves proxied domains: the
+    /// query never leaves the machine in the clear and the answer can't be
+    /// poisoned. The range can't be mihomo's 198.18.0.0/15 default because
+    /// the transparent proxy's excludedNetworkRules bypass that range, which
+    /// would send fake-IP flows straight to the physical interface.
+    static let managedDNSSection = """
+    dns:
+      enable: true
+      listen: 127.0.0.1:0
+      enhanced-mode: fake-ip
+      fake-ip-range: 28.0.0.0/8
+      # Bootstrap-only resolvers: proxy-server hostnames must resolve
+      # without going through a proxy (dial cycle otherwise).
+      default-nameserver:
+        - 223.5.5.5
+        - 114.114.114.114
+      # Only reached for DIRECT rules and fake-ip-filtered names — proxied
+      # domains are resolved remotely by the proxy itself, so plaintext UDP
+      # here can neither poison nor observe them.
+      nameserver:
+        - 119.29.29.29
+        - 223.5.5.5
+    """
+
+    /// Replace any existing top-level `dns:` section with `managedDNSSection`,
+    /// inserting it ahead of `proxies:` (or at the end) to keep the header
+    /// layout stable. Idempotent: re-running on a managed config is a no-op
+    /// change in content.
+    static func forceManagedDNS(_ config: inout String) {
+        var lines = config.components(separatedBy: "\n")
+        if let start = lines.firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces).hasPrefix("dns:")
+                && !$0.hasPrefix(" ") && !$0.hasPrefix("\t")
+        }) {
+            var end = lines.count
+            for i in (start + 1)..<lines.count {
+                let line = lines[i]
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                // Comments at any indentation stay with the section; only a
+                // real top-level key ends it.
+                if !trimmed.isEmpty && !trimmed.hasPrefix("#")
+                    && !line.hasPrefix(" ") && !line.hasPrefix("\t") {
+                    end = i
+                    break
+                }
+            }
+            lines.removeSubrange(start..<end)
+        }
+        let block = Self.managedDNSSection.components(separatedBy: "\n")
+        if let idx = lines.firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces).hasPrefix("proxies:")
+                && !$0.hasPrefix(" ") && !$0.hasPrefix("\t")
+        }) {
+            lines.insert(contentsOf: block + [""], at: idx)
+        } else {
+            // Drop trailing blank lines so appending stays idempotent.
+            while lines.last?.trimmingCharacters(in: .whitespaces).isEmpty == true {
+                lines.removeLast()
+            }
+            lines.append(contentsOf: [""] + block)
+        }
+        config = lines.joined(separator: "\n")
     }
 
     /// Remove the top-level `subscriptions:` section from a config string.
@@ -562,19 +632,12 @@ final class ConfigManager {
         // 1. Extract raw sections from subscription (preserves exact formatting)
         let sub = extractYAMLSections(from: yaml, named: ["proxies", "proxy-groups", "proxy-providers", "rules", "rule-providers"])
 
-        // 2. Header from base config (everything before proxies:) preserves user edits to ports, DNS, etc.
+        // 2. Header from base config (everything before proxies:) preserves
+        // user edits to ports etc. The dns block in it is replaced with the
+        // managed fake-ip block below.
         let baseLines = baseConfig.components(separatedBy: "\n")
         let proxiesCut = baseLines.firstIndex(where: { !$0.hasPrefix(" ") && !$0.hasPrefix("\t") && $0.hasPrefix("proxies:") }) ?? baseLines.count
-        var header = baseLines[0..<proxiesCut].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // The header's proxy-routed dns entries (`tcp://…#GROUP`) must
-        // reference a group that exists after the merge replaces all groups
-        // with the subscription's — a dangling reference is a hard config-load
-        // error in the engine, not a warning.
-        header = retargetProxiedNameservers(
-            in: header,
-            to: defaultProxyGroupName(inProxyGroupsSection: sub["proxy-groups"])
-        )
+        let header = baseLines[0..<proxiesCut].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
 
         // 3. Build merged config — pass through raw sections from subscription
         var result = header
@@ -588,72 +651,13 @@ final class ConfigManager {
         let defaultRules = extractYAMLSections(from: defaultConfig, named: ["rules"])
         result += "\n\n" + (sub["rules"] ?? defaultRules["rules"] ?? "rules:\n  - MATCH,DIRECT")
 
+        // Replace the base header's dns block with the managed fake-ip block,
+        // so a pre-upgrade header (redir-host, `tcp://…#GROUP` nameservers
+        // pointing at groups the subscription may not define) can't make the
+        // merged config fail validation or load.
+        forceManagedDNS(&result)
+
         return result
-    }
-
-    /// Rewrite the `#GROUP` tag on proxy-routed entries in the header's
-    /// `dns.nameserver:` list to `target`, or strip the tag when `target` is
-    /// nil so the entry degrades to a plain upstream instead of a dangling
-    /// reference. Only single-quoted `tcp://` / `udp://` list items are
-    /// touched — on `tls:///https://` upstreams the fragment is SNI, and
-    /// `default-nameserver` entries may not carry proxy tags at all.
-    static func retargetProxiedNameservers(in header: String, to target: String?) -> String {
-        var lines = header.components(separatedBy: "\n")
-        var inNameserverList = false
-        var keyIndent = 0
-        for i in lines.indices {
-            let line = lines[i]
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            let indent = line.prefix(while: { $0 == " " }).count
-            if trimmed == "nameserver:" {
-                inNameserverList = true
-                keyIndent = indent
-                continue
-            }
-            guard inNameserverList else { continue }
-            if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
-            if indent <= keyIndent {
-                inNameserverList = false
-                continue
-            }
-            lines[i] = retargetNameserverEntry(line, to: target)
-        }
-        return lines.joined(separator: "\n")
-    }
-
-    private static func retargetNameserverEntry(_ line: String, to target: String?) -> String {
-        let trimmed = line.trimmingCharacters(in: .whitespaces)
-        guard trimmed.hasPrefix("- 'tcp://") || trimmed.hasPrefix("- 'udp://"),
-              trimmed.hasSuffix("'"),
-              let openQuote = line.firstIndex(of: "'"),
-              let closeQuote = line.lastIndex(of: "'"),
-              openQuote < closeQuote else {
-            return line
-        }
-        var url = String(line[line.index(after: openQuote)..<closeQuote])
-        if let hash = url.firstIndex(of: "#") {
-            url = String(url[..<hash])
-        }
-        if let target {
-            url += "#" + target.replacingOccurrences(of: "'", with: "''")
-        }
-        return String(line[..<openQuote]) + "'" + url + "'"
-    }
-
-    /// Default proxy group of a raw `proxy-groups:` section: the first
-    /// select-type group (the conventional main selector in subscription
-    /// configs), falling back to the first named group of any type.
-    static func defaultProxyGroupName(inProxyGroupsSection section: String?) -> String? {
-        guard let section,
-              let dict = (try? Yams.load(yaml: section)) as? [String: Any],
-              let groups = dict["proxy-groups"] as? [[String: Any]] else {
-            return nil
-        }
-        let named = groups.compactMap { group -> (name: String, type: String)? in
-            guard let name = group["name"] as? String, !name.isEmpty else { return nil }
-            return (name, group["type"] as? String ?? "")
-        }
-        return (named.first(where: { $0.type == "select" }) ?? named.first)?.name
     }
 
     /// Set interval to 0 in provider sections so Mihomo won't auto-refresh subscription URLs.
@@ -891,26 +895,7 @@ final class ConfigManager {
 
         geo-auto-update: false
 
-        dns:
-          enable: true
-          listen: 127.0.0.1:0
-          enhanced-mode: redir-host
-          # Bootstrap-only resolvers: proxy-server hostnames must resolve
-          # without going through a proxy (dial cycle otherwise), and the
-          # engine rejects #PROXY tags on default-nameserver entries.
-          default-nameserver:
-            - 223.5.5.5
-            - 114.114.114.114
-          # Public resolvers routed through the default proxy group so answers
-          # can't be poisoned locally. DNS-over-TCP, not tls:// — meow-rs
-          # treats the # fragment on tls:///https:// upstreams as SNI and has
-          # no proxy-routing for encrypted upstreams (EncryptedProxyUnsupported);
-          # the query still rides inside the proxy's encrypted transport.
-          # mergeSubscription retargets the #PROXY tag to the subscription's
-          # default select group.
-          nameserver:
-            - 'tcp://1.1.1.1:53#PROXY'
-            - 'tcp://8.8.8.8:53#PROXY'
+        \(Self.managedDNSSection)
 
         proxies: []
 

--- a/TransparentProxy/TransparentProxyProvider.swift
+++ b/TransparentProxy/TransparentProxyProvider.swift
@@ -275,10 +275,10 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                 )
                 socksConn = conn
 
-                // SOCKS5 handshake — pass the raw destination IP; mihomo
-                // recovers the domain via its DNS snooping reverse cache
-                // (populated from the UDP DNS queries we forward to its
-                // ephemeral DNS port).
+                // SOCKS5 handshake — pass the raw destination IP. Fake-IP
+                // destinations are mapped back to their domain by mihomo's
+                // fake-ip pool (populated from the UDP DNS queries we forward
+                // to its ephemeral DNS port); real IPs match IP-based rules.
                 try await SOCKS5Client.handshake(
                     connection: conn,
                     destHost: destHost,
@@ -389,6 +389,15 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                     guard !isBroadcastOrMulticast(endpoint.hostname) else {
                         continue
                     }
+                    // Fake-IP destinations (28.0.0.0/8) only exist inside
+                    // mihomo's fake-ip pool — relaying them to the physical
+                    // interface blackholes the packets (QUIC to a proxied
+                    // domain is the common case). Drop them; the client
+                    // falls back to TCP, which rides the SOCKS5 path where
+                    // mihomo maps the fake IP back to the domain.
+                    guard !isFakeIP(endpoint.hostname) else {
+                        continue
+                    }
 
                     // Lazily create relay on first non-DNS datagram
                     if relay == nil {
@@ -412,9 +421,9 @@ class TransparentProxyProvider: NETransparentProxyProvider {
 
     /// Forward a UDP DNS query directly to mihomo's DNS server on the
     /// ephemeral port stored in `mihomoDNSPort` and relay the response
-    /// back to the app. Mihomo populates its own snooping cache from the
-    /// query, and its SOCKS5 listener uses that cache to recover the
-    /// domain when subsequent TCP flows arrive with only an IP.
+    /// back to the app. In fake-ip mode the answer is a synthetic 28.0.0.0/8
+    /// address that mihomo's SOCKS5 listener maps back to the queried domain
+    /// when the app connects to it.
     private func handleDNSQuery(
         query: Data, flow: NEAppProxyUDPFlow, endpoint: NWHostEndpoint
     ) async {

--- a/TransparentProxy/UDPNATRelay.swift
+++ b/TransparentProxy/UDPNATRelay.swift
@@ -21,6 +21,18 @@ func isBroadcastOrMulticast(_ hostname: String) -> Bool {
     return false
 }
 
+/// Check if an IP address belongs to mihomo's fake-ip pool (28.0.0.0/8, see
+/// `ConfigManager.managedDNSSection`). Fake IPs are only meaningful to the
+/// engine's reverse mapping — they must never be dialed on the physical
+/// interface.
+func isFakeIP(_ hostname: String) -> Bool {
+    if let dot = hostname.firstIndex(of: "."),
+       let first = UInt8(hostname[hostname.startIndex..<dot]) {
+        return first == 28
+    }
+    return false
+}
+
 // MARK: - UDP NAT Relay (NAT2, Address-Restricted Cone)
 
 /// Relays non-DNS UDP traffic directly to the internet via POSIX UDP sockets.

--- a/tests/e2e/config/stress-test-config.yaml
+++ b/tests/e2e/config/stress-test-config.yaml
@@ -10,7 +10,7 @@ dns:
   enable: true
   ipv6: false
   listen: 127.0.0.1:1053
-  enhanced-mode: redir-host
+  enhanced-mode: fake-ip
   nameserver:
     - https://__HOST_IP__:18444/dns-query
 

--- a/tests/e2e/config/test-config.yaml
+++ b/tests/e2e/config/test-config.yaml
@@ -10,7 +10,7 @@ dns:
   enable: true
   ipv6: false
   listen: 127.0.0.1:1053
-  enhanced-mode: redir-host
+  enhanced-mode: fake-ip
   nameserver:
     - 8.8.8.8
     - 1.1.1.1


### PR DESCRIPTION
## Summary

Follows meow-ios's latest DNS changes (dottyback, `fix(dns): restore fake-ip mode`). redir-host depended on local upstream resolution + the snooping reverse cache: answers could be poisoned, and domain routing was lost whenever an app bypassed the intercepted resolver. fake-ip hands every A query a synthetic address, so the engine resolves proxied domains remotely — the query never leaves the machine in the clear.

- **ConfigManager**: force a managed `dns:` block (`fake-ip`, `28.0.0.0/8`, plain UDP nameservers 119.29.29.29/223.5.5.5) on every sanitize and subscription merge, replacing any user/subscription-supplied block; drop the now-dead `#PROXY` nameserver retargeting. The range can't be mihomo's `198.18.0.0/15` default — `excludedNetworkRules` bypasses it, which would send fake-IP flows straight to the physical interface.
- **TransparentProxy**: drop non-DNS UDP datagrams to fake-IP destinations (unroutable on the physical interface; QUIC falls back to TCP, which the engine maps back to the domain via the fake-ip pool).
- **Rust bridge**: diagnostics fake-ip detection `198.18.0.0/15` → `28.0.0.0/8`; stale comments updated.
- **Tests**: remove the retarget suite; add `forceManagedDNS` + merge coverage; e2e configs updated.

## Verification

- `cargo test` (Rust/meow-ffi): 18/18
- `xcodebuild test -only-testing:BaoLianDengTests` (incl. ProxyEngineIntegrationTests): 196/196
- SwiftLint `--strict`: 0 violations
- Release build installed locally and launches
