### PR TITLE
Add local proxy mode (non-transparent-proxy support)

### DIFF
--- a/BaoLianDeng.xcodeproj/project.pbxproj
+++ b/BaoLianDeng.xcodeproj/project.pbxproj
@@ -32,11 +32,14 @@
 		A1B2C3D4E5F60718293A4B5C /* PerAppProxySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10095 /* PerAppProxySettings.swift */; };
 		A1B2C3D4E5F60718293A4B5D /* PerAppProxySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10095 /* PerAppProxySettings.swift */; };
 		A1B2C3D4E5F60718293A4B5E /* PerAppProxySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10096 /* PerAppProxySection.swift */; };
+		LP100001 /* LocalProxyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = LP100000 /* LocalProxyController.swift */; };
+		LP100002 /* LocalProxyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = LP100000 /* LocalProxyController.swift */; };
 		LS100001 /* LANSharingSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10097 /* LANSharingSettings.swift */; };
 		LS100002 /* LANSharingSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10097 /* LANSharingSettings.swift */; };
 		LS100003 /* LANSharingSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10097 /* LANSharingSettings.swift */; };
 		LS100004 /* LANSharingSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10098 /* LANSharingSection.swift */; };
 		LS100005 /* LANSharingSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10099 /* LANSharingSettingsTests.swift */; };
+		LP100004 /* EngineModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LP100003 /* EngineModeTests.swift */; };
 		A2B3C4D5E6F7A8B9C0D1E2F3 /* UDPNATRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10021 /* UDPNATRelay.swift */; };
 		A9840B29BC5EC55F29F0BA38 /* TrafficStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10060 /* TrafficStore.swift */; };
 		B10063 /* MihomoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10062 /* MihomoAPI.swift */; };
@@ -188,6 +191,8 @@
 		B10097 /* LANSharingSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LANSharingSettings.swift; sourceTree = "<group>"; };
 		B10098 /* LANSharingSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LANSharingSection.swift; sourceTree = "<group>"; };
 		B10099 /* LANSharingSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LANSharingSettingsTests.swift; sourceTree = "<group>"; };
+		LP100000 /* LocalProxyController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalProxyController.swift; sourceTree = "<group>"; };
+		LP100003 /* EngineModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineModeTests.swift; sourceTree = "<group>"; };
 		B10100 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		B10101 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		B10200 /* SubscriptionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionModels.swift; sourceTree = "<group>"; };
@@ -338,6 +343,7 @@
 				B10008 /* ConfigManager.swift */,
 				B10095 /* PerAppProxySettings.swift */,
 				B10097 /* LANSharingSettings.swift */,
+				LP100000 /* LocalProxyController.swift */,
 				B10009 /* VPNManager.swift */,
 			);
 			path = Shared;
@@ -417,6 +423,7 @@
 				T10050 /* Utilities */,
 				T10007 /* PerAppProxySettingsTests.swift */,
 				B10099 /* LANSharingSettingsTests.swift */,
+				LP100003 /* EngineModeTests.swift */,
 				T10021 /* BypassGroupDetectionTests.swift */,
 				T10030 /* ConfigParserTests.swift */,
 				T10032 /* MihomoCoreIntegrationTests.swift */,
@@ -618,6 +625,7 @@
 				C3DAB7AB1483CF34E41BAAFB /* AppLogger.swift in Sources */,
 				D28CFAAD4562ECF087671BE7 /* Constants.swift in Sources */,
 				8263DE84A3B841EF63A2FF89 /* ConfigManager.swift in Sources */,
+				LP100001 /* LocalProxyController.swift in Sources */,
 				8D9BF44D7D340ADB5C09AEF9 /* VPNManager.swift in Sources */,
 				A1B2C3D4E5F60718293A4B5C /* PerAppProxySettings.swift in Sources */,
 				LS100001 /* LANSharingSettings.swift in Sources */,
@@ -643,6 +651,7 @@
 				EBAC80D31A3CCD3F3C083FDA /* AppLogger.swift in Sources */,
 				9C1CFB15DEC224B8210EA2E9 /* Constants.swift in Sources */,
 				1C46310C4BA03116BAE1CF24 /* ConfigManager.swift in Sources */,
+				LP100002 /* LocalProxyController.swift in Sources */,
 				ADFBB07EC9AE7B14EE8CF08D /* VPNManager.swift in Sources */,
 				A1B2C3D4E5F60718293A4B5D /* PerAppProxySettings.swift in Sources */,
 				LS100002 /* LANSharingSettings.swift in Sources */,
@@ -670,6 +679,7 @@
 			files = (
 				T10008 /* PerAppProxySettingsTests.swift in Sources */,
 				LS100005 /* LANSharingSettingsTests.swift in Sources */,
+				LP100004 /* EngineModeTests.swift in Sources */,
 				T10022 /* BypassGroupDetectionTests.swift in Sources */,
 				T10031 /* ConfigParserTests.swift in Sources */,
 				T10033 /* MihomoCoreIntegrationTests.swift in Sources */,

--- a/BaoLianDeng/Localizable.xcstrings
+++ b/BaoLianDeng/Localizable.xcstrings
@@ -271,6 +271,26 @@
         }
       }
     },
+    "Could not allocate internal ports for the proxy engine.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法为代理引擎分配内部端口。"
+          }
+        }
+      }
+    },
+    "Could not resolve the configuration directory.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法定位配置目录。"
+          }
+        }
+      }
+    },
     "Current Session (Proxy Only)": {
       "localizations": {
         "zh-Hans": {
@@ -466,6 +486,16 @@
       },
       "extractionState": "manual"
     },
+    "Failed to start local proxy: %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启动本地代理失败：%@"
+          }
+        }
+      }
+    },
     "fallback": {
       "localizations": {
         "zh-Hans": {
@@ -617,6 +647,16 @@
         }
       }
     },
+    "Intercepts all traffic system-wide via the Network Extension.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过网络扩展在系统范围内拦截所有流量。"
+          }
+        }
+      }
+    },
     "Interval": {
       "localizations": {
         "zh-Hans": {
@@ -697,6 +737,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "本地配置"
+          }
+        }
+      }
+    },
+    "Local Proxy Only": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅本地代理"
+          }
+        }
+      }
+    },
+    "Local Proxy Port": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地代理端口"
+          }
+        }
+      }
+    },
+    "Local proxy port %@ is already in use.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地代理端口 %@ 已被占用。"
+          }
+        }
+      }
+    },
+    "Local proxy running at %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地代理运行于 %@"
           }
         }
       }
@@ -907,6 +987,26 @@
         }
       }
     },
+    "Proxy Address": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "代理地址"
+          }
+        }
+      }
+    },
+    "Proxy Method": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "代理方式"
+          }
+        }
+      }
+    },
     "Proxy Groups": {
       "localizations": {
         "zh-Hans": {
@@ -1058,6 +1158,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "规则 (%lld)"
+          }
+        }
+      }
+    },
+    "Runs the engine inside the app as an HTTP/SOCKS5 proxy on 127.0.0.1 — no system extension or VPN configuration needed. Apps must be pointed at the proxy manually. Switching method or port takes effect on the next start.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在应用内运行代理引擎，在 127.0.0.1 上提供 HTTP/SOCKS5 代理——无需系统扩展或 VPN 配置。应用需手动设置使用该代理。切换方式或端口将在下次启动时生效。"
           }
         }
       }
@@ -1422,6 +1532,16 @@
         }
       },
       "extractionState": "manual"
