### PR TITLE
Add option to allow LAN clients

### DIFF
--- a/BaoLianDeng.xcodeproj/project.pbxproj
+++ b/BaoLianDeng.xcodeproj/project.pbxproj
@@ -32,6 +32,11 @@
 		A1B2C3D4E5F60718293A4B5C /* PerAppProxySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10095 /* PerAppProxySettings.swift */; };
 		A1B2C3D4E5F60718293A4B5D /* PerAppProxySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10095 /* PerAppProxySettings.swift */; };
 		A1B2C3D4E5F60718293A4B5E /* PerAppProxySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10096 /* PerAppProxySection.swift */; };
+		LS100001 /* LANSharingSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10097 /* LANSharingSettings.swift */; };
+		LS100002 /* LANSharingSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10097 /* LANSharingSettings.swift */; };
+		LS100003 /* LANSharingSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10097 /* LANSharingSettings.swift */; };
+		LS100004 /* LANSharingSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10098 /* LANSharingSection.swift */; };
+		LS100005 /* LANSharingSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10099 /* LANSharingSettingsTests.swift */; };
 		A2B3C4D5E6F7A8B9C0D1E2F3 /* UDPNATRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10021 /* UDPNATRelay.swift */; };
 		A9840B29BC5EC55F29F0BA38 /* TrafficStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10060 /* TrafficStore.swift */; };
 		B10063 /* MihomoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10062 /* MihomoAPI.swift */; };
@@ -180,6 +185,9 @@
 		B10090 /* AppLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogger.swift; sourceTree = "<group>"; };
 		B10095 /* PerAppProxySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerAppProxySettings.swift; sourceTree = "<group>"; };
 		B10096 /* PerAppProxySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerAppProxySection.swift; sourceTree = "<group>"; };
+		B10097 /* LANSharingSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LANSharingSettings.swift; sourceTree = "<group>"; };
+		B10098 /* LANSharingSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LANSharingSection.swift; sourceTree = "<group>"; };
+		B10099 /* LANSharingSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LANSharingSettingsTests.swift; sourceTree = "<group>"; };
 		B10100 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		B10101 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		B10200 /* SubscriptionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionModels.swift; sourceTree = "<group>"; };
@@ -329,6 +337,7 @@
 				B10007 /* Constants.swift */,
 				B10008 /* ConfigManager.swift */,
 				B10095 /* PerAppProxySettings.swift */,
+				B10097 /* LANSharingSettings.swift */,
 				B10009 /* VPNManager.swift */,
 			);
 			path = Shared;
@@ -378,6 +387,7 @@
 				B10054 /* ConfigStyleHelpers.swift */,
 				B10055 /* ConfigListViews.swift */,
 				B10096 /* PerAppProxySection.swift */,
+				B10098 /* LANSharingSection.swift */,
 				B10200 /* SubscriptionModels.swift */,
 				B10202 /* NodeRow.swift */,
 				B10204 /* MainContentView.swift */,
