### PR TITLE
Fix NE TCP relay leak that pinned closed flows forever

### DIFF
--- a/BaoLianDengTests/EngineModeTests.swift
+++ b/BaoLianDengTests/EngineModeTests.swift
@@ -140,3 +140,72 @@ final class EngineModeTests: XCTestCase {
         XCTAssertTrue(EphemeralPort.isTCPPortFree(port))
     }
 }
+
+final class OnceResumeTests: XCTestCase {
+
+    func testResumeAfterArmDeliversValue() async {
+        let gate = OnceResume<Int>()
+        let value = await withCheckedContinuation { (cont: CheckedContinuation<Int, Never>) in
+            gate.arm(cont)
+            DispatchQueue.global().async {
+                gate.resume(7)
+            }
+        }
+        XCTAssertEqual(value, 7)
+    }
+
+    func testResumeBeforeArmParksValue() async {
+        let gate = OnceResume<Int?>()
+        gate.resume(nil)
+        let value = await withCheckedContinuation { (cont: CheckedContinuation<Int?, Never>) in
+            gate.arm(cont)
+        }
+        XCTAssertNil(value)
+    }
+
+    func testFirstResumeWins() async {
+        let gate = OnceResume<String>()
+        let value = await withCheckedContinuation { (cont: CheckedContinuation<String, Never>) in
+            gate.arm(cont)
+            gate.resume("first")
+            gate.resume("second")
+        }
+        XCTAssertEqual(value, "first")
+    }
+
+    /// Stands in for `relayTCP`: one direction finishes, `cancelAll` must
+    /// unblock a sibling sitting on a callback that will never fire
+    /// (`flow.readData` after `closeRead` is the real case).
+    func testSiblingCancelUnblocksNeverFiringCallback() async {
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try? await SOCKS5Client.withCancellableResult { (_: (Result<Void, Error>) -> Void) in
+                    // never resume
+                }
+            }
+            group.addTask {
+                // other direction already finished
+            }
+            _ = await group.next()
+            group.cancelAll()
+            await group.waitForAll()
+        }
+    }
+
+    func testCancelledWaitThrowsConnectionCancelled() async {
+        let task = Task {
+            try await SOCKS5Client.withCancellableResult { (_: (Result<Void, Error>) -> Void) in
+                // never resume
+            }
+        }
+        task.cancel()
+        do {
+            try await task.value
+            XCTFail("expected connectionCancelled")
+        } catch let error as SOCKS5Error {
+            XCTAssertEqual(error, .connectionCancelled)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+}

--- a/TransparentProxy/SOCKS5Client.swift
+++ b/TransparentProxy/SOCKS5Client.swift
@@ -6,7 +6,7 @@ import Foundation
 @preconcurrency import Network
 
 /// Errors thrown by the shared SOCKS5 / NWConnection helpers.
-enum SOCKS5Error: LocalizedError {
+enum SOCKS5Error: LocalizedError, Equatable {
     case connectionCancelled
     case unexpectedEOF
     case socks5AuthFailed
@@ -37,61 +37,77 @@ enum SOCKS5Client {
             port: NWEndpoint.Port(rawValue: port)!
         )
         let connection = NWConnection(to: endpoint, using: .tcp)
+        let gate = OnceResume<Result<NWConnection, Error>>()
 
-        return try await withCheckedThrowingContinuation { cont in
-            connection.stateUpdateHandler = { state in
-                switch state {
-                case .ready:
-                    connection.stateUpdateHandler = nil
-                    cont.resume(returning: connection)
-                case .failed(let error):
-                    connection.stateUpdateHandler = nil
-                    cont.resume(throwing: error)
-                case .cancelled:
-                    connection.stateUpdateHandler = nil
-                    cont.resume(throwing: SOCKS5Error.connectionCancelled)
-                default:
-                    break
+        return try await withTaskCancellationHandler {
+            let result = await withCheckedContinuation { (cont: CheckedContinuation<Result<NWConnection, Error>, Never>) in
+                gate.arm(cont)
+                connection.stateUpdateHandler = { state in
+                    switch state {
+                    case .ready:
+                        connection.stateUpdateHandler = nil
+                        gate.resume(.success(connection))
+                    case .failed(let error):
+                        connection.stateUpdateHandler = nil
+                        gate.resume(.failure(error))
+                    case .cancelled:
+                        connection.stateUpdateHandler = nil
+                        gate.resume(.failure(SOCKS5Error.connectionCancelled))
+                    default:
+                        break
+                    }
                 }
+                connection.start(queue: .global(qos: .userInitiated))
             }
-            connection.start(queue: .global(qos: .userInitiated))
+            return try result.get()
+        } onCancel: {
+            connection.cancel()
+            gate.resume(.failure(SOCKS5Error.connectionCancelled))
         }
     }
 
     static func sendAll(connection: NWConnection, data: Data) async throws {
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+        try await withCancellableResult(Void.self) { resume in
             connection.send(
                 content: data,
                 completion: .contentProcessed { error in
                     if let error = error {
-                        cont.resume(throwing: error)
+                        resume(.failure(error))
                     } else {
-                        cont.resume()
+                        resume(.success(()))
                     }
                 })
         }
     }
 
     static func readExact(connection: NWConnection, count: Int) async throws -> Data {
-        try await withCheckedThrowingContinuation { cont in
+        try await withCancellableResult(Data.self) { resume in
             connection.receive(
                 minimumIncompleteLength: count,
                 maximumLength: count
             ) { data, _, _, error in
                 if let error = error {
-                    cont.resume(throwing: error)
+                    resume(.failure(error))
                 } else if let data = data, data.count >= count {
-                    cont.resume(returning: data)
+                    resume(.success(data))
                 } else {
-                    cont.resume(throwing: SOCKS5Error.unexpectedEOF)
+                    resume(.failure(SOCKS5Error.unexpectedEOF))
                 }
             }
         }
     }
 
     static func readSome(connection: NWConnection) async throws -> Data {
-        try await withCheckedThrowingContinuation { cont in
-            readSomeLoop(connection: connection, cont: cont)
+        let gate = OnceResume<Result<Data, Error>>()
+        return try await withTaskCancellationHandler {
+            let result = await withCheckedContinuation { (cont: CheckedContinuation<Result<Data, Error>, Never>) in
+                gate.arm(cont)
+                readSomeLoop(connection: connection, gate: gate)
+            }
+            return try result.get()
+        } onCancel: {
+            connection.cancel()
+            gate.resume(.failure(SOCKS5Error.connectionCancelled))
         }
     }
 
@@ -103,26 +119,46 @@ enum SOCKS5Client {
     /// yet would end the relay prematurely.
     private static func readSomeLoop(
         connection: NWConnection,
-        cont: CheckedContinuation<Data, Error>
+        gate: OnceResume<Result<Data, Error>>
     ) {
         connection.receive(
             minimumIncompleteLength: 1,
             maximumLength: 65536
         ) { data, _, isComplete, error in
             if let error = error {
-                cont.resume(throwing: error)
+                gate.resume(.failure(error))
             } else if let data = data, !data.isEmpty {
-                cont.resume(returning: data)
+                gate.resume(.success(data))
             } else if isComplete {
                 // Genuine remote close / end-of-stream.
-                cont.resume(returning: Data())
+                gate.resume(.success(Data()))
             } else {
                 // No data, no error, not complete. `receive` with
                 // minimumIncompleteLength: 1 shouldn't invoke the callback in
                 // this shape, but if it ever does, keep waiting rather than
                 // reporting a false end-of-stream.
-                readSomeLoop(connection: connection, cont: cont)
+                readSomeLoop(connection: connection, gate: gate)
             }
+        }
+    }
+
+    /// Bridge a Network.framework / NE callback to async, resuming exactly
+    /// once. Task cancellation force-resumes with `connectionCancelled` so a
+    /// callback that never fires (common after `NWConnection.cancel()` or
+    /// `NEAppProxyFlow.close*`) cannot pin the caller forever.
+    static func withCancellableResult<T: Sendable>(
+        _: T.Type = T.self,
+        _ body: (@escaping @Sendable (Result<T, Error>) -> Void) -> Void
+    ) async throws -> T {
+        let gate = OnceResume<Result<T, Error>>()
+        return try await withTaskCancellationHandler {
+            let result = await withCheckedContinuation { (cont: CheckedContinuation<Result<T, Error>, Never>) in
+                gate.arm(cont)
+                body { gate.resume($0) }
+            }
+            return try result.get()
+        } onCancel: {
+            gate.resume(.failure(SOCKS5Error.connectionCancelled))
         }
     }
 
@@ -201,5 +237,55 @@ enum SOCKS5Client {
         request.append(UInt8(destPort >> 8))
         request.append(UInt8(destPort & 0xFF))
         return request
+    }
+}
+
+// MARK: - One-shot resume gate
+
+/// Resumes a continuation exactly once. `arm` and `resume` may race:
+/// `withTaskCancellationHandler.onCancel` can fire before the continuation
+/// exists, and an NE / Network.framework callback can fire after cancel.
+///
+/// First `resume` wins. A `resume` that arrives before `arm` is parked and
+/// delivered when `arm` runs, so the waiter cannot hang either way.
+final class OnceResume<T>: @unchecked Sendable {
+    private enum State {
+        case idle
+        case waiting(CheckedContinuation<T, Never>)
+        case pending(T)
+        case done
+    }
+
+    private let lock = NSLock()
+    private var state: State = .idle
+
+    func arm(_ continuation: CheckedContinuation<T, Never>) {
+        lock.lock()
+        switch state {
+        case .pending(let value):
+            state = .done
+            lock.unlock()
+            continuation.resume(returning: value)
+        case .idle:
+            state = .waiting(continuation)
+            lock.unlock()
+        case .waiting, .done:
+            lock.unlock()
+        }
+    }
+
+    func resume(_ value: T) {
+        lock.lock()
+        switch state {
+        case .waiting(let continuation):
+            state = .done
+            lock.unlock()
+            continuation.resume(returning: value)
+        case .idle:
+            state = .pending(value)
+            lock.unlock()
+        case .pending, .done:
+            lock.unlock()
+        }
     }
 }

--- a/TransparentProxy/TransparentProxyProvider.swift
+++ b/TransparentProxy/TransparentProxyProvider.swift
@@ -489,36 +489,32 @@ class TransparentProxyProvider: NETransparentProxyProvider {
         await withTaskGroup(of: Void.self) { group in
             // Flow → SOCKS5
             group.addTask {
-                while true {
-                    let data: Data? = await withOneShotFlowContinuation { resume in
-                        flow.readData(completionHandler: { data, error in
+                while !Task.isCancelled {
+                    let data: Data? = await withCancellableFlowContinuation(onCancel: nil) { resume in
+                        flow.readData { data, error in
                             if error != nil || data == nil || data!.isEmpty {
                                 resume(nil)
                             } else {
                                 resume(data)
                             }
-                        })
+                        }
                     }
-                    guard let data = data else { break }
+                    guard let data else { break }
                     do {
                         try await SOCKS5Client.sendAll(connection: connection, data: data)
                     } catch {
                         break
                     }
                 }
-                // Signal both sides so the other task can exit
-                connection.cancel()
-                flow.closeReadWithError(nil)
-                flow.closeWriteWithError(nil)
             }
 
             // SOCKS5 → Flow
             group.addTask {
-                while true {
+                while !Task.isCancelled {
                     do {
                         let data = try await SOCKS5Client.readSome(connection: connection)
                         guard !data.isEmpty else { break }
-                        let writeOK: Bool = await withOneShotFlowContinuation { resume in
+                        let writeOK: Bool = await withCancellableFlowContinuation(onCancel: false) { resume in
                             flow.write(data) { error in
                                 resume(error == nil)
                             }
@@ -528,11 +524,24 @@ class TransparentProxyProvider: NETransparentProxyProvider {
                         break
                     }
                 }
-                // Signal both sides so the other task can exit
-                connection.cancel()
-                flow.closeReadWithError(nil)
-                flow.closeWriteWithError(nil)
             }
+
+            // First direction to finish tears the sibling down.
+            //
+            // `closeRead`/`closeWrite` and `NWConnection.cancel()` do **not**
+            // reliably invoke a pending NE / Network.framework callback. The
+            // previous code waited for both tasks and only "signalled" by
+            // closing; the sibling then sat forever in `readData`/`receive`,
+            // retaining the flow, the SOCKS connection, and three Tasks.
+            // Heap on a 2-day process showed ~11k of each. `cancelAll()`
+            // force-resumes the pending continuation via
+            // `withTaskCancellationHandler`.
+            _ = await group.next()
+            connection.cancel()
+            flow.closeReadWithError(nil)
+            flow.closeWriteWithError(nil)
+            group.cancelAll()
+            await group.waitForAll()
         }
     }
 
@@ -910,33 +919,28 @@ extension Collection {
 
 // MARK: - Flow continuation helper
 
-/// Bridge a flow completion-handler callback to async, resuming the
-/// continuation exactly once even if the handler fires more than once during
-/// teardown races.
+/// Bridge a flow completion-handler callback to async, resuming exactly once
+/// even if the handler fires more than once during teardown races — or never
+/// fires at all after `closeRead`/`closeWrite`.
 ///
 /// `NEAppProxyTCPFlow.readData`/`write` belong to the same flow family as
-/// `NEAppProxyFlow.open` (see `TransparentProxyProvider.openFlow`), whose
-/// completion handler can fire multiple times during teardown. A bare
-/// `withCheckedContinuation` would then call `cont.resume` twice and trap with
-/// "SWIFT TASK CONTINUATION MISUSE" (EXC_BREAKPOINT), killing the extension.
-/// The `resumed` flag (guarded by a lock, since the handler may fire on
-/// different threads) makes resumption happen exactly once.
-private func withOneShotFlowContinuation<T>(
-    _ body: (@escaping (T) -> Void) -> Void
+/// `NEAppProxyFlow.open` (see `TransparentProxyProvider.openFlow`). The
+/// completion can fire multiple times (a bare `withCheckedContinuation`
+/// would trap "SWIFT TASK CONTINUATION MISUSE") **or never**, which is how
+/// finished TCP relays leaked ~11k flows. Task cancellation delivers
+/// `onCancel` so the waiter cannot pin the flow forever.
+private func withCancellableFlowContinuation<T: Sendable>(
+    onCancel: T,
+    _ body: (@escaping @Sendable (T) -> Void) -> Void
 ) async -> T {
-    await withCheckedContinuation { (cont: CheckedContinuation<T, Never>) in
-        let lock = NSLock()
-        var resumed = false
-        body { value in
-            lock.lock()
-            if resumed {
-                lock.unlock()
-                return
-            }
-            resumed = true
-            lock.unlock()
-            cont.resume(returning: value)
+    let gate = OnceResume<T>()
+    return await withTaskCancellationHandler {
+        await withCheckedContinuation { (cont: CheckedContinuation<T, Never>) in
+            gate.arm(cont)
+            body { gate.resume($0) }
         }
+    } onCancel: {
+        gate.resume(onCancel)
     }
 }
 


### PR DESCRIPTION
## Summary
- `relayTCP` used to wait for both directions after one side closed. `NEAppProxyTCPFlow.readData` / `NWConnection.receive` often never complete after `closeRead`/`cancel()`, so the sibling Task hung forever.
- A 2-day live process had **~11k** leaked `NEAppProxyTCPFlow` + `NWConnection` objects and a **10.8GB** heap, while kernel sockets and the engine `/connections` table were healthy.
- First finished direction now cancels the sibling. Pending NE / Network.framework callbacks resume on `Task` cancellation via `OnceResume`, so a missing completion cannot pin the flow.

## Test plan
- [x] `swiftlint lint --strict` on the changed files
- [x] `OnceResumeTests` + `EngineModeTests` via `xcodebuild test` (11 tests)
- [x] Standalone harness: sibling cancel, 500-relay soak (0.001s), real `NWConnection.readSome` + `Task.cancel`
- [x] Installed Release 6.0 locally: fresh extension was **7MB / 31 flows**; after 40 short HTTPS requests still **7MB / 31 flows** (old process was 10.8GB / 11.5k flows)