### PR TITLE
Clean up test cases

### DIFF
--- a/BaoLianDengTests/BypassGroupDetectionTests.swift
+++ b/BaoLianDengTests/BypassGroupDetectionTests.swift
@@ -2,7 +2,6 @@
 //
 // Licensed under the MIT License. See the LICENSE file for details.
 
-import Foundation
 import Testing
 @testable import BaoLianDeng
 

--- a/BaoLianDengTests/MihomoAPITests.swift
+++ b/BaoLianDengTests/MihomoAPITests.swift
@@ -483,18 +483,6 @@ struct DelayColorTests {
         #expect(delayColor(1000) == "red")
         #expect(delayColor(9999) == "red")
     }
-
-    @Test("Boundary: 199 is green, 200 is orange")
-    func greenOrangeBoundary() {
-        #expect(delayColor(199) == "green")
-        #expect(delayColor(200) == "orange")
-    }
-
-    @Test("Boundary: 499 is orange, 500 is red")
-    func orangeRedBoundary() {
-        #expect(delayColor(499) == "orange")
-        #expect(delayColor(500) == "red")
-    }
 }
 
 // MARK: - ProxyNode Delay Display Tests
@@ -653,8 +641,7 @@ struct ConnectionFilteringTests {
 struct RuleProxyColorTests {
 
     // Per spec: DIRECT=green, REJECT=red, proxy=blue
-    // Note: current RulesView.swift has a bug — uses blue for all targets.
-    // These tests document the expected behavior.
+    // (mirrors proxyColor in ConfigListViews.swift)
 
     private func expectedProxyColor(_ proxy: String) -> String {
         switch proxy {

--- a/BaoLianDengTests/MihomoCoreIntegrationTests.swift
+++ b/BaoLianDengTests/MihomoCoreIntegrationTests.swift
@@ -50,14 +50,6 @@ struct MihomoCoreIntegrationTests {
         #expect(err!.localizedDescription.contains("NONEXISTENT"))
     }
 
-    @Test("Rejects empty config")
-    func rejectsEmptyConfig() {
-        var err: NSError?
-        BridgeValidateConfig("", &err)
-        // Empty config should either parse as empty (valid) or produce an error
-        // Either outcome is acceptable — this documents the behavior
-    }
-
     @Test("Validates config with GEOIP rule when geodata available")
     func validatesGeoIPRule() throws {
         // Ensure geodata files exist in a temp directory

--- a/BaoLianDengTests/ProxyGroupsViewModelTests.swift
+++ b/BaoLianDengTests/ProxyGroupsViewModelTests.swift
@@ -2,7 +2,6 @@
 //
 // Licensed under the MIT License. See the LICENSE file for details.
 
-import Foundation
 import Testing
 @testable import BaoLianDeng
 

--- a/BaoLianDengTests/Utilities/ProxyEngineHelper.swift
+++ b/BaoLianDengTests/Utilities/ProxyEngineHelper.swift
@@ -12,9 +12,7 @@ enum ProxyEngineHelper {
 
     struct EngineContext {
         let tempDir: String
-        let configPath: String
         let socksPort: UInt16
-        let dnsPort: UInt16
         let controllerAddr: String
     }
 
@@ -63,9 +61,7 @@ enum ProxyEngineHelper {
 
         return EngineContext(
             tempDir: tempDir,
-            configPath: configPath,
             socksPort: socksPort,
-            dnsPort: dnsPort,
             controllerAddr: controllerAddr
         )
     }

--- a/BaoLianDengTests/Utilities/TestConfigs.swift
+++ b/BaoLianDengTests/Utilities/TestConfigs.swift
@@ -29,29 +29,6 @@ enum TestConfigs {
           - MATCH,DIRECT
         """
 
-    /// Config with an unreachable proxy node for testing error paths.
-    static let withUnreachableProxy = """
-        mixed-port: 7890
-        mode: rule
-        log-level: silent
-        external-controller: 127.0.0.1:9090
-        proxies:
-          - name: unreachable
-            type: ss
-            server: 192.0.2.1
-            port: 8388
-            cipher: aes-256-gcm
-            password: test
-        proxy-groups:
-          - name: PROXY
-            type: select
-            proxies:
-              - unreachable
-              - DIRECT
-        rules:
-          - MATCH,PROXY
-        """
-
     /// Invalid YAML that should fail parsing.
     static let invalid = """
         mixed-port: 7890


### PR DESCRIPTION
Removes redundant and dead test code found in a full-suite audit (cross-checked against current production code):

- **Duplicate coverage**: the two `Delay Color` boundary tests repeated assertions already made by `fastColor`/`mediumColor`/`slowColor`.
- **No-op test**: `Rejects empty config` had zero assertions, so it always passed.
- **Dead fixtures/fields**: `TestConfigs.withUnreachableProxy` and `EngineContext.configPath`/`.dnsPort` were never referenced by any test.
- **Stale comment**: a note claimed `RulesView.swift` had a color bug — that file no longer exists and the current `proxyColor` in `ConfigListViews.swift` is correct.
- **Unused imports**: `Foundation` in two test files.

The audit also confirmed there are no leftover redir-host DNS expectations after the fake-ip switch (#85) — the DNS tests already assert the managed fake-ip block.

## Testing
`xcodebuild test` — 193 tests in 45 suites pass (196 before, minus the 3 removed cases; no coverage lost).