### PR TITLE
Fix VPN reconnect when switching to the Settings tab

### DIFF
--- a/BaoLianDeng/Views/LANSharingSection.swift
+++ b/BaoLianDeng/Views/LANSharingSection.swift
@@ -70,15 +70,17 @@ struct LANSharingSection: View {
     }
 
     private func save() {
+        // onChange also fires when load() populates the state on appear —
+        // skip when nothing actually changed so switching to the Settings
+        // tab doesn't bounce the VPN.
+        guard settings != LANSharingSettings.load() else { return }
         settings.save()
         vpnManager.restartIfConnected()
     }
 
-    /// Persist an edited port field, but only restart the tunnel when the
-    /// stored value actually changed — onDisappear fires on every tab
-    /// switch and must not bounce the VPN gratuitously.
+    /// Persist an edited port field — commits on Enter and when focus
+    /// leaves the tab (onDisappear); save() ignores no-op commits.
     private func commitPort() {
-        guard settings != LANSharingSettings.load() else { return }
         save()
     }
 

--- a/BaoLianDeng/Views/PerAppProxySection.swift
+++ b/BaoLianDeng/Views/PerAppProxySection.swift
@@ -34,6 +34,22 @@ struct PerAppProxySection: View {
     }
 
     private func load() {
+        settings = Self.stored()
+    }
+
+    private func save() {
+        // onChange also fires when load() populates the state on appear —
+        // skip when nothing actually changed so switching to the Settings
+        // tab doesn't bounce the VPN.
+        guard settings != Self.stored() else { return }
+        guard let data = try? JSONEncoder().encode(settings) else { return }
+        AppConstants.sharedDefaults.set(
+            data, forKey: AppConstants.perAppProxySettingsKey
+        )
+        vpnManager.restartIfConnected()
+    }
+
+    private static func stored() -> PerAppProxySettings {
         let defaults = AppConstants.sharedDefaults
         guard let data = defaults.data(
             forKey: AppConstants.perAppProxySettingsKey
@@ -41,16 +57,8 @@ struct PerAppProxySection: View {
             let decoded = try? JSONDecoder().decode(
                 PerAppProxySettings.self, from: data
             )
-        else { return }
-        settings = decoded
-    }
-
-    private func save() {
-        guard let data = try? JSONEncoder().encode(settings) else { return }
-        AppConstants.sharedDefaults.set(
-            data, forKey: AppConstants.perAppProxySettingsKey
-        )
-        vpnManager.restartIfConnected()
+        else { return PerAppProxySettings() }
+        return decoded
     }
 }
 

--- a/Shared/PerAppProxySettings.swift
+++ b/Shared/PerAppProxySettings.swift
@@ -16,7 +16,7 @@ struct PerAppEntry: Codable, Identifiable, Equatable {
     let bundlePath: String
 }
 
-struct PerAppProxySettings: Codable {
+struct PerAppProxySettings: Codable, Equatable {
     var enabled: Bool = false
     var mode: PerAppProxyMode = .blocklist
     var apps: [PerAppEntry] = []


### PR DESCRIPTION
## Problem
Switching to the Settings tab bounced the VPN (disconnect + reconnect) whenever Per-App Proxy or Allow LAN was enabled.

## Cause
`PerAppProxySection` and `LANSharingSection` start with default `@State` settings and load the persisted values in `onAppear`. That programmatic state change fires the `.onChange` handlers, which called `save()` → `vpnManager.restartIfConnected()` — so merely showing the tab restarted the tunnel when the stored value differed from the default (i.e. either feature enabled).

## Fix
Make `save()` in both sections a no-op when the settings equal what is already persisted — the same guard `commitPort()` already used for the LAN port field. User-initiated changes still restart the tunnel as before.

- `PerAppProxySettings` gains `Equatable` for the comparison.
- `LANSharingSection.commitPort()` now just delegates to the guarded `save()`.

## Testing
- `xcodebuild test` — 196 tests in 45 suites pass.
- `swiftlint lint --strict` — only the pre-existing TODO violation in `ProxyGroupsViewModel.swift` (untouched).