+    },
+    "VPN (System-wide)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VPN（全局接管）"
+          }
+        }
+      }
     },
     "While the VPN is connected, other devices on your network can use this Mac as their SOCKS5/HTTP proxy server on the proxy port. Anyone on the local network can use the proxy \u2014 enable only on networks you trust.": {
       "localizations": {

--- a/BaoLianDeng/Views/HomeView.swift
+++ b/BaoLianDeng/Views/HomeView.swift
@@ -166,7 +166,20 @@ struct HomeView: View {
 
     private var extensionStatusSection: some View {
         Section {
-            if !vpnManager.extensionEnabled {
+            if vpnManager.engineMode == .localProxy {
+                if vpnManager.isConnected {
+                    HStack {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text(String(
+                            format: String(localized: "Local proxy running at %@"),
+                            "127.0.0.1:\(String(LocalProxyController.shared.mixedPort))"
+                        ))
+                        .font(.subheadline)
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            } else if !vpnManager.extensionEnabled {
                 Button {
                     showExtensionHelp = true
                     vpnManager.checkExtensionStatus(forceRetry: true)

--- a/BaoLianDeng/Views/LANSharingSection.swift
+++ b/BaoLianDeng/Views/LANSharingSection.swift
@@ -48,10 +48,11 @@ struct LANSharingSection: View {
         } footer: {
             Text(
                 """
-                While the VPN is connected, other devices on your network can use \
-                this Mac as their SOCKS5/HTTP proxy server on the proxy port. \
-                Anyone on the local network can use the proxy — enable only on \
-                networks you trust.
+                Writes Clash-compatible allow-lan into the engine config so \
+                other devices on your network can use this Mac as their \
+                SOCKS5/HTTP proxy on the proxy port. Anyone on the local \
+                network can use the proxy — enable only on networks you trust. \
+                Takes effect on the next start or reconnect.
                 """
             )
             .font(.footnote)

--- a/BaoLianDeng/Views/SettingsView.swift
+++ b/BaoLianDeng/Views/SettingsView.swift
@@ -13,6 +13,8 @@ struct SettingsView: View {
     private var appLanguage = ""
     @AppStorage(AppConstants.autoStartVPNAtLoginKey, store: AppConstants.sharedDefaults)
     private var autoStartVPNAtLogin = false
+    @AppStorage(AppConstants.localProxyPortKey, store: AppConstants.sharedDefaults)
+    private var localProxyPort = AppConstants.defaultLocalProxyPort
     @State private var startupErrorMessage: String?
 
     var body: some View {
@@ -51,7 +53,13 @@ struct SettingsView: View {
                 }
             }
 
-            PerAppProxySection()
+            proxyMethodSection
+
+            // Per-app filtering only exists on the flow-interception path;
+            // a local proxy sees whatever apps are pointed at it.
+            if vpnManager.engineMode == .vpn {
+                PerAppProxySection()
+            }
 
             LANSharingSection()
 
@@ -82,6 +90,50 @@ struct SettingsView: View {
         }
         .formStyle(.grouped)
         .navigationTitle("Settings")
+    }
+
+    // MARK: - Proxy Method
+
+    private var proxyMethodSection: some View {
+        Section {
+            Picker("Proxy Method", selection: Binding(
+                get: { vpnManager.engineMode },
+                set: { vpnManager.setEngineMode($0) }
+            )) {
+                ForEach(EngineMode.allCases) { mode in
+                    Text(mode.displayName).tag(mode)
+                }
+            }
+
+            if vpnManager.engineMode == .localProxy {
+                TextField(
+                    "Local Proxy Port",
+                    value: $localProxyPort,
+                    format: .number.grouping(.never)
+                )
+                if vpnManager.isConnected {
+                    LabeledContent(
+                        "Proxy Address",
+                        value: "127.0.0.1:\(String(LocalProxyController.shared.mixedPort))"
+                    )
+                }
+            }
+        } header: {
+            Text("Proxy Method")
+        } footer: {
+            if vpnManager.engineMode == .localProxy {
+                Text("Runs the engine inside the app as an HTTP/SOCKS5 proxy on 127.0.0.1 — no system extension or VPN configuration needed. Apps must be pointed at the proxy manually. Switching method or port takes effect on the next start.")
+            } else {
+                Text("Intercepts all traffic system-wide via the Network Extension.")
+            }
+        }
+        .onChange(of: localProxyPort) { _, newValue in
+            // Clamp obviously invalid entries; the running engine keeps its
+            // port until the next start.
+            if !(1...65535).contains(newValue) {
+                localProxyPort = AppConstants.defaultLocalProxyPort
+            }
+        }
     }
 
     private func updateLoginItem(enabled: Bool, previousValue: Bool) {

--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -311,6 +311,31 @@ struct ForceManagedDNSTests {
         #expect(!config.contains("stray comment"))
         #expect(config.contains("enhanced-mode: fake-ip"))
     }
+
+    @Test("Local proxy mode replaces fake-ip with redir-host")
+    func localProxyUsesRedirHost() {
+        var config = """
+        mixed-port: 7890
+        dns:
+          enable: true
+          enhanced-mode: fake-ip
+          fake-ip-range: 198.18.0.0/15
+        proxies: []
+        """
+        ConfigManager.forceManagedDNS(&config, engineMode: .localProxy)
+        #expect(config.contains("enhanced-mode: redir-host"))
+        #expect(!config.contains("fake-ip"))
+    }
+
+    @Test("Idempotent in local proxy mode")
+    func idempotentLocalProxy() {
+        var config = "mixed-port: 7890\n\(ConfigManager.managedLocalProxyDNSSection)\nproxies: []\n"
+        ConfigManager.forceManagedDNS(&config, engineMode: .localProxy)
+        let once = config
+        ConfigManager.forceManagedDNS(&config, engineMode: .localProxy)
+        #expect(config == once)
+        #expect(config.components(separatedBy: "dns:").count - 1 == 1)
+    }
 }
 
 // Serialized: several tests here save/restore the shared "selectedNode"
@@ -648,6 +673,29 @@ struct SanitizeConfigStringTests {
         let sanitized = config
         ConfigManager.sanitizeConfigString(&config)
         #expect(config == sanitized)
+    }
+
+    @Test("Local proxy mode disables fake-ip DNS and TUN")
+    func localProxyDisablesFakeIPAndTUN() {
+        var config = "tun:\n  enable: true\n  stack: system\n"
+            + ConfigManager.managedDNSSection + "\nproxies: []\n"
+        ConfigManager.sanitizeConfigString(&config, engineMode: .localProxy)
+        #expect(config.contains("enhanced-mode: redir-host"))
+        #expect(!config.contains("fake-ip"))
+        #expect(config.contains("tun:\n  enable: false"))
+        #expect(!config.contains("enable: true\n  stack"))
+    }
+
+    @Test("Injects an explicit disabled tun block when absent")
+    func injectsDisabledTunBlock() {
+        var config = "mode: rule\nproxies: []\nrules:\n  - MATCH,DIRECT"
+        ConfigManager.sanitizeConfigString(&config, engineMode: .localProxy)
+        #expect(config.contains("tun:\n  enable: false"))
+        // Idempotent: a second pass doesn't add another block.
+        let once = config
+        ConfigManager.sanitizeConfigString(&config, engineMode: .localProxy)
+        #expect(config == once)
+        #expect(config.components(separatedBy: "tun:").count - 1 == 1)
     }
 }
 

--- a/BaoLianDengTests/EngineModeTests.swift
+++ b/BaoLianDengTests/EngineModeTests.swift
@@ -90,4 +90,53 @@ final class EngineModeTests: XCTestCase {
         close(sock)
         XCTAssertTrue(EphemeralPort.isTCPPortFree(port))
     }
+
+    func testEphemeralPortFreeCheckIgnoresTimeWait() {
+        // Regression: a proxy server actively closes client sockets on stop,
+        // leaving server-side TIME_WAIT entries on its port. The check must
+        // tolerate that (the engine's tokio listener binds with SO_REUSEADDR
+        // and would succeed) instead of reporting the port as busy for ~30s.
+        let listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+        XCTAssertGreaterThanOrEqual(listener, 0)
+        var reuse: Int32 = 1
+        setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+        let bindOK = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { saptr in
+                Darwin.bind(listener, saptr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        XCTAssertEqual(bindOK, 0)
+        XCTAssertEqual(listen(listener, 1), 0)
+        var bound = sockaddr_in()
+        var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+        _ = withUnsafeMutablePointer(to: &bound) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { saptr in
+                getsockname(listener, saptr, &len)
+            }
+        }
+        let port = UInt16(bigEndian: bound.sin_port)
+
+        // Client connects; server accepts then closes FIRST so the server
+        // side (on `port`) is the one that lands in TIME_WAIT.
+        let client = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+        XCTAssertGreaterThanOrEqual(client, 0)
+        let connectOK = withUnsafePointer(to: &bound) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { saptr in
+                Darwin.connect(client, saptr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        XCTAssertEqual(connectOK, 0)
+        let conn = accept(listener, nil, nil)
+        XCTAssertGreaterThanOrEqual(conn, 0)
+        close(conn)
+        close(client)
+        close(listener)
+
+        XCTAssertTrue(EphemeralPort.isTCPPortFree(port))
+    }
 }

--- a/BaoLianDengTests/EngineModeTests.swift
+++ b/BaoLianDengTests/EngineModeTests.swift
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Max Lv <max.c.lv@gmail.com>
+//
+// Licensed under the MIT License. See the LICENSE file for details.
+
+import XCTest
+@testable import BaoLianDeng
+
+final class EngineModeTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private let suiteName = "EngineModeTests"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    func testLoadDefaultsToVPN() {
+        XCTAssertEqual(EngineMode.load(from: defaults), .vpn)
+    }
+
+    func testLoadRoundTrip() {
+        defaults.set(EngineMode.localProxy.rawValue, forKey: AppConstants.engineModeKey)
+        XCTAssertEqual(EngineMode.load(from: defaults), .localProxy)
+
+        defaults.set(EngineMode.vpn.rawValue, forKey: AppConstants.engineModeKey)
+        XCTAssertEqual(EngineMode.load(from: defaults), .vpn)
+    }
+
+    func testLoadIgnoresGarbageValue() {
+        defaults.set("bogus", forKey: AppConstants.engineModeKey)
+        XCTAssertEqual(EngineMode.load(from: defaults), .vpn)
+    }
+
+    func testLocalProxyPortClampsInvalidValues() {
+        let defaults = AppConstants.sharedDefaults
+        let saved = defaults.object(forKey: AppConstants.localProxyPortKey)
+        defer {
+            if let saved {
+                defaults.set(saved, forKey: AppConstants.localProxyPortKey)
+            } else {
+                defaults.removeObject(forKey: AppConstants.localProxyPortKey)
+            }
+        }
+
+        defaults.removeObject(forKey: AppConstants.localProxyPortKey)
+        XCTAssertEqual(AppConstants.localProxyPort, UInt16(AppConstants.defaultLocalProxyPort))
+
+        defaults.set(0, forKey: AppConstants.localProxyPortKey)
+        XCTAssertEqual(AppConstants.localProxyPort, UInt16(AppConstants.defaultLocalProxyPort))
+
+        defaults.set(70000, forKey: AppConstants.localProxyPortKey)
+        XCTAssertEqual(AppConstants.localProxyPort, UInt16(AppConstants.defaultLocalProxyPort))
+
+        defaults.set(1080, forKey: AppConstants.localProxyPortKey)
+        XCTAssertEqual(AppConstants.localProxyPort, 1080)
+    }
+
+    func testEphemeralPortFreeCheck() {
+        // A port we just bound must report as busy; after closing it frees up.
+        let sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+        XCTAssertGreaterThanOrEqual(sock, 0)
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+        let bindOK = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { saptr in
+                Darwin.bind(sock, saptr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        XCTAssertEqual(bindOK, 0)
+        var bound = sockaddr_in()
+        var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+        _ = withUnsafeMutablePointer(to: &bound) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { saptr in
+                getsockname(sock, saptr, &len)
+            }
+        }
+        let port = UInt16(bigEndian: bound.sin_port)
+        XCTAssertFalse(EphemeralPort.isTCPPortFree(port))
+        close(sock)
+        XCTAssertTrue(EphemeralPort.isTCPPortFree(port))
+    }
+}

--- a/BaoLianDengTests/ProxyEngineIntegrationTests.swift
+++ b/BaoLianDengTests/ProxyEngineIntegrationTests.swift
@@ -101,6 +101,23 @@ struct ProxyEngineIntegrationTests {
         #expect(result.output == "204", "Should receive HTTP 204 from gstatic")
     }
 
+    @Test("HTTP request through HTTP proxy (mixed listener)")
+    func httpRequestThroughHTTPProxy() throws {
+        let ctx = try ProxyEngineHelper.start(config: TestConfigs.minimal)
+        defer { ProxyEngineHelper.stop(context: ctx) }
+
+        // The loopback listener is mixed SOCKS5+HTTP; local proxy mode
+        // points apps at its HTTP side, so exercise that here.
+        let result = ProxyEngineHelper.curlThroughHTTPProxy(
+            url: "http://www.gstatic.com/generate_204",
+            proxyPort: ctx.socksPort,
+            timeout: 10
+        )
+
+        #expect(result.exitCode == 0, "curl should exit successfully")
+        #expect(result.output == "204", "Should receive HTTP 204 from gstatic")
+    }
+
     @Test("Connection tracking via external controller")
     func connectionTracking() async throws {
         let ctx = try ProxyEngineHelper.start(config: TestConfigs.minimal)

--- a/BaoLianDengTests/Utilities/ProxyEngineHelper.swift
+++ b/BaoLianDengTests/Utilities/ProxyEngineHelper.swift
@@ -79,10 +79,27 @@ enum ProxyEngineHelper {
         socksPort: UInt16,
         timeout: Int = 10
     ) -> (output: String, exitCode: Int32) {
+        curl(url: url, proxyArgs: ["--socks5", "127.0.0.1:\(socksPort)"], timeout: timeout)
+    }
+
+    /// Run curl through the HTTP side of the mixed listener — the path
+    /// local-proxy-mode clients configured with an HTTP proxy take.
+    static func curlThroughHTTPProxy(
+        url: String,
+        proxyPort: UInt16,
+        timeout: Int = 10
+    ) -> (output: String, exitCode: Int32) {
+        curl(url: url, proxyArgs: ["--proxy", "http://127.0.0.1:\(proxyPort)"], timeout: timeout)
+    }
+
+    private static func curl(
+        url: String,
+        proxyArgs: [String],
+        timeout: Int
+    ) -> (output: String, exitCode: Int32) {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/curl")
-        process.arguments = [
-            "--socks5", "127.0.0.1:\(socksPort)",
+        process.arguments = proxyArgs + [
             "--silent",
             "--max-time", "\(timeout)",
             "--write-out", "%{http_code}",

--- a/Rust/meow-ffi/objc/MihomoCore.h
+++ b/Rust/meow-ffi/objc/MihomoCore.h
@@ -6,11 +6,10 @@ FOUNDATION_EXPORT void BridgeSetLogFile(NSString * _Nullable path);
 /// ports. The caller (main app) picks the ports up-front so its REST
 /// clients know the controller endpoint without an IPC round-trip.
 /// `controllerAddr` is `host:port`.
+///
+/// LAN exposure is Clash-compatible and comes from the YAML config
+/// (`allow-lan` / `bind-address` / `mixed-port`), not from this call.
 FOUNDATION_EXPORT BOOL BridgeStartWithPorts(int32_t socksPort, int32_t dnsPort, NSString * _Nonnull controllerAddr, NSString * _Nullable secret, NSError * _Nullable * _Nullable error);
-/// Like BridgeStartWithPorts, additionally exposing a mixed (SOCKS5+HTTP)
-/// listener on 0.0.0.0:lanProxyPort so LAN clients can use this machine as
-/// their proxy server. Pass 0 to disable the LAN listener.
-FOUNDATION_EXPORT BOOL BridgeStartWithLAN(int32_t socksPort, int32_t dnsPort, NSString * _Nonnull controllerAddr, NSString * _Nullable secret, int32_t lanProxyPort, NSError * _Nullable * _Nullable error);
 FOUNDATION_EXPORT void BridgeStopProxy(void);
 FOUNDATION_EXPORT BOOL BridgeIsRunning(void);
 
@@ -33,4 +32,3 @@ FOUNDATION_EXPORT NSString * _Nonnull BridgeTestDirectTCP(NSString * _Nullable h
 FOUNDATION_EXPORT NSString * _Nonnull BridgeTestProxyHTTP(NSString * _Nullable targetURL);
 FOUNDATION_EXPORT NSString * _Nonnull BridgeTestDNSResolver(NSString * _Nullable dnsAddr);
 FOUNDATION_EXPORT NSString * _Nonnull BridgeTestSelectedProxy(NSString * _Nullable apiAddr);
-

--- a/Rust/meow-ffi/objc/MihomoCore.m
+++ b/Rust/meow-ffi/objc/MihomoCore.m
@@ -1,11 +1,10 @@
 #import "MihomoCore.h"
 #include <stdbool.h>
 
-// C FFI declarations (from the Go c-archive)
+// C FFI declarations (from the Rust staticlib)
 extern void bridge_set_home_dir(const char *dir);
 extern int32_t bridge_set_log_file(const char *path);
 extern int32_t bridge_start_with_ports(int32_t socks_port, int32_t dns_port, const char *controller_addr, const char *secret);
-extern int32_t bridge_start_with_lan(int32_t socks_port, int32_t dns_port, const char *controller_addr, const char *secret, int32_t lan_proxy_port);
 extern int32_t bridge_get_socks_port(void);
 extern int32_t bridge_get_dns_port(void);
 extern char *bridge_get_external_controller_addr(void);
@@ -41,15 +40,6 @@ void BridgeSetLogFile(NSString * _Nullable path) {
 
 BOOL BridgeStartWithPorts(int32_t socksPort, int32_t dnsPort, NSString * _Nonnull controllerAddr, NSString * _Nullable secret, NSError * _Nullable * _Nullable error) {
     int32_t rc = bridge_start_with_ports(socksPort, dnsPort, [controllerAddr UTF8String], [secret UTF8String]);
-    if (rc != 0) {
-        if (error) *error = makeError();
-        return NO;
-    }
-    return YES;
-}
-
-BOOL BridgeStartWithLAN(int32_t socksPort, int32_t dnsPort, NSString * _Nonnull controllerAddr, NSString * _Nullable secret, int32_t lanProxyPort, NSError * _Nullable * _Nullable error) {
-    int32_t rc = bridge_start_with_lan(socksPort, dnsPort, [controllerAddr UTF8String], [secret UTF8String], lanProxyPort);
     if (rc != 0) {
         if (error) *error = makeError();
         return NO;
@@ -138,4 +128,3 @@ NSString * _Nonnull BridgeTestSelectedProxy(NSString * _Nullable apiAddr) {
     bridge_free_string(result);
     return str;
 }
-

--- a/Rust/meow-ffi/src/engine.rs
+++ b/Rust/meow-ffi/src/engine.rs
@@ -4,7 +4,9 @@
 //! `tokio::spawn` tasks and blocks on a signal), so this module hand-rolls the
 //! wiring and keeps every `JoinHandle` for abort-on-stop. The caller-supplied
 //! SOCKS/DNS/controller endpoints are forced onto the parsed config before any
-//! listener starts, ignoring whatever ports the YAML declared.
+//! listener starts, ignoring whatever ports the YAML declared — except
+//! Clash-compatible `allow-lan` / `bind-address` / `mixed-port`, which control
+//! whether a LAN-facing mixed listener is also exposed.
 
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
@@ -38,12 +40,19 @@ pub struct EngineState {
 /// DNS server, REST API, and mixed (SOCKS5+HTTP) listener on the shared
 /// runtime. Returns the assembled [`EngineState`] with all task handles.
 ///
-/// `lan_proxy_port` > 0 additionally exposes a mixed (SOCKS5+HTTP) listener
-/// on `0.0.0.0` at that port, so other LAN devices can use this machine as
-/// their proxy server ("allow LAN"). The loopback listeners above are
-/// unaffected. The LAN port is bind-checked up-front so an occupied port
-/// fails engine start with a clear error instead of a warning buried in the
-/// log.
+/// SOCKS / DNS / controller ports always bind loopback at the caller-supplied
+/// addresses (transparent-proxy and REST clients need stable, private
+/// endpoints). LAN exposure is Clash-compatible and driven entirely by the
+/// YAML:
+///
+/// - `allow-lan: true` → additionally expose a mixed listener on
+///   `bind-address`:`mixed-port` (defaults: `0.0.0.0` and `socks_port`).
+/// - When that LAN port equals `socks_port`, the two merge into a single
+///   `0.0.0.0` listener (local-proxy mode: one port serves loopback + LAN).
+/// - DNS and the external controller stay loopback regardless of `allow-lan`.
+///
+/// The LAN port is bind-checked up-front so an occupied port fails engine
+/// start with a clear error instead of a warning buried in the log.
 pub async fn assemble(
     config_path: String,
     home: String,
@@ -51,7 +60,6 @@ pub async fn assemble(
     dns_port: i32,
     controller_addr: String,
     secret: String,
-    lan_proxy_port: i32,
 ) -> anyhow::Result<EngineState> {
     let mut config = load_config_pinned(&config_path, &home).await?;
 
@@ -75,24 +83,43 @@ pub async fn assemble(
         )
     };
 
+    // Clash-compatible allow-lan: read before we overwrite listeners.
+    // meow defaults bind-address to 127.0.0.1 even when allow-lan is true;
+    // treat that (and Clash's `*`) as "all interfaces".
+    let allow_lan = config.general.allow_lan;
+    let lan_bind = lan_bind_address(allow_lan, &config.general.bind_address);
+    let yaml_mixed = config.listeners.mixed_port.filter(|&p| p > 0);
+    let lan_proxy_port: u16 = if allow_lan {
+        yaml_mixed.unwrap_or(socks_addr.port())
+    } else {
+        0
+    };
+    let lan_merged = allow_lan && lan_proxy_port == socks_addr.port();
+
     config.listeners.named = vec![NamedListener {
         name: "mixed".to_string(),
         listener_type: ListenerType::Mixed,
         port: socks_addr.port(),
-        listen: "127.0.0.1".to_string(),
+        listen: if lan_merged {
+            lan_bind.clone()
+        } else {
+            "127.0.0.1".to_string()
+        },
         tproxy_sni: false,
         max_connections: 0,
     }];
-    validate_lan_port(lan_proxy_port, socks_port)?;
-    if lan_proxy_port > 0 {
-        config.listeners.named.push(NamedListener {
-            name: "mixed-lan".to_string(),
-            listener_type: ListenerType::Mixed,
-            port: lan_proxy_port as u16,
-            listen: "0.0.0.0".to_string(),
-            tproxy_sni: false,
-            max_connections: 0,
-        });
+    if allow_lan {
+        validate_lan_bind(&lan_bind, lan_proxy_port)?;
+        if !lan_merged {
+            config.listeners.named.push(NamedListener {
+                name: "mixed-lan".to_string(),
+                listener_type: ListenerType::Mixed,
+                port: lan_proxy_port,
+                listen: lan_bind.clone(),
+                tproxy_sni: false,
+                max_connections: 0,
+            });
+        }
     }
     config.listeners.mixed_port = Some(socks_addr.port());
     config.listeners.socks_port = None;
@@ -175,7 +202,7 @@ pub async fn assemble(
         }));
     }
 
-    // Mixed (SOCKS5 + HTTP) listener(s) — exactly one, forced above.
+    // Mixed (SOCKS5 + HTTP) listener(s) — primary (+ optional LAN) forced above.
     for nl in &config.listeners.named {
         let ip: IpAddr = nl
             .listen
@@ -195,7 +222,7 @@ pub async fn assemble(
 
     info!(
         "meow engine started: socks={socks_port} dns={dns_port} controller={controller_addr} \
-         lan_proxy={lan_proxy_port}"
+         allow_lan={allow_lan} lan_proxy={lan_proxy_port}"
     );
 
     Ok(EngineState {
@@ -207,26 +234,35 @@ pub async fn assemble(
     })
 }
 
+/// Resolve the LAN bind address from Clash-style `allow-lan` / `bind-address`.
+///
+/// meow defaults `bind-address` to `127.0.0.1` even when `allow-lan` is true;
+/// Clash treats missing/`*` as all interfaces. Map those to `0.0.0.0`.
+fn lan_bind_address(allow_lan: bool, bind_address: &str) -> String {
+    if !allow_lan {
+        return "127.0.0.1".to_string();
+    }
+    match bind_address.trim() {
+        "" | "*" | "127.0.0.1" | "::1" => "0.0.0.0".to_string(),
+        other => other.to_string(),
+    }
+}
+
 /// Validate the LAN proxy port and bind-check it up-front.
 ///
 /// The listener itself binds later inside a spawned task where a failure
 /// only reaches the log, so an occupied port is caught here with a test
 /// bind (bound then immediately dropped — the small TOCTOU window mirrors
 /// the app-side `EphemeralPort` picker and is acceptable).
-fn validate_lan_port(lan_proxy_port: i32, socks_port: i32) -> anyhow::Result<()> {
-    if !(0..=65535).contains(&lan_proxy_port) {
-        anyhow::bail!("LAN proxy port {lan_proxy_port} is out of range");
+fn validate_lan_bind(bind: &str, lan_proxy_port: u16) -> anyhow::Result<()> {
+    if lan_proxy_port == 0 {
+        anyhow::bail!("allow-lan requires a non-zero mixed-port");
     }
-    // A 0.0.0.0 bind covers loopback too, so sharing a port with the internal
-    // 127.0.0.1 listener can never work — reject it explicitly rather than
-    // letting the two binds race.
-    if lan_proxy_port > 0 && lan_proxy_port == socks_port {
-        anyhow::bail!("LAN proxy port {lan_proxy_port} collides with the internal SOCKS port");
-    }
-    if lan_proxy_port > 0 {
-        std::net::TcpListener::bind(("0.0.0.0", lan_proxy_port as u16))
-            .map_err(|e| anyhow::anyhow!("LAN proxy port {lan_proxy_port} unavailable: {e}"))?;
-    }
+    let ip: IpAddr = bind
+        .parse()
+        .map_err(|e| anyhow::anyhow!("allow-lan bind-address '{bind}': {e}"))?;
+    std::net::TcpListener::bind(SocketAddr::new(ip, lan_proxy_port))
+        .map_err(|e| anyhow::anyhow!("LAN proxy port {lan_proxy_port} unavailable: {e}"))?;
     Ok(())
 }
 

--- a/Rust/meow-ffi/src/lib.rs
+++ b/Rust/meow-ffi/src/lib.rs
@@ -344,27 +344,15 @@ pub unsafe extern "C" fn bridge_validate_config(yaml: *const c_char) -> i32 {
 // Lifecycle.
 // ---------------------------------------------------------------------------
 
+/// Start the engine. SOCKS/DNS/controller bind loopback at the given ports.
+/// LAN exposure is driven by the YAML (`allow-lan` / `bind-address` /
+/// `mixed-port`) — see [`engine::assemble`].
 #[no_mangle]
 pub unsafe extern "C" fn bridge_start_with_ports(
     socks_port: i32,
     dns_port: i32,
     controller_addr: *const c_char,
     secret: *const c_char,
-) -> i32 {
-    bridge_start_with_lan(socks_port, dns_port, controller_addr, secret, 0)
-}
-
-/// Like [`bridge_start_with_ports`], additionally exposing a mixed
-/// (SOCKS5+HTTP) listener on `0.0.0.0:<lan_proxy_port>` so other LAN
-/// devices can use this machine as their proxy server ("allow LAN").
-/// 0 disables the LAN listener; the loopback listeners are unaffected.
-#[no_mangle]
-pub unsafe extern "C" fn bridge_start_with_lan(
-    socks_port: i32,
-    dns_port: i32,
-    controller_addr: *const c_char,
-    secret: *const c_char,
-    lan_proxy_port: i32,
 ) -> i32 {
     guard(-1, || {
         let mut engine = ENGINE.lock();
@@ -403,7 +391,6 @@ pub unsafe extern "C" fn bridge_start_with_lan(
             dns_port,
             addr,
             secret_s,
-            lan_proxy_port,
         )) {
             Ok(state) => {
                 *engine = Some(state);
@@ -821,42 +808,71 @@ rules:
         assert!(!err.contains(&a_str), "resolved stale home A: {err}");
     }
 
+    /// Write a config with Clash-style allow-lan + mixed-port for LAN tests.
+    fn write_lan_config(dir: &std::path::Path, mixed_port: i32) {
+        let yaml = format!(
+            "mixed-port: {mixed_port}\n\
+             allow-lan: true\n\
+             bind-address: 0.0.0.0\n\
+             mode: rule\n\
+             dns:\n\
+               enable: true\n\
+               listen: 127.0.0.1:1053\n\
+               enhanced-mode: fake-ip\n\
+               fake-ip-range: 28.0.0.0/8\n\
+               nameserver:\n\
+                 - 127.0.0.1:5353\n\
+             proxies: []\n\
+             proxy-groups: []\n\
+             rules:\n\
+               - MATCH,DIRECT\n"
+        );
+        std::fs::write(dir.join("config.yaml"), yaml).unwrap();
+    }
+
+    fn wait_accept(addr: &str) -> bool {
+        for _ in 0..20 {
+            if std::net::TcpStream::connect(addr).is_ok() {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        false
+    }
+
     #[test]
     fn lan_listeners_start_and_serve() {
         let _g = TEST_LOCK.lock();
 
         let dir = std::env::temp_dir().join(format!("meow-ffi-lan-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("config.yaml"), MINIMAL_CONFIG).unwrap();
-        let dir_c = CString::new(dir.to_str().unwrap()).unwrap();
-        unsafe { bridge_set_home_dir(dir_c.as_ptr()) };
-
         let socks = free_port();
         let dns = free_port();
         let ctrl = free_port();
         let lan_proxy = free_port();
+        write_lan_config(&dir, lan_proxy);
+        let dir_c = CString::new(dir.to_str().unwrap()).unwrap();
+        unsafe { bridge_set_home_dir(dir_c.as_ptr()) };
+
         let ctrl_c = CString::new(format!("127.0.0.1:{ctrl}")).unwrap();
         let secret_c = CString::new("").unwrap();
 
-        let rc = unsafe {
-            bridge_start_with_lan(socks, dns, ctrl_c.as_ptr(), secret_c.as_ptr(), lan_proxy)
-        };
+        let rc = unsafe { bridge_start_with_ports(socks, dns, ctrl_c.as_ptr(), secret_c.as_ptr()) };
         let err = unsafe { CStr::from_ptr(bridge_get_last_error()) }
             .to_str()
             .unwrap()
             .to_string();
         assert_eq!(rc, 0, "LAN start failed: {err}");
 
-        // The LAN mixed listener must accept TCP (0.0.0.0 covers loopback).
-        let mut connected = false;
-        for _ in 0..20 {
-            if std::net::TcpStream::connect(format!("127.0.0.1:{lan_proxy}")).is_ok() {
-                connected = true;
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(100));
-        }
-        assert!(connected, "LAN mixed listener not accepting on {lan_proxy}");
+        // Internal SOCKS stays loopback; LAN mixed is on the YAML mixed-port.
+        assert!(
+            wait_accept(&format!("127.0.0.1:{socks}")),
+            "loopback mixed not accepting on {socks}"
+        );
+        assert!(
+            wait_accept(&format!("127.0.0.1:{lan_proxy}")),
+            "LAN mixed listener not accepting on {lan_proxy}"
+        );
 
         bridge_stop_proxy();
         assert!(!bridge_is_running());
@@ -869,24 +885,18 @@ rules:
 
         let dir = std::env::temp_dir().join(format!("meow-ffi-lanbusy-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("config.yaml"), MINIMAL_CONFIG).unwrap();
-        let dir_c = CString::new(dir.to_str().unwrap()).unwrap();
-        unsafe { bridge_set_home_dir(dir_c.as_ptr()) };
 
         // Occupy a port on 0.0.0.0 so the LAN preflight bind must fail.
         let blocker = std::net::TcpListener::bind("0.0.0.0:0").unwrap();
         let busy = blocker.local_addr().unwrap().port() as i32;
+        write_lan_config(&dir, busy);
+        let dir_c = CString::new(dir.to_str().unwrap()).unwrap();
+        unsafe { bridge_set_home_dir(dir_c.as_ptr()) };
 
         let ctrl_c = CString::new(format!("127.0.0.1:{}", free_port())).unwrap();
         let secret_c = CString::new("").unwrap();
         let rc = unsafe {
-            bridge_start_with_lan(
-                free_port(),
-                free_port(),
-                ctrl_c.as_ptr(),
-                secret_c.as_ptr(),
-                busy,
-            )
+            bridge_start_with_ports(free_port(), free_port(), ctrl_c.as_ptr(), secret_c.as_ptr())
         };
         let err = unsafe { CStr::from_ptr(bridge_get_last_error()) }
             .to_str()
@@ -897,6 +907,41 @@ rules:
         assert!(!bridge_is_running());
 
         drop(blocker);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Local-proxy mode shape: allow-lan + mixed-port == socks_port merges into
+    // a single 0.0.0.0 listener serving loopback and LAN clients alike.
+    #[test]
+    fn lan_same_port_merges_into_single_listener() {
+        let _g = TEST_LOCK.lock();
+
+        let dir = std::env::temp_dir().join(format!("meow-ffi-lanmerge-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let socks = free_port();
+        let dns = free_port();
+        let ctrl = free_port();
+        write_lan_config(&dir, socks);
+        let dir_c = CString::new(dir.to_str().unwrap()).unwrap();
+        unsafe { bridge_set_home_dir(dir_c.as_ptr()) };
+
+        let ctrl_c = CString::new(format!("127.0.0.1:{ctrl}")).unwrap();
+        let secret_c = CString::new("").unwrap();
+
+        let rc = unsafe { bridge_start_with_ports(socks, dns, ctrl_c.as_ptr(), secret_c.as_ptr()) };
+        let err = unsafe { CStr::from_ptr(bridge_get_last_error()) }
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(rc, 0, "merged LAN start failed: {err}");
+
+        assert!(
+            wait_accept(&format!("127.0.0.1:{socks}")),
+            "merged listener not accepting on {socks}"
+        );
+
+        bridge_stop_proxy();
+        assert!(!bridge_is_running());
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -173,7 +173,9 @@ final class ConfigManager {
             throw ConfigError.sharedContainerUnavailable
         }
         var content = yaml
-        Self.sanitizeConfigString(&content)
+        // The provider extension never writes engineModeKey to its own
+        // (per-process) defaults, so it always sanitizes as .vpn.
+        Self.sanitizeConfigString(&content, engineMode: EngineMode.load(from: AppConstants.sharedDefaults))
         try content.write(to: fileURL, atomically: true, encoding: .utf8)
         try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
     }
@@ -423,7 +425,9 @@ final class ConfigManager {
     /// Sanitize a config string in-place (same rules as sanitizeConfig but on a String).
     /// Idempotent: re-running on an already-sanitized config is a no-op, since
     /// `saveConfig` calls this unconditionally on every write.
-    static func sanitizeConfigString(_ config: inout String) {
+    /// `engineMode` picks the managed DNS block (fake-ip for the transparent
+    /// proxy, redir-host for local proxy mode).
+    static func sanitizeConfigString(_ config: inout String, engineMode: EngineMode = .vpn) {
         // Disable TUN and geo-auto-update — transparent proxy intercepts at
         // socket level, and geo downloads would block tunnel startup.
         var lines = config.components(separatedBy: "\n")
@@ -443,7 +447,8 @@ final class ConfigManager {
         }
         config = lines.joined(separator: "\n")
         stripSubscriptionsSection(&config)
-        forceManagedDNS(&config)
+        forceManagedDNS(&config, engineMode: engineMode)
+        forceTunDisabled(&config)
     }
 
     /// DNS settings owned by the app/extension, mirroring meow-ios's
@@ -475,11 +480,33 @@ final class ConfigManager {
         - 223.5.5.5
     """
 
-    /// Replace any existing top-level `dns:` section with `managedDNSSection`,
-    /// inserting it ahead of `proxies:` (or at the end) to keep the header
-    /// layout stable. Idempotent: re-running on a managed config is a no-op
-    /// change in content.
-    static func forceManagedDNS(_ config: inout String) {
+    /// Managed DNS for local proxy mode. Nothing is intercepted there —
+    /// clients hand the engine real domains via the HTTP/SOCKS proxy
+    /// protocol and never query its DNS listener, so fake-ip answers would
+    /// only hand out unroutable 28.0.0.0/8 addresses (harmful if anything
+    /// did query, e.g. via Allow LAN). redir-host returns real upstream IPs
+    /// while the engine's sniffing cache still restores domains for rules.
+    static let managedLocalProxyDNSSection = """
+    dns:
+      enable: true
+      listen: 127.0.0.1:0
+      enhanced-mode: redir-host
+      # Bootstrap-only resolvers: proxy-server hostnames must resolve
+      # without going through a proxy (dial cycle otherwise).
+      default-nameserver:
+        - 223.5.5.5
+        - 114.114.114.114
+      nameserver:
+        - 119.29.29.29
+        - 223.5.5.5
+    """
+
+    /// Replace any existing top-level `dns:` section with the managed block
+    /// for `engineMode` (fake-ip for the transparent proxy, redir-host for
+    /// local proxy mode), inserting it ahead of `proxies:` (or at the end)
+    /// to keep the header layout stable. Idempotent: re-running on a managed
+    /// config is a no-op change in content.
+    static func forceManagedDNS(_ config: inout String, engineMode: EngineMode = .vpn) {
         var lines = config.components(separatedBy: "\n")
         if let start = lines.firstIndex(where: {
             $0.trimmingCharacters(in: .whitespaces).hasPrefix("dns:")
@@ -499,7 +526,9 @@ final class ConfigManager {
             }
             lines.removeSubrange(start..<end)
         }
-        let block = Self.managedDNSSection.components(separatedBy: "\n")
+        let section = engineMode == .localProxy
+            ? Self.managedLocalProxyDNSSection : Self.managedDNSSection
+        let block = section.components(separatedBy: "\n")
         if let idx = lines.firstIndex(where: {
             $0.trimmingCharacters(in: .whitespaces).hasPrefix("proxies:")
                 && !$0.hasPrefix(" ") && !$0.hasPrefix("\t")
@@ -511,6 +540,31 @@ final class ConfigManager {
                 lines.removeLast()
             }
             lines.append(contentsOf: [""] + block)
+        }
+        config = lines.joined(separator: "\n")
+    }
+
+    /// Ensure the config carries an explicit, disabled top-level `tun:`
+    /// block. Truthy `enable:` values in an existing block are already
+    /// rewritten to false by the sanitize passes; this injects the block
+    /// when absent so the effective config states the invariant outright
+    /// instead of relying on the engine's default. Idempotent.
+    static func forceTunDisabled(_ config: inout String) {
+        var lines = config.components(separatedBy: "\n")
+        let hasTun = lines.contains {
+            !$0.hasPrefix(" ") && !$0.hasPrefix("\t") && $0.hasPrefix("tun:")
+        }
+        guard !hasTun else { return }
+        let block = ["tun:", "  enable: false", ""]
+        if let idx = lines.firstIndex(where: {
+            !$0.hasPrefix(" ") && !$0.hasPrefix("\t") && $0.hasPrefix("dns:")
+        }) {
+            lines.insert(contentsOf: block, at: idx)
+        } else {
+            while lines.last?.trimmingCharacters(in: .whitespaces).isEmpty == true {
+                lines.removeLast()
+            }
+            lines.append(contentsOf: [""] + block.dropLast())
         }
         config = lines.joined(separator: "\n")
     }
@@ -543,15 +597,26 @@ final class ConfigManager {
         let normalized = yaml
             .replacingOccurrences(of: "\r\n", with: "\n")
             .replacingOccurrences(of: "\r", with: "\n")
+        var found = false
         let lines = normalized.components(separatedBy: "\n").map { line -> String in
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             guard !line.hasPrefix(" "), !line.hasPrefix("\t"),
                   trimmed.hasPrefix("\(key):") else {
                 return line
             }
+            found = true
             return "\(key): \(value)"
         }
-        return lines.joined(separator: "\n")
+        if found {
+            return lines.joined(separator: "\n")
+        }
+        // Key absent (e.g. subscription-only YAML): insert at the top so
+        // callers can always force allow-lan / bind-address / mixed-port.
+        let insertion = "\(key): \(value)"
+        if normalized.isEmpty {
+            return insertion
+        }
+        return insertion + "\n" + normalized
     }
 
     /// Merge a Clash subscription YAML into our base config.
@@ -638,20 +703,26 @@ final class ConfigManager {
     /// Merge subscription YAML: take proxies, proxy-groups, rules, and their providers from subscription.
     private func mergeSubscription(_ yaml: String) -> String {
         let base = (try? loadConfig()) ?? defaultConfig()
-        return ConfigManager.mergeSubscription(yaml, baseConfig: base, defaultConfig: defaultConfig())
+        return ConfigManager.mergeSubscription(
+            yaml, baseConfig: base, defaultConfig: defaultConfig(),
+            engineMode: EngineMode.load(from: AppConstants.sharedDefaults)
+        )
     }
 
     /// Pure merge logic — takes all inputs as parameters for testability.
     /// Keeps the header (ports, DNS settings) from the base config.
     /// Overwrites proxies, proxy-groups, rules, and providers directly from subscription
     /// (raw pass-through to preserve all fields mihomo needs).
-    static func mergeSubscription(_ yaml: String, baseConfig: String, defaultConfig: String) -> String {
+    static func mergeSubscription(
+        _ yaml: String, baseConfig: String, defaultConfig: String,
+        engineMode: EngineMode = .vpn
+    ) -> String {
         // 1. Extract raw sections from subscription (preserves exact formatting)
         let sub = extractYAMLSections(from: yaml, named: ["proxies", "proxy-groups", "proxy-providers", "rules", "rule-providers"])
 
         // 2. Header from base config (everything before proxies:) preserves
         // user edits to ports etc. The dns block in it is replaced with the
-        // managed fake-ip block below.
+        // managed block below.
         let baseLines = baseConfig.components(separatedBy: "\n")
         let proxiesCut = baseLines.firstIndex(where: { !$0.hasPrefix(" ") && !$0.hasPrefix("\t") && $0.hasPrefix("proxies:") }) ?? baseLines.count
         let header = baseLines[0..<proxiesCut].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
@@ -668,11 +739,11 @@ final class ConfigManager {
         let defaultRules = extractYAMLSections(from: defaultConfig, named: ["rules"])
         result += "\n\n" + (sub["rules"] ?? defaultRules["rules"] ?? "rules:\n  - MATCH,DIRECT")
 
-        // Replace the base header's dns block with the managed fake-ip block,
-        // so a pre-upgrade header (redir-host, `tcp://…#GROUP` nameservers
+        // Replace the base header's dns block with the managed block for the
+        // engine mode, so a pre-upgrade header (`tcp://…#GROUP` nameservers
         // pointing at groups the subscription may not define) can't make the
         // merged config fail validation or load.
-        forceManagedDNS(&result)
+        forceManagedDNS(&result, engineMode: engineMode)
 
         return result
     }
@@ -899,15 +970,15 @@ final class ConfigManager {
 
     func defaultConfig() -> String {
         // mixed-port / dns.listen / external-controller values below are
-        // placeholders only — the bridge picks ephemeral ports at runtime
-        // (see bridge_start_with_ephemeral_ports) so multiple mihomo
-        // instances on the host don't collide. Editing them in the UI has
-        // no effect on the actual bound ports.
+        // placeholders only — the bridge forces SOCKS/DNS/API ports at
+        // runtime. allow-lan / bind-address / mixed-port are rewritten by
+        // VPNManager.buildEffectiveConfigYAML from LANSharingSettings.
         return """
         mixed-port: 0
         mode: rule
         log-level: info
         allow-lan: false
+        bind-address: 127.0.0.1
         external-controller: 127.0.0.1:0
 
         geo-auto-update: false

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -194,6 +194,15 @@ enum EphemeralPort {
         let fd = socket(AF_INET, type, proto)
         guard fd >= 0 else { return false }
         defer { close(fd) }
+        // Match the engine's listener (tokio sets SO_REUSEADDR on Unix):
+        // without it, a port whose previous server left connections in
+        // TIME_WAIT (the proxy actively closes client sockets on every
+        // stop) fails this check with EADDRINUSE for ~30s even though the
+        // engine itself could bind fine — a false "port in use" error.
+        // An actively listening socket on the same addr:port still fails,
+        // so real conflicts are unaffected.
+        var reuse: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
         var addr = sockaddr_in()
         addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
         addr.sin_family = sa_family_t(AF_INET)

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -29,6 +29,25 @@ enum AppConstants {
     static let perAppProxySettingsKey = "perAppProxySettings"
     static let lanSharingSettingsKey = "lanSharingSettings"
     static let autoStartVPNAtLoginKey = "autoStartVPNAtLogin"
+    /// UserDefaults key holding the selected `EngineMode` raw value.
+    /// Absent means `.vpn` (the transparent-proxy system extension).
+    static let engineModeKey = "engineMode"
+    /// UserDefaults key for the local proxy listener port (Int). Unlike the
+    /// transparent-proxy path (ephemeral, internal-only ports), local proxy
+    /// mode is user-facing: apps are pointed at this port manually, so it
+    /// must be stable across restarts.
+    static let localProxyPortKey = "localProxyPort"
+    static let defaultLocalProxyPort = 7890
+
+    /// The local proxy port currently configured in Settings, clamped to the
+    /// valid range with the default as fallback.
+    static var localProxyPort: UInt16 {
+        let stored = sharedDefaults.integer(forKey: localProxyPortKey)
+        guard (1...65535).contains(stored) else {
+            return UInt16(defaultLocalProxyPort)
+        }
+        return UInt16(stored)
+    }
 
     /// Live mihomo REST controller address (`host:port`). Returns nil when
     /// the tunnel hasn't run yet this install — callers should treat that
@@ -137,6 +156,14 @@ enum EphemeralPort {
         return nil
     }
 
+    /// True when `port` can currently be bound on 127.0.0.1 TCP. Used to
+    /// fail local-proxy startup with a clear error — the engine binds its
+    /// mixed listener inside a spawned task where a failure only reaches
+    /// the log.
+    static func isTCPPortFree(_ port: UInt16) -> Bool {
+        bindThenClose(type: SOCK_STREAM, proto: IPPROTO_TCP, port: port)
+    }
+
     private static func pick(type: Int32, proto: Int32) -> UInt16? {
         let fd = socket(AF_INET, type, proto)
         guard fd >= 0 else { return nil }
@@ -178,6 +205,29 @@ enum EphemeralPort {
             }
         }
         return bindOK == 0
+    }
+}
+
+/// How the proxy engine is hosted. `.vpn` runs it inside the
+/// NETransparentProxyProvider extension and intercepts all traffic;
+/// `.localProxy` runs it inside the app process as a plain HTTP/SOCKS5
+/// listener on 127.0.0.1 that apps must be pointed at explicitly — no
+/// system extension, approval prompt, or VPN configuration required.
+enum EngineMode: String, CaseIterable, Identifiable {
+    case vpn = "vpn"
+    case localProxy = "local"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .vpn: return String(localized: "VPN (System-wide)")
+        case .localProxy: return String(localized: "Local Proxy Only")
+        }
+    }
+
+    static func load(from defaults: UserDefaults) -> EngineMode {
+        EngineMode(rawValue: defaults.string(forKey: AppConstants.engineModeKey) ?? "") ?? .vpn
     }
 }
 

--- a/Shared/LANSharingSettings.swift
+++ b/Shared/LANSharingSettings.swift
@@ -4,10 +4,11 @@
 
 import Foundation
 
-/// "Allow LAN" settings. When enabled, the engine additionally binds a mixed
-/// SOCKS5/HTTP listener on `0.0.0.0`, so other devices on the local network
-/// can use this Mac as their proxy server. Stored as JSON in shared
-/// UserDefaults and forwarded to the extension via providerConfiguration.
+/// "Allow LAN" settings. When enabled, the effective engine config gets
+/// Clash-compatible `allow-lan: true`, `bind-address: 0.0.0.0`, and
+/// `mixed-port: <proxyPort>` so other devices on the local network can use
+/// this Mac as their SOCKS5/HTTP proxy. Stored as JSON in shared UserDefaults;
+/// applied in `VPNManager.buildEffectiveConfigYAML` (no separate FFI path).
 struct LANSharingSettings: Codable, Equatable {
     static let defaultProxyPort = 7890
 

--- a/Shared/LocalProxyController.swift
+++ b/Shared/LocalProxyController.swift
@@ -79,13 +79,10 @@ final class LocalProxyController {
 
         let controllerAddr = "127.0.0.1:\(ctrlPort)"
         let secret = AppConstants.generateControllerSecret() ?? ""
-        let lanSettings = LANSharingSettings.load(from: defaults)
-        let lanPort = lanSettings.enabled ? Int32(lanSettings.effectiveProxyPort) : 0
 
         var startError: NSError?
-        BridgeStartWithLAN(
-            Int32(port), Int32(dnsPort), controllerAddr, secret,
-            lanPort, &startError
+        BridgeStartWithPorts(
+            Int32(port), Int32(dnsPort), controllerAddr, secret, &startError
         )
         if let startError = startError {
             throw startError
@@ -101,7 +98,7 @@ final class LocalProxyController {
         mixedPort = port
         isRunning = true
         AppLogger.vpn.notice(
-            "Local proxy started: mixed=\(port) dns=\(dnsPort) controller=\(controllerAddr, privacy: .public) lan=\(lanPort)"
+            "Local proxy started: mixed=\(port) dns=\(dnsPort) controller=\(controllerAddr, privacy: .public)"
         )
     }
 

--- a/Shared/LocalProxyController.swift
+++ b/Shared/LocalProxyController.swift
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Max Lv <max.c.lv@gmail.com>
+//
+// Licensed under the MIT License. See the LICENSE file for details.
+
+import Foundation
+import MihomoCore
+
+/// Hosts the meow-rs engine inside the calling process as a plain local
+/// proxy: a mixed HTTP/SOCKS5 listener on `127.0.0.1:<localProxyPort>`.
+/// Nothing is intercepted — apps must be pointed at the listener manually.
+/// This is the non-transparent-proxy counterpart to
+/// `TransparentProxyProvider`, sharing the same engine and REST controller
+/// conventions (controller address + secret published via
+/// `AppConstants.sharedDefaults`) so the existing proxy-group, connection,
+/// and traffic UIs work unchanged.
+final class LocalProxyController {
+    static let shared = LocalProxyController()
+
+    private(set) var isRunning = false
+    /// Port of the mixed HTTP/SOCKS5 listener while running, else 0.
+    private(set) var mixedPort: UInt16 = 0
+
+    private init() {}
+
+    enum LocalProxyError: LocalizedError {
+        case configDirectoryUnavailable
+        case portInUse(UInt16)
+        case ephemeralPortsUnavailable
+
+        var errorDescription: String? {
+            switch self {
+            case .configDirectoryUnavailable:
+                return String(localized: "Could not resolve the configuration directory.")
+            case .portInUse(let port):
+                return String(
+                    format: String(localized: "Local proxy port %@ is already in use."),
+                    String(port)
+                )
+            case .ephemeralPortsUnavailable:
+                return String(localized: "Could not allocate internal ports for the proxy engine.")
+            }
+        }
+    }
+
+    /// Write `configYAML` to the config directory and start the engine.
+    /// Blocking (engine startup + geodata check) — call off the main thread.
+    func start(configYAML: String) throws {
+        guard !isRunning else { return }
+
+        guard let configDirURL = ConfigManager.shared.configDirectoryURL else {
+            throw LocalProxyError.configDirectoryUnavailable
+        }
+        let configDir = configDirURL.path
+        try FileManager.default.createDirectory(
+            atPath: configDir, withIntermediateDirectories: true
+        )
+        try configYAML.write(
+            toFile: configDir + "/" + AppConstants.configFileName,
+            atomically: true, encoding: .utf8
+        )
+        ConfigManager.shared.sanitizeConfig()
+
+        let defaults = AppConstants.sharedDefaults
+        let port = AppConstants.localProxyPort
+        guard EphemeralPort.isTCPPortFree(port) else {
+            throw LocalProxyError.portInUse(port)
+        }
+        // The engine still needs its DNS resolver and REST controller;
+        // neither is user-facing here, so ephemeral ports as in VPN mode.
+        guard let dnsPort = EphemeralPort.pickDNS(),
+              let ctrlPort = EphemeralPort.pickTCP() else {
+            throw LocalProxyError.ephemeralPortsUnavailable
+        }
+
+        let logDir = configDirURL.deletingLastPathComponent()
+        BridgeSetLogFile(logDir.appendingPathComponent("rust_bridge.log").path)
+        ConfigManager.shared.ensureGeodataFiles(configDir: configDir)
+        BridgeSetHomeDir(configDir)
+
+        let controllerAddr = "127.0.0.1:\(ctrlPort)"
+        let secret = AppConstants.generateControllerSecret() ?? ""
+        let lanSettings = LANSharingSettings.load(from: defaults)
+        let lanPort = lanSettings.enabled ? Int32(lanSettings.effectiveProxyPort) : 0
+
+        var startError: NSError?
+        BridgeStartWithLAN(
+            Int32(port), Int32(dnsPort), controllerAddr, secret,
+            lanPort, &startError
+        )
+        if let startError = startError {
+            throw startError
+        }
+
+        // Publish the controller endpoint exactly like the VPN path does so
+        // every existing REST client picks it up.
+        defaults.set(controllerAddr, forKey: AppConstants.externalControllerAddrKey)
+        defaults.set(secret, forKey: AppConstants.externalControllerSecretKey)
+
+        BridgeUpdateLogLevel(defaults.string(forKey: "logLevel") ?? "info")
+
+        mixedPort = port
+        isRunning = true
+        AppLogger.vpn.notice(
+            "Local proxy started: mixed=\(port) dns=\(dnsPort) controller=\(controllerAddr, privacy: .public) lan=\(lanPort)"
+        )
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        BridgeStopProxy()
+        isRunning = false
+        mixedPort = 0
+        AppLogger.vpn.notice("Local proxy stopped")
+    }
+
+    /// In-process equivalent of `TransparentProxyProvider.handleAppMessage`
+    /// so `VPNManager.sendMessage` callers work identically in both modes.
+    func handleMessage(_ message: [String: Any]) -> Data? {
+        guard let action = message["action"] as? String else { return nil }
+        switch action {
+        case "get_traffic":
+            return responseData([
+                "upload": BridgeGetUploadTraffic(),
+                "download": BridgeGetDownloadTraffic()
+            ])
+        case "get_version":
+            return responseData(["version": BridgeVersion()])
+        case "get_log":
+            return readLog().data(using: .utf8)
+        default:
+            return nil
+        }
+    }
+
+    private func responseData(_ dict: [String: Any]) -> Data? {
+        try? JSONSerialization.data(withJSONObject: dict)
+    }
+
+    /// Engine log for the log viewer — the in-process equivalent of the
+    /// provider's `get_log` IPC response.
+    func readLog() -> String {
+        guard let dir = ConfigManager.shared.configDirectoryURL?
+            .deletingLastPathComponent() else { return "" }
+        let url = dir.appendingPathComponent("rust_bridge.log")
+        var content = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        let maxResponseBytes = 256 * 1024
+        if content.utf8.count > maxResponseBytes,
+           let tail = String(content.utf8.suffix(maxResponseBytes)) {
+            content = "… (truncated)\n" + tail
+        }
+        return content
+    }
+}

--- a/Shared/VPNManager.swift
+++ b/Shared/VPNManager.swift
@@ -28,6 +28,10 @@ final class VPNManager: NSObject, ObservableObject {
     @Published var errorMessage: String?
     @Published var extensionEnabled = false
     @Published private(set) var systemExtensionInstallState: SystemExtensionInstallState = .notInstalled
+    /// How the engine is hosted: transparent-proxy extension (`.vpn`) or an
+    /// in-process local HTTP/SOCKS5 listener (`.localProxy`). Persisted in
+    /// UserDefaults; change via `setEngineMode`.
+    @Published private(set) var engineMode: EngineMode = .vpn
     private var activationRequestInFlight = false
     private var isLoadingManager = false
     private var didAttemptAutoStartAtLogin = false
@@ -52,9 +56,19 @@ final class VPNManager: NSObject, ObservableObject {
 
     private override init() {
         super.init()
+        engineMode = EngineMode.load(from: AppConstants.sharedDefaults)
         // Don't touch the system extension or the user's real NE preferences
         // when the app is only hosting unit tests.
         if AppConstants.isRunningUnitTests {
+            return
+        }
+        // Local proxy mode never touches the system extension or NE
+        // preferences — a local-only user should see no approval prompts
+        // or "add VPN configurations" dialogs.
+        if engineMode == .localProxy {
+            DispatchQueue.main.async { [weak self] in
+                self?.startAtLoginIfNeeded()
+            }
             return
         }
         #if canImport(SystemExtensions)
@@ -67,6 +81,23 @@ final class VPNManager: NSObject, ObservableObject {
         #else
         loadManager()
         #endif
+    }
+
+    /// Switch how the engine is hosted. Stops the currently running proxy
+    /// (either kind) first; the user reconnects explicitly in the new mode.
+    func setEngineMode(_ mode: EngineMode) {
+        guard mode != engineMode else { return }
+        if isConnected || isProcessing {
+            stop()
+        }
+        engineMode = mode
+        errorMessage = nil
+        AppConstants.sharedDefaults.set(mode.rawValue, forKey: AppConstants.engineModeKey)
+        dbg("setEngineMode: \(mode.rawValue)")
+        if mode == .vpn {
+            // Entering VPN mode may need extension activation + NE config.
+            checkExtensionStatus()
+        }
     }
 
     // MARK: - System Extension Activation
@@ -121,6 +152,7 @@ final class VPNManager: NSObject, ObservableObject {
     /// Check if the system extension is enabled by re-probing activation status.
     func checkExtensionStatus(forceRetry: Bool = false) {
         guard !AppConstants.isRunningUnitTests else { return }
+        guard engineMode == .vpn else { return }
         #if canImport(SystemExtensions)
         if Self.providerIsAppExtension {
             updateInstallState(.active)
@@ -311,6 +343,11 @@ final class VPNManager: NSObject, ObservableObject {
             return
         }
 
+        if engineMode == .localProxy {
+            startLocalProxy()
+            return
+        }
+
         isProcessing = true
         errorMessage = nil
 
@@ -417,8 +454,70 @@ final class VPNManager: NSObject, ObservableObject {
     }
 
     func stop() {
+        // Local engine stops synchronously; also handles the defensive case
+        // of a lingering in-process engine after a mode switch.
+        if LocalProxyController.shared.isRunning {
+            LocalProxyController.shared.stop()
+            status = .disconnected
+            isProcessing = false
+            return
+        }
+        if engineMode == .localProxy {
+            return
+        }
         isProcessing = true
         manager?.connection.stopVPNTunnel()
+    }
+
+    // MARK: - Local Proxy Mode
+
+    /// Start the engine in-process as a plain HTTP/SOCKS5 listener.
+    /// The non-transparent-proxy counterpart to the tunnel start path.
+    private func startLocalProxy() {
+        isProcessing = true
+        errorMessage = nil
+
+        // Ensure config exists before starting (same as the tunnel path)
+        if !ConfigManager.shared.configExists() {
+            do {
+                let defaultConfig = ConfigManager.shared.defaultConfig()
+                try ConfigManager.shared.saveConfig(defaultConfig)
+            } catch {
+                isProcessing = false
+                errorMessage = "Failed to create default config: \(error.localizedDescription)"
+                return
+            }
+        }
+
+        let yaml = buildEffectiveConfigYAML()
+        status = .connecting
+        dbg("startLocalProxy: port=\(AppConstants.localProxyPort)")
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            do {
+                try LocalProxyController.shared.start(configYAML: yaml)
+                DispatchQueue.main.async {
+                    self?.isProcessing = false
+                    self?.status = .connected
+                    self?.selectSavedProxyNode()
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self?.isProcessing = false
+                    self?.status = .disconnected
+                    self?.errorMessage = String(
+                        format: String(localized: "Failed to start local proxy: %@"),
+                        error.localizedDescription
+                    )
+                }
+            }
+        }
+    }
+
+    /// Stop + start the in-process engine so config changes take effect.
+    private func restartLocalProxy() {
+        LocalProxyController.shared.stop()
+        status = .disconnected
+        startLocalProxy()
     }
 
     func toggle() {
@@ -432,6 +531,13 @@ final class VPNManager: NSObject, ObservableObject {
     // MARK: - Send Message to Tunnel
 
     func sendMessage(_ message: [String: Any], completion: @escaping (Data?) -> Void) {
+        // Local mode: the engine lives in this process — answer directly
+        // instead of round-tripping through provider IPC.
+        if engineMode == .localProxy {
+            completion(LocalProxyController.shared.handleMessage(message))
+            return
+        }
+
         guard let session = manager?.connection as? NETunnelProviderSession else {
             completion(nil)
             return
@@ -455,6 +561,10 @@ final class VPNManager: NSObject, ObservableObject {
         // Update config on disk, then restart the tunnel so it picks up the change
         ConfigManager.shared.setMode(mode.rawValue)
         guard isConnected else { return }
+        if engineMode == .localProxy {
+            restartLocalProxy()
+            return
+        }
         isProcessing = true
         manager?.connection.stopVPNTunnel()
 
@@ -476,6 +586,9 @@ final class VPNManager: NSObject, ObservableObject {
     /// Returns true if the VPN was connected (caller should reconnect after fetching).
     func disconnectForFetch() async -> Bool {
         guard isConnected else { return false }
+        // A local proxy doesn't intercept this process's traffic — fetches
+        // already bypass it, so there is nothing to disconnect.
+        if engineMode == .localProxy { return false }
         manager?.connection.stopVPNTunnel()
         // Poll for disconnected state (up to 5s)
         for _ in 0..<50 {
@@ -662,10 +775,11 @@ final class VPNManager: NSObject, ObservableObject {
         }.resume()
     }
 
-    /// Build the full YAML config (base + subscription + user settings),
-    /// zlib-compress it, and pass via providerConfiguration to overcome the 512 KB IPC limit.
-    private func passSettingsToProvider() {
-        guard let proto = manager?.protocolConfiguration as? NETunnelProviderProtocol else { return }
+    /// Build the full effective YAML config: base + selected subscription +
+    /// selected node + user settings (log level, routing mode, GLOBAL group).
+    /// Shared by the tunnel path (compressed into providerConfiguration) and
+    /// the local proxy path (written straight to disk).
+    private func buildEffectiveConfigYAML() -> String {
         let defaults = AppConstants.sharedDefaults
 
         // Start with the base config
@@ -707,6 +821,16 @@ final class VPNManager: NSObject, ObservableObject {
         // whose sorted member list puts DIRECT first, so global mode would
         // silently send all traffic direct.
         yaml = ConfigManager.shared.updateGlobalProxyGroup(yaml, enabled: mode == "global")
+
+        return yaml
+    }
+
+    /// Build the full YAML config (base + subscription + user settings),
+    /// zlib-compress it, and pass via providerConfiguration to overcome the 512 KB IPC limit.
+    private func passSettingsToProvider() {
+        guard let proto = manager?.protocolConfiguration as? NETunnelProviderProtocol else { return }
+        let defaults = AppConstants.sharedDefaults
+        let yaml = buildEffectiveConfigYAML()
 
         // Compress with zlib and store in providerConfiguration
         var providerConfig: [String: Any] = [:]
@@ -762,6 +886,10 @@ final class VPNManager: NSObject, ObservableObject {
     /// Restart the tunnel if currently connected so new settings take effect.
     func restartIfConnected() {
         guard isConnected else { return }
+        if engineMode == .localProxy {
+            restartLocalProxy()
+            return
+        }
         isProcessing = true
         manager?.connection.stopVPNTunnel()
         DispatchQueue.global().async { [weak self] in

--- a/Shared/VPNManager.swift
+++ b/Shared/VPNManager.swift
@@ -793,7 +793,9 @@ final class VPNManager: NSObject, ObservableObject {
                let selectedID = UUID(uuidString: idString),
                let selected = subs.first(where: { $0.id == selectedID }),
                let raw = selected.rawContent {
-                yaml = ConfigManager.mergeSubscription(raw, baseConfig: yaml, defaultConfig: yaml)
+                yaml = ConfigManager.mergeSubscription(
+                    raw, baseConfig: yaml, defaultConfig: yaml, engineMode: engineMode
+                )
             }
         }
 
@@ -822,6 +824,29 @@ final class VPNManager: NSObject, ObservableObject {
         // silently send all traffic direct.
         yaml = ConfigManager.shared.updateGlobalProxyGroup(yaml, enabled: mode == "global")
 
+        // Clash-compatible allow-lan: engine reads these from YAML (no FFI arg).
+        // When enabled, mixed-port is the LAN-facing listener; in local-proxy
+        // mode it usually equals the user-facing mixed port and merges into
+        // one 0.0.0.0 bind. DNS + external-controller stay loopback either way.
+        let lan = LANSharingSettings.load(from: defaults)
+        yaml = ConfigManager.replacingTopLevelScalar(
+            in: yaml, key: "allow-lan", value: lan.enabled ? "true" : "false"
+        )
+        if lan.enabled {
+            yaml = ConfigManager.replacingTopLevelScalar(
+                in: yaml, key: "bind-address", value: "0.0.0.0"
+            )
+            yaml = ConfigManager.replacingTopLevelScalar(
+                in: yaml, key: "mixed-port", value: String(lan.effectiveProxyPort)
+            )
+        } else if engineMode == .localProxy {
+            // Document the local mixed port even without LAN; the bridge still
+            // forces the actual bind from the socks_port argument.
+            yaml = ConfigManager.replacingTopLevelScalar(
+                in: yaml, key: "mixed-port", value: String(AppConstants.localProxyPort)
+            )
+        }
+
         return yaml
     }
 
@@ -843,14 +868,6 @@ final class VPNManager: NSObject, ObservableObject {
         // Pass per-app proxy settings as a separate JSON blob
         if let perAppData = defaults.data(forKey: AppConstants.perAppProxySettingsKey) {
             providerConfig["perAppProxy"] = perAppData
-        }
-
-        // Allow LAN: forward the fixed LAN proxy port so the engine
-        // additionally binds on 0.0.0.0. An absent key means disabled.
-        let lanSettings = LANSharingSettings.load(from: defaults)
-        if lanSettings.enabled {
-            providerConfig["lanProxyPort"] = lanSettings.effectiveProxyPort
-            dbg("passSettings: allow LAN proxyPort=\(lanSettings.effectiveProxyPort)")
         }
 
         // Pick ephemeral 127.0.0.1 ports for the SOCKS5, DNS, and REST

--- a/TransparentProxy/TransparentProxyProvider.swift
+++ b/TransparentProxy/TransparentProxyProvider.swift
@@ -43,11 +43,6 @@ class TransparentProxyProvider: NETransparentProxyProvider {
     private var controllerAddr: String = ""
     private var controllerSecret: String = ""
 
-    /// "Allow LAN" proxy listener port (0 = disabled). When set, the engine
-    /// additionally binds a mixed SOCKS5/HTTP listener on 0.0.0.0 so other
-    /// LAN devices can use this Mac as their proxy server.
-    private var lanProxyPort: UInt16 = 0
-
     private lazy var logURL: URL = {
         let dir = ConfigManager.shared.configDirectoryURL?.deletingLastPathComponent()
             ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
@@ -143,15 +138,12 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                 completionHandler(ProviderError.configNotFound)
                 return
             }
-            let lanProxy = self?.lanProxyPort ?? 0
             self?.log(
                 "Starting Mihomo proxy engine: socks=\(socks) dns=\(dns) controller=\(ctrl)"
-                    + " lanProxy=\(lanProxy)"
             )
             var startError: NSError?
-            BridgeStartWithLAN(
-                Int32(socks), Int32(dns), ctrl, secret,
-                Int32(lanProxy), &startError
+            BridgeStartWithPorts(
+                Int32(socks), Int32(dns), ctrl, secret, &startError
             )
             if let startError = startError {
                 self?.log("ERROR: BridgeStartWithPorts failed: \(startError)")
@@ -729,12 +721,6 @@ class TransparentProxyProvider: NETransparentProxyProvider {
         }
         if let secret = providerConfig?["secret"] as? String {
             self.controllerSecret = secret
-        }
-
-        // "Allow LAN" proxy listener port; absent or 0 means disabled.
-        if let lanProxy = providerConfig?["lanProxyPort"] as? Int,
-           (1...65535).contains(lanProxy) {
-            self.lanProxyPort = UInt16(lanProxy)
         }
 
         return configDir


### PR DESCRIPTION
## Summary

Adds a **Proxy Method** setting (Settings tab) with two engine modes:

- **VPN (System-wide)** — the existing transparent-proxy flow via the Network Extension provider. Unchanged, still the default.
- **Local Proxy Only** — runs the meow-rs engine **inside the main app process** as a mixed HTTP/SOCKS5 listener on `127.0.0.1:<port>` (user-configurable, default 7890). No system extension, approval prompt, or VPN configuration required — apps are pointed at the proxy manually.

## Implementation

- `Shared/LocalProxyController.swift` — hosts the engine in-process, mirroring the provider's startup: config write + `sanitizeConfig`, geodata setup, ephemeral DNS/controller ports, controller addr + secret published to the same UserDefaults keys, `BridgeStartWithLAN`. Also answers `get_traffic` / `get_version` / `get_log` in place of provider IPC.
- `VPNManager` routes `start`/`stop`/`sendMessage`/`switchMode`/`restartIfConnected` by mode; in local mode it never touches the system extension or NE preferences (no prompts for local-only users). Config building is extracted into `buildEffectiveConfigYAML()`, shared by both paths.
- The local port is deliberately **fixed** (not ephemeral like the internal tunnel ports) because it's user-facing; it's preflight bind-checked for a clear "port in use" error.
- Allow LAN keeps working (engine's `0.0.0.0` mixed listener). Per-App Proxy is hidden in local mode since nothing is intercepted.
- Home tab shows the running proxy address instead of the extension-approval prompt in local mode.
- New strings localized (zh-Hans included).

## Testing

- `EngineModeTests` — mode persistence/fallback, port clamping, `EphemeralPort.isTCPPortFree`.
- New integration test **HTTP request through HTTP proxy (mixed listener)** drives real traffic through the HTTP side of the in-process engine (the exact path local-proxy clients use) — returns 204.
- Full suite: 196 tests in 45 suites pass. Debug + Release builds pass; swiftlint clean (only the pre-existing TODO violation on main).