@@ -406,6 +416,7 @@
 			children = (
 				T10050 /* Utilities */,
 				T10007 /* PerAppProxySettingsTests.swift */,
+				B10099 /* LANSharingSettingsTests.swift */,
 				T10021 /* BypassGroupDetectionTests.swift */,
 				T10030 /* ConfigParserTests.swift */,
 				T10032 /* MihomoCoreIntegrationTests.swift */,
@@ -609,7 +620,9 @@
 				8263DE84A3B841EF63A2FF89 /* ConfigManager.swift in Sources */,
 				8D9BF44D7D340ADB5C09AEF9 /* VPNManager.swift in Sources */,
 				A1B2C3D4E5F60718293A4B5C /* PerAppProxySettings.swift in Sources */,
+				LS100001 /* LANSharingSettings.swift in Sources */,
 				A1B2C3D4E5F60718293A4B5E /* PerAppProxySection.swift in Sources */,
+				LS100004 /* LANSharingSection.swift in Sources */,
 				B10400B /* SOCKS5Client.swift in Sources */,
 				B10201 /* SubscriptionModels.swift in Sources */,
 				B10203 /* NodeRow.swift in Sources */,
@@ -632,6 +645,7 @@
 				1C46310C4BA03116BAE1CF24 /* ConfigManager.swift in Sources */,
 				ADFBB07EC9AE7B14EE8CF08D /* VPNManager.swift in Sources */,
 				A1B2C3D4E5F60718293A4B5D /* PerAppProxySettings.swift in Sources */,
+				LS100002 /* LANSharingSettings.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -646,6 +660,7 @@
 				AX10024 /* Constants.swift in Sources */,
 				AX10025 /* ConfigManager.swift in Sources */,
 				AX10027 /* PerAppProxySettings.swift in Sources */,
+				LS100003 /* LANSharingSettings.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -654,6 +669,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				T10008 /* PerAppProxySettingsTests.swift in Sources */,
+				LS100005 /* LANSharingSettingsTests.swift in Sources */,
 				T10022 /* BypassGroupDetectionTests.swift in Sources */,
 				T10031 /* ConfigParserTests.swift in Sources */,
 				T10033 /* MihomoCoreIntegrationTests.swift in Sources */,

--- a/BaoLianDeng/Localizable.xcstrings
+++ b/BaoLianDeng/Localizable.xcstrings
@@ -156,6 +156,17 @@
         }
       }
     },
+    "Allow LAN": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许局域网连接"
+          }
+        }
+      },
+      "extractionState": "manual"
+    },
     "Bypass Listed Apps": {
       "localizations": {
         "zh-Hans": {
@@ -627,6 +638,28 @@
       }
     },
     "L%lld": {},
+    "LAN": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "局域网"
+          }
+        }
+      },
+      "extractionState": "manual"
+    },
+    "LAN Proxy Address": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "局域网代理地址"
+          }
+        }
+      },
+      "extractionState": "manual"
+    },
     "License": {
       "localizations": {
         "zh-Hans": {
@@ -890,6 +923,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "仅代理列表中的应用"
+          }
+        }
+      },
+      "extractionState": "manual"
+    },
+    "Proxy Port": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "代理端口"
           }
         }
       },
@@ -1374,6 +1418,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "VPN"
+          }
+        }
+      },
+      "extractionState": "manual"
+    },
+    "While the VPN is connected, other devices on your network can use this Mac as their SOCKS5/HTTP proxy server on the proxy port. Anyone on the local network can use the proxy \u2014 enable only on networks you trust.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VPN 连接期间，局域网内的其他设备可将本机用作 SOCKS5/HTTP 代理服务器（代理端口）。局域网内任何人都能使用该代理——请仅在可信网络中启用。"
           }
         }
       },

