### PR TITLE
Fix global route mode routing all traffic direct

### DIFF
--- a/BaoLianDeng/Views/HomeView.swift
+++ b/BaoLianDeng/Views/HomeView.swift
@@ -213,6 +213,14 @@ struct HomeView: View {
                     // Live switch via REST API — no tunnel restart needed
                     Task {
                         try? await MihomoAPI.switchMode(newMode.rawValue)
+                        // The engine's auto-created GLOBAL selector defaults to
+                        // DIRECT (sorted member list); point it at the selected
+                        // node or global mode routes all traffic direct.
+                        if newMode == .global,
+                           let node = AppConstants.sharedDefaults.string(forKey: "selectedNode"),
+                           !node.isEmpty {
+                            try? await MihomoAPI.selectProxy(group: "GLOBAL", name: node)
+                        }
                     }
                     ConfigManager.shared.setMode(newMode.rawValue)
                 } else {

--- a/BaoLianDeng/Views/HomeView.swift
+++ b/BaoLianDeng/Views/HomeView.swift
@@ -214,12 +214,10 @@ struct HomeView: View {
                     Task {
                         try? await MihomoAPI.switchMode(newMode.rawValue)
                         // The engine's auto-created GLOBAL selector defaults to
-                        // DIRECT (sorted member list); point it at the selected
-                        // node or global mode routes all traffic direct.
-                        if newMode == .global,
-                           let node = AppConstants.sharedDefaults.string(forKey: "selectedNode"),
-                           !node.isEmpty {
-                            try? await MihomoAPI.selectProxy(group: "GLOBAL", name: node)
+                        // DIRECT (sorted member list); point it at a real
+                        // target or global mode routes all traffic direct.
+                        if newMode == .global {
+                            vpnManager.syncGlobalSelector()
                         }
                     }
                     ConfigManager.shared.setMode(newMode.rawValue)

--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -313,7 +313,9 @@ struct ForceManagedDNSTests {
     }
 }
 
-@Suite("Proxy group serialization")
+// Serialized: several tests here save/restore the shared "selectedNode"
+// default, which races under parallel execution.
+@Suite("Proxy group serialization", .serialized)
 struct ProxyGroupSerializationTests {
 
     @Test("Quotes editable proxy group string values")
@@ -377,6 +379,89 @@ struct ProxyGroupSerializationTests {
         #expect(globalNameCount == 1)
         #expect(updated.contains("      - \"node #1\\nnext\""))
         #expect(!updated.contains("      - old"))
+        // Fallback members: the first non-bypass select group, then DIRECT,
+        // in case the saved node name is stale.
+        #expect(updated.contains("      - \"PROXY\""))
+        #expect(updated.contains("      - \"DIRECT\""))
+    }
+
+    @Test("Global proxy group falls back to select group when no node saved")
+    func globalProxyGroupFallsBackToSelectGroup() {
+        let defaults = AppConstants.sharedDefaults
+        let previous = defaults.string(forKey: "selectedNode")
+        defer {
+            if let previous {
+                defaults.set(previous, forKey: "selectedNode")
+            } else {
+                defaults.removeObject(forKey: "selectedNode")
+            }
+        }
+        defaults.removeObject(forKey: "selectedNode")
+
+        let yaml = """
+        proxy-groups:
+          - name: Bypass
+            type: select
+            proxies:
+              - DIRECT
+              - node1
+          - name: Choice
+            type: select
+            proxies:
+              - node1
+              - DIRECT
+        rules:
+          - MATCH,Choice
+        """
+
+        let updated = ConfigManager.shared.updateGlobalProxyGroup(yaml, enabled: true)
+        let parsed = ConfigManager.shared.parseProxyGroups(from: updated)
+        let global = parsed.first { $0.name == "GLOBAL" }
+
+        // Bypass (DIRECT-first) is skipped; GLOBAL heads with the first
+        // non-bypass select group, then DIRECT.
+        #expect(global?.proxies == ["Choice", "DIRECT"])
+    }
+
+    @Test("Global proxy group falls back to MATCH target when every group is DIRECT-first")
+    func globalProxyGroupFallsBackToMatchTarget() {
+        let defaults = AppConstants.sharedDefaults
+        let previous = defaults.string(forKey: "selectedNode")
+        defer {
+            if let previous {
+                defaults.set(previous, forKey: "selectedNode")
+            } else {
+                defaults.removeObject(forKey: "selectedNode")
+            }
+        }
+        // Stale node: saved name no longer exists in the subscription.
+        defaults.set("Old Node 05", forKey: "selectedNode")
+
+        // Common subscription shape: every select group lists DIRECT first,
+        // so the bypass heuristic matches all of them.
+        let yaml = """
+        proxy-groups:
+          - name: Choice
+            type: select
+            proxies:
+              - DIRECT
+              - node1
+          - name: Fish
+            type: select
+            proxies:
+              - DIRECT
+              - Choice
+        rules:
+          - MATCH,Fish
+        """
+
+        let updated = ConfigManager.shared.updateGlobalProxyGroup(yaml, enabled: true)
+        let parsed = ConfigManager.shared.parseProxyGroups(from: updated)
+        let global = parsed.first { $0.name == "GLOBAL" }
+
+        // Stale node stays listed (the engine's lenient parser drops it),
+        // followed by the MATCH rule's target group, then DIRECT.
+        #expect(global?.proxies == ["Old Node 05", "Fish", "DIRECT"])
     }
 
 }

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -307,15 +307,42 @@ final class ConfigManager {
             $0.trimmingCharacters(in: .whitespaces).hasPrefix("proxy-groups:")
         }) else { return lines.joined(separator: "\n") }
 
+        // The saved node name can be stale after a subscription refresh renames
+        // nodes (the engine's lenient parser silently drops missing members),
+        // so list fallbacks after it: the MATCH rule's target group — global
+        // mode then routes everything the way rule mode routes unmatched
+        // traffic, including the user's persisted group selections — then the
+        // first non-bypass select group, then DIRECT as a last resort.
+        var members: [String] = []
+        if let node = selectedNode, !node.isEmpty {
+            members.append(node)
+        }
+        let stripped = lines.joined(separator: "\n")
+        let groups = parseProxyGroups(from: stripped)
+        let groupMembers = Dictionary(groups.map { ($0.name, $0.proxies) }) { first, _ in first }
+        if let matchTarget = parseRules(from: stripped).last(where: { $0.type == "MATCH" })?.target,
+           groups.contains(where: { $0.name == matchTarget }),
+           !members.contains(matchTarget) {
+            members.append(matchTarget)
+        }
+        if let fallback = groups.first(where: { group in
+            guard group.type == "select", group.name != "GLOBAL",
+                  let first = group.proxies.first else { return false }
+            return !isBypassGroup(firstMember: first, groupMembers: groupMembers)
+        }), !members.contains(fallback.name) {
+            members.append(fallback.name)
+        }
+        if !members.contains("DIRECT") {
+            members.append("DIRECT")
+        }
+
         var globalGroup = [
             "  - name: \(Self.yamlQuotedString("GLOBAL"))",
             "    type: select",
             "    proxies:",
         ]
-        if let node = selectedNode, !node.isEmpty {
-            globalGroup.append("      - \(Self.yamlQuotedString(node))")
-        } else {
-            globalGroup.append("      - DIRECT")
+        for member in members {
+            globalGroup.append("      - \(Self.yamlQuotedString(member))")
         }
 
         lines.insert(contentsOf: globalGroup, at: pgIdx + 1)

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -204,16 +204,6 @@ final class ConfigManager {
         try? saveConfig(config)
     }
 
-    /// Apply the saved mode to config.yaml. Call after applySelectedSubscription/sanitizeConfig.
-    func applyMode() {
-        let mode = AppConstants.sharedDefaults
-            .string(forKey: "proxyMode") ?? "rule"
-        guard var config = try? loadConfig() else { return }
-        config = Self.replacingTopLevelScalar(in: config, key: "mode", value: mode)
-        config = updateGlobalProxyGroup(config, enabled: mode == "global")
-        try? saveConfig(config)
-    }
-
     /// Return all proxy group names with type "select" from config.yaml.
     func selectProxyGroupNames() -> [String] {
         guard let yaml = try? loadConfig() else { return [] }

--- a/Shared/VPNManager.swift
+++ b/Shared/VPNManager.swift
@@ -549,8 +549,18 @@ final class VPNManager: NSObject, ObservableObject {
                 guard let info = value as? [String: Any],
                       (info["type"] as? String) == "Selector",
                       let all = info["all"] as? [String],
-                      let first = all.first,
-                      !isBypassGroup(firstMember: first, groupMembers: groupMembers) else { continue }
+                      let first = all.first else { continue }
+                // GLOBAL is the engine's auto-created all-proxies selector; its
+                // sorted member list puts DIRECT first, which the bypass
+                // heuristic below would misread. Always push the node so
+                // global mode routes through it.
+                if name == "GLOBAL" {
+                    if all.contains(nodeName) {
+                        targets.append((name, nodeName))
+                    }
+                    continue
+                }
+                guard !isBypassGroup(firstMember: first, groupMembers: groupMembers) else { continue }
                 if all.contains(nodeName) {
                     targets.append((name, nodeName))
                 } else if let bypass = firstBypassMember(in: all, groupMembers: groupMembers) {
@@ -611,11 +621,15 @@ final class VPNManager: NSObject, ObservableObject {
                 in: yaml, key: "log-level", value: logLevel
             )
         }
-        if let mode = defaults.string(forKey: "proxyMode") {
-            yaml = ConfigManager.replacingTopLevelScalar(
-                in: yaml, key: "mode", value: mode
-            )
-        }
+        let mode = defaults.string(forKey: "proxyMode") ?? "rule"
+        yaml = ConfigManager.replacingTopLevelScalar(
+            in: yaml, key: "mode", value: mode
+        )
+        // Global mode routes everything through the GLOBAL selector. Define it
+        // with the selected node first — otherwise the engine auto-creates one
+        // whose sorted member list puts DIRECT first, so global mode would
+        // silently send all traffic direct.
+        yaml = ConfigManager.shared.updateGlobalProxyGroup(yaml, enabled: mode == "global")
 
         // Compress with zlib and store in providerConfiguration
         var providerConfig: [String: Any] = [:]

--- a/Shared/VPNManager.swift
+++ b/Shared/VPNManager.swift
@@ -585,6 +585,83 @@ final class VPNManager: NSObject, ObservableObject {
         }.resume()
     }
 
+    /// Point the engine's GLOBAL selector at a real target so global mode
+    /// routes through the proxy instead of GLOBAL's default (DIRECT, the
+    /// first entry of its sorted member list). Prefers the saved node, but
+    /// that name can be stale after a subscription refresh renames nodes —
+    /// then falls back to the largest non-bypass selector group (the
+    /// subscription's node-choice group), which tracks future node changes.
+    func syncGlobalSelector() {
+        guard let url = AppConstants.externalControllerURL(pathSegments: ["proxies"]) else { return }
+        URLSession.shared.dataTask(with: AppConstants.authorizedControllerRequest(url: url)) { [weak self] data, _, _ in
+            guard let self = self, let data = data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let proxies = json["proxies"] as? [String: Any],
+                  let global = proxies["GLOBAL"] as? [String: Any],
+                  let globalMembers = global["all"] as? [String] else { return }
+
+            let groupTypes: Set<String> = ["Selector", "URLTest", "Fallback", "LoadBalance", "Relay"]
+            var groupMembers: [String: [String]] = [:]
+            for (name, value) in proxies {
+                guard let info = value as? [String: Any],
+                      let type = info["type"] as? String,
+                      groupTypes.contains(type),
+                      let all = info["all"] as? [String] else { continue }
+                groupMembers[name] = all
+            }
+
+            var target: String?
+            let saved = AppConstants.sharedDefaults.string(forKey: "selectedNode")
+            if let saved = saved, !saved.isEmpty, globalMembers.contains(saved) {
+                target = saved
+            } else {
+                // A selector group whose current selection chain ends at a
+                // real proxy node reflects what the user routes through today.
+                // Prefer the largest such group (the subscription's node-choice
+                // group); the bypass heuristic is useless here because many
+                // subscriptions list DIRECT first in every group.
+                func resolvesToProxy(_ name: String, depth: Int = 0) -> Bool {
+                    if depth > 8 || name == "DIRECT" || name.hasPrefix("REJECT") { return false }
+                    guard let info = proxies[name] as? [String: Any] else { return false }
+                    if let now = info["now"] as? String, !now.isEmpty {
+                        return resolvesToProxy(now, depth: depth + 1)
+                    }
+                    return groupMembers[name] == nil
+                }
+                target = proxies
+                    .compactMap { name, value -> (name: String, size: Int)? in
+                        guard name != "GLOBAL",
+                              let info = value as? [String: Any],
+                              (info["type"] as? String) == "Selector",
+                              let all = info["all"] as? [String],
+                              globalMembers.contains(name),
+                              resolvesToProxy(name) else { return nil }
+                        return (name, all.count)
+                    }
+                    .sorted { $0.size == $1.size ? $0.name < $1.name : $0.size > $1.size }
+                    .first?.name
+            }
+
+            guard let selection = target else {
+                self.dbg("syncGlobalSelector: no valid target for GLOBAL")
+                return
+            }
+            self.dbg("syncGlobalSelector: GLOBAL=\(selection)")
+            guard let putURL = AppConstants.externalControllerURL(pathSegments: ["proxies", "GLOBAL"]),
+                  let body = try? JSONSerialization.data(withJSONObject: ["name": selection]) else { return }
+            var request = AppConstants.authorizedControllerRequest(url: putURL, method: "PUT")
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = body
+            URLSession.shared.dataTask(with: request) { [weak self] _, response, putError in
+                if let putError = putError {
+                    self?.dbg("syncGlobalSelector: \(putError.localizedDescription)")
+                } else if let http = response as? HTTPURLResponse {
+                    self?.dbg("syncGlobalSelector: PUT \(http.statusCode)")
+                }
+            }.resume()
+        }.resume()
+    }
+
     /// Build the full YAML config (base + subscription + user settings),
     /// zlib-compress it, and pass via providerConfiguration to overcome the 512 KB IPC limit.
     private func passSettingsToProvider() {


### PR DESCRIPTION
## Problem
Switching route mode from **rule** to **global** appeared to have no effect.

Root cause (reproduced against the pinned meow-rs rev `a234015`): the app never defines a `GLOBAL` proxy group in the config it hands to the tunnel, so the engine auto-creates one over **all** proxy names **sorted alphabetically**. `DIRECT` sorts first, and a selector with no saved selection dials its first member — so global mode silently routed every connection `GLOBAL -> DIRECT`, bypassing the proxy entirely:

```
GLOBAL now: 'DIRECT' | all: ['DIRECT', 'PROXY', 'REJECT', 'REJECT-DROP', '美国 02', '香港 01']
conn: neverssl.com | chains: ['GLOBAL'] | rule: Global   # succeeded direct
```

Three compounding app-side gaps:
1. `ConfigManager.applyMode()` — the only code that wrote the `GLOBAL` group into the config — was dead code, never called.
2. The live-switch path only PATCHed `/configs {mode}`, never pointed `GLOBAL` at the selected node.
3. `selectNodeViaRestAPI` skipped `GLOBAL` via the bypass-group heuristic (its sorted member list starts with `DIRECT`).

## Fix
- `passSettingsToProvider` now stamps `mode:` unconditionally and injects the `GLOBAL` group (headed by the selected node) when mode is global; the orphaned `applyMode()` is removed.
- Live mode switch additionally PUTs the saved node into `GLOBAL`.
- `selectNodeViaRestAPI` exempts `GLOBAL` from the bypass heuristic and always pushes the selected node, keeping it in sync with future node changes.

## Testing
- `xcodebuild test` unit suite (185 tests, CI invocation incl. `-skip-testing:ProxyEngineIntegrationTests`): **passed**
- `ProxyEngineIntegrationTests`: **passed**
- swiftlint --strict: only pre-existing TODO violation in `ProxyGroupsViewModel.swift` (untouched)