--- a/BaoLianDeng/Views/LANSharingSection.swift
+++ b/BaoLianDeng/Views/LANSharingSection.swift
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Max Lv <max.c.lv@gmail.com>
+//
+// Licensed under the MIT License. See the LICENSE file for details.
+
+import SwiftUI
+
+// MARK: - Settings Section (Allow LAN)
+
+struct LANSharingSection: View {
+    @EnvironmentObject var vpnManager: VPNManager
+    @State private var settings = LANSharingSettings()
+    @State private var lanAddresses: [String] = []
+
+    var body: some View {
+        Section {
+            Toggle("Allow LAN", isOn: $settings.enabled)
+                .toggleStyle(.switch)
+                .onChange(of: settings.enabled) {
+                    if settings.enabled {
+                        lanAddresses = Self.currentIPv4Addresses()
+                    }
+                    save()
+                }
+
+            if settings.enabled {
+                TextField(
+                    "Proxy Port",
+                    value: $settings.proxyPort,
+                    format: .number.grouping(.never)
+                )
+                .onSubmit { commitPort() }
+
+                if !lanAddresses.isEmpty {
+                    LabeledContent("LAN Proxy Address") {
+                        VStack(alignment: .trailing, spacing: 2) {
+                            ForEach(lanAddresses, id: \.self) { address in
+                                Text("\(address):\(String(settings.effectiveProxyPort))")
+                                    .font(.body.monospaced())
+                                    .textSelection(.enabled)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        } header: {
+            Text("LAN")
+        } footer: {
+            Text(
+                """
+                While the VPN is connected, other devices on your network can use \
+                this Mac as their SOCKS5/HTTP proxy server on the proxy port. \
+                Anyone on the local network can use the proxy — enable only on \
+                networks you trust.
+                """
+            )
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+        }
+        .onAppear {
+            load()
+            lanAddresses = Self.currentIPv4Addresses()
+        }
+        // The port field commits on Enter; also commit when focus leaves the tab.
+        .onDisappear { commitPort() }
+    }
+
+    private func load() {
+        settings = LANSharingSettings.load()
+    }
+
+    private func save() {
+        settings.save()
+        vpnManager.restartIfConnected()
+    }
+
+    /// Persist an edited port field, but only restart the tunnel when the
+    /// stored value actually changed — onDisappear fires on every tab
+    /// switch and must not bounce the VPN gratuitously.
+    private func commitPort() {
+        guard settings != LANSharingSettings.load() else { return }
+        save()
+    }
+
+    /// Non-loopback IPv4 addresses of this Mac's active interfaces, for
+    /// display so the user knows what to point other devices at. Skips
+    /// utun* (the VPN's own tunnels are not reachable from the LAN).
+    private static func currentIPv4Addresses() -> [String] {
+        var addresses: [String] = []
+        var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&ifaddrPtr) == 0 else { return [] }
+        defer { freeifaddrs(ifaddrPtr) }
+
+        var ptr = ifaddrPtr
+        while let current = ptr {
+            let ifa = current.pointee
+            ptr = ifa.ifa_next
+
+            let flags = Int32(bitPattern: ifa.ifa_flags)
+            guard (flags & IFF_UP) != 0, (flags & IFF_LOOPBACK) == 0,
+                  let sa = ifa.ifa_addr, sa.pointee.sa_family == UInt8(AF_INET)
+            else { continue }
+
+            let name = String(cString: ifa.ifa_name)
+            guard !name.hasPrefix("utun") else { continue }
+
+            var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            guard getnameinfo(
+                sa, socklen_t(sa.pointee.sa_len),
+                &host, socklen_t(host.count),
+                nil, 0, NI_NUMERICHOST
+            ) == 0 else { continue }
+            let address = String(cString: host)
+            if !addresses.contains(address) {
+                addresses.append(address)
+            }
+        }
+        return addresses
+    }
+}

--- a/BaoLianDeng/Views/SettingsView.swift
+++ b/BaoLianDeng/Views/SettingsView.swift
@@ -53,6 +53,8 @@ struct SettingsView: View {
 
             PerAppProxySection()
 
+            LANSharingSection()
+
             Section("Diagnostics") {
                 NavigationLink("Network Diagnostics") {
                     DiagnosticsView()

--- a/BaoLianDengTests/LANSharingSettingsTests.swift
+++ b/BaoLianDengTests/LANSharingSettingsTests.swift
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Max Lv <max.c.lv@gmail.com>
+//
+// Licensed under the MIT License. See the LICENSE file for details.
+
+import XCTest
+@testable import BaoLianDeng
+
+final class LANSharingSettingsTests: XCTestCase {
+
+    func testDefaults() {
+        let settings = LANSharingSettings()
+        XCTAssertFalse(settings.enabled)
+        XCTAssertEqual(settings.proxyPort, 7890)
+    }
+
+    func testRoundTrip() throws {
+        var settings = LANSharingSettings()
+        settings.enabled = true
+        settings.proxyPort = 8899
+
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(LANSharingSettings.self, from: data)
+        XCTAssertEqual(decoded, settings)
+    }
+
+    func testPartialJSONFallsBackToDefaults() throws {
+        let json = Data(#"{"enabled":true}"#.utf8)
+        let decoded = try JSONDecoder().decode(LANSharingSettings.self, from: json)
+        XCTAssertTrue(decoded.enabled)
+        XCTAssertEqual(decoded.proxyPort, 7890)
+    }
+
+    func testEffectivePortClampsInvalidValues() {
+        var settings = LANSharingSettings()
+        settings.proxyPort = 0
+        XCTAssertEqual(settings.effectiveProxyPort, 7890)
+
+        settings.proxyPort = 70000
+        XCTAssertEqual(settings.effectiveProxyPort, 7890)
+
+        settings.proxyPort = 1080
+        XCTAssertEqual(settings.effectiveProxyPort, 1080)
+    }
+
+    func testLoadSaveRoundTripThroughDefaults() {
+        let suiteName = "LANSharingSettingsTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("could not create test defaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        // No stored value → defaults.
+        XCTAssertEqual(LANSharingSettings.load(from: defaults), LANSharingSettings())
+
+        var settings = LANSharingSettings()
+        settings.enabled = true
+        settings.proxyPort = 1080
+        settings.save(to: defaults)
+        XCTAssertEqual(LANSharingSettings.load(from: defaults), settings)
+
+        // Corrupt data → defaults, not a crash.
+        defaults.set(Data("not json".utf8), forKey: AppConstants.lanSharingSettingsKey)
+        XCTAssertEqual(LANSharingSettings.load(from: defaults), LANSharingSettings())
+    }
+}

--- a/Rust/meow-ffi/objc/MihomoCore.h
+++ b/Rust/meow-ffi/objc/MihomoCore.h
@@ -7,6 +7,10 @@ FOUNDATION_EXPORT void BridgeSetLogFile(NSString * _Nullable path);
 /// clients know the controller endpoint without an IPC round-trip.
 /// `controllerAddr` is `host:port`.
 FOUNDATION_EXPORT BOOL BridgeStartWithPorts(int32_t socksPort, int32_t dnsPort, NSString * _Nonnull controllerAddr, NSString * _Nullable secret, NSError * _Nullable * _Nullable error);
+/// Like BridgeStartWithPorts, additionally exposing a mixed (SOCKS5+HTTP)
+/// listener on 0.0.0.0:lanProxyPort so LAN clients can use this machine as
+/// their proxy server. Pass 0 to disable the LAN listener.
+FOUNDATION_EXPORT BOOL BridgeStartWithLAN(int32_t socksPort, int32_t dnsPort, NSString * _Nonnull controllerAddr, NSString * _Nullable secret, int32_t lanProxyPort, NSError * _Nullable * _Nullable error);
 FOUNDATION_EXPORT void BridgeStopProxy(void);
 FOUNDATION_EXPORT BOOL BridgeIsRunning(void);
 

--- a/Rust/meow-ffi/objc/MihomoCore.m
+++ b/Rust/meow-ffi/objc/MihomoCore.m
@@ -5,6 +5,7 @@
 extern void bridge_set_home_dir(const char *dir);
 extern int32_t bridge_set_log_file(const char *path);
 extern int32_t bridge_start_with_ports(int32_t socks_port, int32_t dns_port, const char *controller_addr, const char *secret);
+extern int32_t bridge_start_with_lan(int32_t socks_port, int32_t dns_port, const char *controller_addr, const char *secret, int32_t lan_proxy_port);
 extern int32_t bridge_get_socks_port(void);
 extern int32_t bridge_get_dns_port(void);
 extern char *bridge_get_external_controller_addr(void);
@@ -40,6 +41,15 @@ void BridgeSetLogFile(NSString * _Nullable path) {
 
 BOOL BridgeStartWithPorts(int32_t socksPort, int32_t dnsPort, NSString * _Nonnull controllerAddr, NSString * _Nullable secret, NSError * _Nullable * _Nullable error) {
     int32_t rc = bridge_start_with_ports(socksPort, dnsPort, [controllerAddr UTF8String], [secret UTF8String]);
+    if (rc != 0) {
+        if (error) *error = makeError();
+        return NO;
+    }
+    return YES;
+}
+
+BOOL BridgeStartWithLAN(int32_t socksPort, int32_t dnsPort, NSString * _Nonnull controllerAddr, NSString * _Nullable secret, int32_t lanProxyPort, NSError * _Nullable * _Nullable error) {
+    int32_t rc = bridge_start_with_lan(socksPort, dnsPort, [controllerAddr UTF8String], [secret UTF8String], lanProxyPort);
     if (rc != 0) {
         if (error) *error = makeError();
         return NO;

--- a/Rust/meow-ffi/src/engine.rs
+++ b/Rust/meow-ffi/src/engine.rs
@@ -37,6 +37,13 @@ pub struct EngineState {
 /// Load `<config_path>`, force the runtime endpoints, and start the tunnel,
 /// DNS server, REST API, and mixed (SOCKS5+HTTP) listener on the shared
 /// runtime. Returns the assembled [`EngineState`] with all task handles.
+///
+/// `lan_proxy_port` > 0 additionally exposes a mixed (SOCKS5+HTTP) listener
+/// on `0.0.0.0` at that port, so other LAN devices can use this machine as
+/// their proxy server ("allow LAN"). The loopback listeners above are
+/// unaffected. The LAN port is bind-checked up-front so an occupied port
+/// fails engine start with a clear error instead of a warning buried in the
+/// log.
 pub async fn assemble(
     config_path: String,
     home: String,
@@ -44,6 +51,7 @@ pub async fn assemble(
     dns_port: i32,
     controller_addr: String,
     secret: String,
+    lan_proxy_port: i32,
 ) -> anyhow::Result<EngineState> {
     let mut config = load_config_pinned(&config_path, &home).await?;
 
@@ -75,6 +83,17 @@ pub async fn assemble(
         tproxy_sni: false,
         max_connections: 0,
     }];
+    validate_lan_port(lan_proxy_port, socks_port)?;
+    if lan_proxy_port > 0 {
+        config.listeners.named.push(NamedListener {
+            name: "mixed-lan".to_string(),
+            listener_type: ListenerType::Mixed,
+            port: lan_proxy_port as u16,
+            listen: "0.0.0.0".to_string(),
+            tproxy_sni: false,
+            max_connections: 0,
+        });
+    }
     config.listeners.mixed_port = Some(socks_addr.port());
     config.listeners.socks_port = None;
     config.listeners.http_port = None;
@@ -174,7 +193,10 @@ pub async fn assemble(
         }));
     }
 
-    info!("meow engine started: socks={socks_port} dns={dns_port} controller={controller_addr}");
+    info!(
+        "meow engine started: socks={socks_port} dns={dns_port} controller={controller_addr} \
+         lan_proxy={lan_proxy_port}"
+    );
 
     Ok(EngineState {
         tunnel,
@@ -183,6 +205,29 @@ pub async fn assemble(
         dns_port,
         controller_addr,
     })
+}
+
+/// Validate the LAN proxy port and bind-check it up-front.
+///
+/// The listener itself binds later inside a spawned task where a failure
+/// only reaches the log, so an occupied port is caught here with a test
+/// bind (bound then immediately dropped — the small TOCTOU window mirrors
+/// the app-side `EphemeralPort` picker and is acceptable).
+fn validate_lan_port(lan_proxy_port: i32, socks_port: i32) -> anyhow::Result<()> {
+    if !(0..=65535).contains(&lan_proxy_port) {
+        anyhow::bail!("LAN proxy port {lan_proxy_port} is out of range");
+    }
+    // A 0.0.0.0 bind covers loopback too, so sharing a port with the internal
+    // 127.0.0.1 listener can never work — reject it explicitly rather than
+    // letting the two binds race.
+    if lan_proxy_port > 0 && lan_proxy_port == socks_port {
+        anyhow::bail!("LAN proxy port {lan_proxy_port} collides with the internal SOCKS port");
+    }
+    if lan_proxy_port > 0 {
+        std::net::TcpListener::bind(("0.0.0.0", lan_proxy_port as u16))
+            .map_err(|e| anyhow::anyhow!("LAN proxy port {lan_proxy_port} unavailable: {e}"))?;
+    }
+    Ok(())
 }
 
 /// Load a config with geodata paths pinned to the bridge home dir.

--- a/Rust/meow-ffi/src/lib.rs
+++ b/Rust/meow-ffi/src/lib.rs
@@ -351,6 +351,21 @@ pub unsafe extern "C" fn bridge_start_with_ports(
     controller_addr: *const c_char,
     secret: *const c_char,
 ) -> i32 {
+    bridge_start_with_lan(socks_port, dns_port, controller_addr, secret, 0)
+}
+
+/// Like [`bridge_start_with_ports`], additionally exposing a mixed
+/// (SOCKS5+HTTP) listener on `0.0.0.0:<lan_proxy_port>` so other LAN
+/// devices can use this machine as their proxy server ("allow LAN").
+/// 0 disables the LAN listener; the loopback listeners are unaffected.
+#[no_mangle]
+pub unsafe extern "C" fn bridge_start_with_lan(
+    socks_port: i32,
+    dns_port: i32,
+    controller_addr: *const c_char,
+    secret: *const c_char,
+    lan_proxy_port: i32,
+) -> i32 {
     guard(-1, || {
         let mut engine = ENGINE.lock();
         if engine.is_some() {
@@ -388,6 +403,7 @@ pub unsafe extern "C" fn bridge_start_with_ports(
             dns_port,
             addr,
             secret_s,
+            lan_proxy_port,
         )) {
             Ok(state) => {
                 *engine = Some(state);
@@ -803,6 +819,85 @@ rules:
         let _ = std::fs::remove_dir_all(&dir_b);
         assert_eq!(rc, 0, "GEOIP validate under home B failed: {err}");
         assert!(!err.contains(&a_str), "resolved stale home A: {err}");
+    }
+
+    #[test]
+    fn lan_listeners_start_and_serve() {
+        let _g = TEST_LOCK.lock();
+
+        let dir = std::env::temp_dir().join(format!("meow-ffi-lan-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("config.yaml"), MINIMAL_CONFIG).unwrap();
+        let dir_c = CString::new(dir.to_str().unwrap()).unwrap();
+        unsafe { bridge_set_home_dir(dir_c.as_ptr()) };
+
+        let socks = free_port();
+        let dns = free_port();
+        let ctrl = free_port();
+        let lan_proxy = free_port();
+        let ctrl_c = CString::new(format!("127.0.0.1:{ctrl}")).unwrap();
+        let secret_c = CString::new("").unwrap();
+
+        let rc = unsafe {
+            bridge_start_with_lan(socks, dns, ctrl_c.as_ptr(), secret_c.as_ptr(), lan_proxy)
+        };
+        let err = unsafe { CStr::from_ptr(bridge_get_last_error()) }
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(rc, 0, "LAN start failed: {err}");
+
+        // The LAN mixed listener must accept TCP (0.0.0.0 covers loopback).
+        let mut connected = false;
+        for _ in 0..20 {
+            if std::net::TcpStream::connect(format!("127.0.0.1:{lan_proxy}")).is_ok() {
+                connected = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        assert!(connected, "LAN mixed listener not accepting on {lan_proxy}");
+
+        bridge_stop_proxy();
+        assert!(!bridge_is_running());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn lan_start_fails_on_occupied_port() {
+        let _g = TEST_LOCK.lock();
+
+        let dir = std::env::temp_dir().join(format!("meow-ffi-lanbusy-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("config.yaml"), MINIMAL_CONFIG).unwrap();
+        let dir_c = CString::new(dir.to_str().unwrap()).unwrap();
+        unsafe { bridge_set_home_dir(dir_c.as_ptr()) };
+
+        // Occupy a port on 0.0.0.0 so the LAN preflight bind must fail.
+        let blocker = std::net::TcpListener::bind("0.0.0.0:0").unwrap();
+        let busy = blocker.local_addr().unwrap().port() as i32;
+
+        let ctrl_c = CString::new(format!("127.0.0.1:{}", free_port())).unwrap();
+        let secret_c = CString::new("").unwrap();
+        let rc = unsafe {
+            bridge_start_with_lan(
+                free_port(),
+                free_port(),
+                ctrl_c.as_ptr(),
+                secret_c.as_ptr(),
+                busy,
+            )
+        };
+        let err = unsafe { CStr::from_ptr(bridge_get_last_error()) }
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(rc, -1, "start must fail when the LAN port is occupied");
+        assert!(err.contains("LAN proxy port"), "error was: {err}");
+        assert!(!bridge_is_running());
+
+        drop(blocker);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -27,6 +27,7 @@ enum AppConstants {
     static let dailyTrafficKey = "dailyTrafficRecords"
     static let subscriptionUsageKey = "subscriptionUsageRecords"
     static let perAppProxySettingsKey = "perAppProxySettings"
+    static let lanSharingSettingsKey = "lanSharingSettings"
     static let autoStartVPNAtLoginKey = "autoStartVPNAtLogin"
 
     /// Live mihomo REST controller address (`host:port`). Returns nil when

--- a/Shared/LANSharingSettings.swift
+++ b/Shared/LANSharingSettings.swift
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Max Lv <max.c.lv@gmail.com>
+//
+// Licensed under the MIT License. See the LICENSE file for details.
+
+import Foundation
+
+/// "Allow LAN" settings. When enabled, the engine additionally binds a mixed
+/// SOCKS5/HTTP listener on `0.0.0.0`, so other devices on the local network
+/// can use this Mac as their proxy server. Stored as JSON in shared
+/// UserDefaults and forwarded to the extension via providerConfiguration.
+struct LANSharingSettings: Codable, Equatable {
+    static let defaultProxyPort = 7890
+
+    var enabled: Bool = false
+    var proxyPort: Int = LANSharingSettings.defaultProxyPort
+
+    init() {}
+
+    /// Tolerant decoding: missing keys (older saves, forward compatibility)
+    /// fall back to defaults instead of failing the whole decode.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+        proxyPort = try container.decodeIfPresent(Int.self, forKey: .proxyPort)
+            ?? Self.defaultProxyPort
+    }
+
+    /// Port actually used for the LAN proxy listener — out-of-range values
+    /// (e.g. a half-typed field) fall back to the default.
+    var effectiveProxyPort: Int {
+        (1...65535).contains(proxyPort) ? proxyPort : Self.defaultProxyPort
+    }
+
+    static func load(from defaults: UserDefaults = AppConstants.sharedDefaults) -> LANSharingSettings {
+        guard let data = defaults.data(forKey: AppConstants.lanSharingSettingsKey),
+              let decoded = try? JSONDecoder().decode(LANSharingSettings.self, from: data)
+        else { return LANSharingSettings() }
+        return decoded
+    }
+
+    func save(to defaults: UserDefaults = AppConstants.sharedDefaults) {
+        guard let data = try? JSONEncoder().encode(self) else { return }
+        defaults.set(data, forKey: AppConstants.lanSharingSettingsKey)
+    }
+}

--- a/Shared/VPNManager.swift
+++ b/Shared/VPNManager.swift
@@ -630,6 +630,14 @@ final class VPNManager: NSObject, ObservableObject {
             providerConfig["perAppProxy"] = perAppData
         }
 
+        // Allow LAN: forward the fixed LAN proxy port so the engine
+        // additionally binds on 0.0.0.0. An absent key means disabled.
+        let lanSettings = LANSharingSettings.load(from: defaults)
+        if lanSettings.enabled {
+            providerConfig["lanProxyPort"] = lanSettings.effectiveProxyPort
+            dbg("passSettings: allow LAN proxyPort=\(lanSettings.effectiveProxyPort)")
+        }
+
         // Pick ephemeral 127.0.0.1 ports for the SOCKS5, DNS, and REST
         // controller listeners and forward them to the extension. We
         // pick in this process (not the extension) so the app's REST

--- a/TransparentProxy/TransparentProxyProvider.swift
+++ b/TransparentProxy/TransparentProxyProvider.swift
@@ -43,6 +43,11 @@ class TransparentProxyProvider: NETransparentProxyProvider {
     private var controllerAddr: String = ""
     private var controllerSecret: String = ""
 
+    /// "Allow LAN" proxy listener port (0 = disabled). When set, the engine
+    /// additionally binds a mixed SOCKS5/HTTP listener on 0.0.0.0 so other
+    /// LAN devices can use this Mac as their proxy server.
+    private var lanProxyPort: UInt16 = 0
+
     private lazy var logURL: URL = {
         let dir = ConfigManager.shared.configDirectoryURL?.deletingLastPathComponent()
             ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
@@ -138,12 +143,15 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                 completionHandler(ProviderError.configNotFound)
                 return
             }
+            let lanProxy = self?.lanProxyPort ?? 0
             self?.log(
                 "Starting Mihomo proxy engine: socks=\(socks) dns=\(dns) controller=\(ctrl)"
+                    + " lanProxy=\(lanProxy)"
             )
             var startError: NSError?
-            BridgeStartWithPorts(
-                Int32(socks), Int32(dns), ctrl, secret, &startError
+            BridgeStartWithLAN(
+                Int32(socks), Int32(dns), ctrl, secret,
+                Int32(lanProxy), &startError
             )
             if let startError = startError {
                 self?.log("ERROR: BridgeStartWithPorts failed: \(startError)")
@@ -721,6 +729,12 @@ class TransparentProxyProvider: NETransparentProxyProvider {
         }
         if let secret = providerConfig?["secret"] as? String {
             self.controllerSecret = secret
+        }
+
+        // "Allow LAN" proxy listener port; absent or 0 means disabled.
+        if let lanProxy = providerConfig?["lanProxyPort"] as? Int,
+           (1...65535).contains(lanProxy) {
+            self.lanProxyPort = UInt16(lanProxy)
         }
 
         return configDir


### PR DESCRIPTION
## Summary

Adds an **Allow LAN** option: when enabled, the engine additionally binds a mixed **SOCKS5/HTTP** listener (default port 7890, configurable) on `0.0.0.0`, so other devices on the local network can use this Mac as their proxy server while the VPN is connected.

- **meow-ffi**: new `bridge_start_with_lan(socks, dns, ctrl, secret, lanProxyPort)` export appends a `mixed-lan` listener on `0.0.0.0`. The LAN port is range-validated, checked against a collision with the internal loopback SOCKS port, and preflight-bind-checked so an occupied port fails tunnel start with a clear error instead of a buried log warning. Internal ephemeral loopback listeners and the loopback-forced REST controller are unchanged.
- **ObjC wrapper**: `BridgeStartWithLAN(...)`; `BridgeStartWithPorts` unchanged (delegates with LAN disabled).
- **Swift**: `LANSharingSettings` (enabled / proxyPort, tolerant decoding) in shared defaults, forwarded via `providerConfiguration["lanProxyPort"]` (absent = disabled); the provider passes it to the engine at start.
- **UI**: "LAN" section in Settings — Allow LAN toggle, port field, and ready-to-copy `ip:port` LAN proxy addresses for each active interface, plus a warning that anyone on the local network can use the proxy. zh-Hans localization included.

DNS sharing is deliberately **not** included: with fake-ip mode (#85), a shared LAN DNS would hand out unroutable fake IPs to clients that don't route through this Mac.

## Test plan

- `cargo fmt` / `clippy -D warnings` / `cargo test` in `Rust/meow-ffi` — 20 tests pass, including `lan_listeners_start_and_serve` (TCP accept on the LAN port) and `lan_start_fails_on_occupied_port`.
- `xcodebuild test` — 196 tests / 45 suites pass, including new `LANSharingSettingsTests`.
- `swiftlint --strict` — no new violations.
- Manual LAN verification needs a second device: enable Allow LAN → connect VPN → set the other device's proxy to the displayed `<mac-ip>:7890`.