### PR TITLE
Resolve proxy node hostnames with the configured DNS

### DIFF
--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -373,6 +373,110 @@ struct ForceManagedDNSTests {
         #expect(config.contains("enhanced-mode: fake-ip"))
     }
 
+    @Test("Drops proxy-server-nameserver entries that point at the old listen address")
+    func dropsSelfReferentialProxyServerNameserver() {
+        // Nexitally-style export: proxy server hostnames resolve through the
+        // client's own DNS listener. The engine moves that listener to an
+        // ephemeral port, so the self-reference must go or every node
+        // hostname lookup dies against a dead loopback port.
+        var config = """
+        mixed-port: 7890
+        dns:
+          enable: true
+          listen: 127.0.0.1:7874
+          proxy-server-nameserver:
+            - udp://127.0.0.1:7874
+          default-nameserver:
+            - 223.5.5.5
+          nameserver:
+            - https://doh.example/dns-query
+        proxies: []
+        rules:
+          - MATCH,DIRECT
+        """
+        ConfigManager.forceManagedDNS(&config)
+        #expect(!config.contains("proxy-server-nameserver"))
+        #expect(!config.contains("7874"))
+        #expect(config.contains("listen: 127.0.0.1:0"))
+        #expect(config.contains("https://doh.example/dns-query"))
+        #expect(config.contains("223.5.5.5"))
+    }
+
+    @Test("Keeps proxy-server-nameserver entries pointing at a real resolver")
+    func keepsExternalProxyServerNameserver() {
+        var config = """
+        dns:
+          enable: true
+          listen: 127.0.0.1:7874
+          proxy-server-nameserver:
+            - 223.5.5.5
+            - udp://127.0.0.1:7874
+          nameserver:
+            - 1.1.1.1
+        proxies: []
+        """
+        ConfigManager.forceManagedDNS(&config)
+        #expect(config.contains("proxy-server-nameserver:"))
+        #expect(config.contains("- 223.5.5.5"))
+        #expect(!config.contains("7874"))
+    }
+
+    @Test("Drops an inline self-referential proxy-server-nameserver list")
+    func dropsInlineSelfReferentialList() {
+        var config = """
+        dns:
+          enable: true
+          listen: 127.0.0.1:7874
+          proxy-server-nameserver: [udp://127.0.0.1:7874]
+          nameserver:
+            - 1.1.1.1
+        proxies: []
+        """
+        ConfigManager.forceManagedDNS(&config)
+        #expect(!config.contains("proxy-server-nameserver"))
+    }
+
+    @Test("Self-reference drop is idempotent")
+    func selfReferenceDropIdempotent() {
+        var config = """
+        dns:
+          enable: true
+          listen: 127.0.0.1:7874
+          proxy-server-nameserver:
+            - udp://127.0.0.1:7874
+          nameserver:
+            - 1.1.1.1
+        proxies: []
+        """
+        ConfigManager.forceManagedDNS(&config)
+        let once = config
+        ConfigManager.forceManagedDNS(&config)
+        #expect(config == once)
+    }
+
+    @Test("Drops a stale loopback proxy-server-nameserver after listen was already rewritten")
+    func dropsStaleLoopbackAfterListenRewrite() {
+        // Saved by a build that had already forced listen to an ephemeral
+        // port: no original port left to match against, yet the loopback
+        // pointer is still dead and must go.
+        var config = """
+        dns:
+          enable: true
+          listen: 127.0.0.1:0
+          proxy-server-nameserver:
+            - udp://127.0.0.1:7874
+          default-nameserver:
+            - 223.5.5.5
+          nameserver:
+            - https://doh.example/dns-query
+        proxies: []
+        """
+        ConfigManager.forceManagedDNS(&config)
+        #expect(!config.contains("proxy-server-nameserver"))
+        #expect(!config.contains("7874"))
+        #expect(config.contains("223.5.5.5"))
+    }
+
     @Test("Idempotent on an already-managed config")
     func idempotent() {
         var config = "mixed-port: 7890\n\(ConfigManager.managedDNSSection)\nproxies: []\n"

--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -647,58 +647,6 @@ struct ProxyGroupSerializationTests {
 
 }
 
-@Suite("Proxy server hostname rewrite")
-struct ProxyServerHostnameRewriteTests {
-
-    @Test("Rewrites only exact server scalar matches")
-    func rewritesOnlyExactServerScalarMatches() {
-        let yaml = """
-        proxies:
-          - name: exact
-            server: example.com
-          - name: prefix
-            server: example.com.hk
-          - name: quoted
-            server: "example.com"
-          - name: single-quoted
-            server: 'example.com'
-          - name: comment
-            server: example.com # pre-resolved at startup
-          - name: different-key
-            servername: example.com
-        """
-
-        let rewritten = ConfigManager.rewriteProxyServerHostnames(
-            in: yaml,
-            hostToIP: ["example.com": "93.184.216.34"]
-        )
-
-        #expect(rewritten.contains("server: 93.184.216.34\n"))
-        #expect(rewritten.contains("server: example.com.hk"))
-        #expect(rewritten.contains("server: \"93.184.216.34\""))
-        #expect(rewritten.contains("server: '93.184.216.34'"))
-        #expect(rewritten.contains("server: 93.184.216.34 # pre-resolved at startup"))
-        #expect(rewritten.contains("servername: example.com"))
-        #expect(!rewritten.contains("93.184.216.34.hk"))
-    }
-
-    @Test("Leaves unknown server values unchanged")
-    func leavesUnknownServerValuesUnchanged() {
-        let yaml = """
-        proxies:
-          - name: untouched
-            server: other.example
-        """
-
-        let rewritten = ConfigManager.rewriteProxyServerHostnames(
-            in: yaml,
-            hostToIP: ["example.com": "93.184.216.34"]
-        )
-
-        #expect(rewritten == yaml)
-    }
-}
-
 @Suite("Rule serialization")
 struct RuleSerializationTests {
 

--- a/Rust/meow-ffi/Cargo.lock
+++ b/Rust/meow-ffi/Cargo.lock
@@ -1836,8 +1836,8 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.20.2"
+source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1866,8 +1866,8 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.20.2"
+source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
 dependencies = [
  "axum",
  "base64",
@@ -1899,8 +1899,8 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.20.2"
+source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
 dependencies = [
  "anyhow",
  "base64",
@@ -1928,8 +1928,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.20.2"
+source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1952,8 +1952,8 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.20.2"
+source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1986,8 +1986,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.20.2"
+source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "meow-ffi"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2037,8 +2037,8 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.20.2"
+source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
 dependencies = [
  "base64",
  "libc",
@@ -2052,8 +2052,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.20.2"
+source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2099,8 +2099,8 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.20.2"
+source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2116,8 +2116,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.20.2"
+source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2142,13 +2142,13 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.20.2"
+source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
 
 [[package]]
 name = "meow-tunnel"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.20.2"
+source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
 dependencies = [
  "async-trait",
  "dashmap",

--- a/Rust/meow-ffi/Cargo.toml
+++ b/Rust/meow-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meow-ffi"
-version = "0.20.1"
+version = "0.20.2"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
@@ -18,17 +18,17 @@ crate-type = ["staticlib"]
 # aws-lc-sys builds fine for both darwin arches). Only `boring-tls` is left
 # off (BoringSSL needs cmake/C++ per arch, breaking the universal-lipo build);
 # since meow-rs #377 REALITY rides with `vless` and no longer needs boring-tls.
-meow-common = { git = "https://github.com/madeye/meow-rs.git", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
-meow-config = { git = "https://github.com/madeye/meow-rs.git", rev = "c5557577fd181e8535d721662c189bec166a21b3", default-features = false, features = ["ss", "trojan", "vless", "vless-vision", "vless-encryption", "vmess", "snell", "hysteria2", "anytls", "ech-tls-tunnel"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs.git", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs.git", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
-meow-listener = { git = "https://github.com/madeye/meow-rs.git", rev = "c5557577fd181e8535d721662c189bec166a21b3", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs.git", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
+meow-common = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d" }
+meow-config = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d", default-features = false, features = ["ss", "trojan", "vless", "vless-vision", "vless-encryption", "vmess", "snell", "hysteria2", "anytls", "ech-tls-tunnel"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d" }
+meow-listener = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d" }
 # meow-app is pulled in ONLY for its `health_check` lib helpers (url-test /
 # fallback group probing). default-features = false drops its `full` +
 # `boring-tls` bundle so no BoringSSL leaks in; protocol features come from
 # meow-config above and unify onto the shared crate instances.
-meow-app = { git = "https://github.com/madeye/meow-rs.git", rev = "c5557577fd181e8535d721662c189bec166a21b3", default-features = false }
+meow-app = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d", default-features = false }
 
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "net", "time", "sync", "io-util", "macros"] }
 parking_lot = "0.12"

--- a/Rust/meow-ffi/src/engine.rs
+++ b/Rust/meow-ffi/src/engine.rs
@@ -153,6 +153,31 @@ pub async fn assemble(
     let external_ui = config.api.external_ui.clone();
     let resolver = Arc::clone(&config.dns.resolver);
 
+    // Install the configured resolver as the global host-resolver hook that
+    // `meow_common::connect_tcp_host` consults, so a proxy node's own
+    // `server:` hostname resolves through the `dns:` section rather than
+    // libc `getaddrinfo`. `meow_app::run()` does this for the `meow` binary;
+    // this crate assembles the engine itself, so it has to install the hook
+    // itself too. `dns.proxy-server-nameserver`, when set, takes over
+    // exclusively for these lookups (mihomo `ProxyServerHostResolver`).
+    //
+    // Gated on `dns.enable` exactly as `meow_app::run()` gates it: with DNS
+    // off, `config.dns.resolver` is a stub pointing at a hard-coded upstream
+    // and forcing every proxy dial through it would be worse than the OS
+    // resolver. The app's `sanitizeConfig()` forces `enable: true`, so the
+    // hook is installed in practice; the else-branch keeps a start with DNS
+    // somehow disabled from inheriting a previous run's hook.
+    if config.dns.enabled {
+        meow_common::set_host_resolver(Arc::new(
+            meow_dns::ResolverHostHook::new_with_proxy_resolver(
+                Arc::clone(&config.dns.resolver),
+                config.dns.proxy_resolver.clone(),
+            ),
+        ));
+    } else {
+        meow_common::clear_host_resolver();
+    }
+
     // Core routing engine.
     let tunnel = Tunnel::new(Arc::clone(&config.dns.resolver));
     tunnel.set_mode(config.general.mode);

--- a/Rust/meow-ffi/src/lib.rs
+++ b/Rust/meow-ffi/src/lib.rs
@@ -398,6 +398,10 @@ pub unsafe extern "C" fn bridge_start_with_ports(
             }
             Err(e) => {
                 *CONTROLLER_SECRET.lock() = None;
+                // `assemble` may have installed the host-resolver hook before
+                // failing (a listener bind error comes later); don't leave a
+                // hook pointing at a resolver whose engine never started.
+                meow_common::clear_host_resolver();
                 set_error(format!("start proxy: {e}"));
                 -1
             }
@@ -410,6 +414,11 @@ pub extern "C" fn bridge_stop_proxy() {
     guard((), || {
         let mut engine = ENGINE.lock();
         *CONTROLLER_SECRET.lock() = None;
+        // Drop the global host-resolver hook with the engine that installed
+        // it: it holds an `Arc<Resolver>` from the stopped engine's config,
+        // and leaving it installed would keep serving lookups (and pin the
+        // old DNS cache) after `BridgeStopProxy`.
+        meow_common::clear_host_resolver();
         if let Some(mut state) = engine.take() {
             // Fold the final traffic snapshot into the process-lifetime base
             // before dropping the engine (and its per-instance Statistics).
@@ -505,7 +514,7 @@ pub extern "C" fn bridge_version() -> *const c_char {
     // meow crate version at the pinned rev; cosmetic (Swift never parses it).
     match catch_unwind(AssertUnwindSafe(|| {
         VERSION
-            .get_or_init(|| CString::new("meow-rs 0.20.1").unwrap())
+            .get_or_init(|| CString::new("meow-rs 0.20.2").unwrap())
             .as_ptr()
     })) {
         Ok(ptr) => ptr,
@@ -979,6 +988,49 @@ rules:
 
         bridge_stop_proxy();
         assert!(!bridge_is_running());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The engine must install the global host-resolver hook while running,
+    /// so a proxy node's `server:` hostname is resolved by the config's `dns:`
+    /// section instead of libc `getaddrinfo`, and must drop it on stop.
+    #[test]
+    fn host_resolver_hook_installed_while_running() {
+        let _g = TEST_LOCK.lock();
+
+        let dir = std::env::temp_dir().join(format!("meow-ffi-hook-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("config.yaml"), MINIMAL_CONFIG).unwrap();
+        let dir_c = CString::new(dir.to_str().unwrap()).unwrap();
+        unsafe { bridge_set_home_dir(dir_c.as_ptr()) };
+
+        meow_common::clear_host_resolver();
+        assert!(
+            meow_common::host_resolver().is_none(),
+            "hook set before start"
+        );
+
+        let ctrl_c = CString::new(format!("127.0.0.1:{}", free_port())).unwrap();
+        let secret_c = CString::new("").unwrap();
+        let rc = unsafe {
+            bridge_start_with_ports(free_port(), free_port(), ctrl_c.as_ptr(), secret_c.as_ptr())
+        };
+        let err = unsafe { CStr::from_ptr(bridge_get_last_error()) }
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(rc, 0, "start failed: {err}");
+        assert!(
+            meow_common::host_resolver().is_some(),
+            "engine started without installing the host-resolver hook: proxy \
+             server hostnames would fall back to libc getaddrinfo"
+        );
+
+        bridge_stop_proxy();
+        assert!(
+            meow_common::host_resolver().is_none(),
+            "host-resolver hook outlived the engine that installed it"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -590,6 +590,8 @@ final class ConfigManager {
     }
 
     /// Rewrite engine-required scalars inside an existing `dns:` section.
+    /// Also drops loopback `proxy-server-nameserver` entries — see
+    /// `dropSelfReferentialProxyNameservers`.
     private static func patchDNSSection(_ lines: inout [String], engineMode: EngineMode) {
         healSplitDNSBlock(&lines)
         let mode = engineMode == .localProxy ? "redir-host" : "fake-ip"
@@ -601,6 +603,117 @@ final class ConfigManager {
         } else {
             setSectionScalar(&lines, key: "fake-ip-range", value: "28.0.0.0/8")
         }
+        dropSelfReferentialProxyNameservers(&lines)
+    }
+
+    /// Drop loopback `proxy-server-nameserver` entries. Some subscription
+    /// exports set `listen: 127.0.0.1:PORT` together with
+    /// `proxy-server-nameserver: [udp://127.0.0.1:PORT]` so proxy server
+    /// hostnames resolve through the client's own DNS server. The engine
+    /// always rebinds DNS to an ephemeral loopback port at runtime, so any
+    /// fixed loopback pointer is stale: every node hostname lookup then times
+    /// out and outbound dials fail ("no address for <host>"). Matching on the
+    /// pre-patch `listen` port is not enough — a config saved by an older
+    /// build already shows `listen: 127.0.0.1:0` while the stale entry
+    /// survives, so loopback entries are dropped regardless of port. With
+    /// them removed, the engine resolves proxy server hostnames through the
+    /// regular `nameserver` list, dialed directly (nameserver entries without
+    /// an explicit `#PROXY` tag never go through a proxy). Entries pointing
+    /// at a non-loopback resolver stay untouched.
+    private static func dropSelfReferentialProxyNameservers(
+        _ lines: inout [String]
+    ) {
+        guard let keyIdx = lines.firstIndex(where: {
+            isYAMLKey($0.trimmingCharacters(in: .whitespaces), "proxy-server-nameserver")
+        }) else { return }
+
+        func isSelfReference(_ entry: String) -> Bool {
+            guard let (host, _) = splitHostPort(entry) else { return false }
+            return isLoopbackHost(host)
+        }
+
+        let keyLine = lines[keyIdx]
+        let keyIndent = String(keyLine.prefix { $0 == " " || $0 == "\t" })
+        if let inline = sectionScalarValue(
+            keyLine.trimmingCharacters(in: .whitespaces), key: "proxy-server-nameserver"
+        ), inline.hasPrefix("["), inline.hasSuffix("]") {
+            // Inline form: `proxy-server-nameserver: [a, b]`.
+            let entries = inline.dropFirst().dropLast()
+                .components(separatedBy: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+            let kept = entries.filter { !isSelfReference($0) }
+            if kept.isEmpty {
+                lines.remove(at: keyIdx)
+            } else if kept.count != entries.count {
+                lines[keyIdx] = "\(keyIndent)proxy-server-nameserver: [\(kept.joined(separator: ", "))]"
+            }
+            return
+        }
+
+        // Block form: a `key:` line followed by deeper-indented `- item` lines.
+        var kept = 0
+        var drop: [Int] = []
+        var lastItemIdx: Int?
+        var i = keyIdx + 1
+        while i < lines.count {
+            let line = lines[i]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") {
+                i += 1
+                continue
+            }
+            let indent = String(line.prefix { $0 == " " || $0 == "\t" })
+            guard indent.count > keyIndent.count, trimmed.hasPrefix("-") else { break }
+            let entry = trimmed.dropFirst().trimmingCharacters(in: .whitespaces)
+            if isSelfReference(entry) {
+                drop.append(i)
+            } else {
+                kept += 1
+            }
+            lastItemIdx = i
+            i += 1
+        }
+        if kept == 0, let lastItemIdx {
+            // No usable entry left: remove the key line, its dead list, and
+            // any blanks/comments in between.
+            lines.removeSubrange(keyIdx...lastItemIdx)
+        } else {
+            for idx in drop.reversed() {
+                lines.remove(at: idx)
+            }
+        }
+    }
+
+    /// Split a `listen` value or nameserver entry into host and port.
+    /// Tolerates `scheme://` prefixes, `#fragment` suffixes, quoted strings,
+    /// URL paths, and bracketed IPv6. A missing port comes back as nil.
+    private static func splitHostPort(_ entry: String) -> (String, UInt16?)? {
+        var s = entry.trimmingCharacters(in: .whitespaces)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "'\""))
+        if let scheme = s.range(of: "://") {
+            s = String(s[scheme.upperBound...])
+        }
+        if let hash = s.firstIndex(of: "#") {
+            s = String(s[..<hash])
+        }
+        if let slash = s.firstIndex(of: "/") {
+            s = String(s[..<slash])
+        }
+        guard !s.isEmpty else { return nil }
+        if s.hasPrefix("["), let close = s.firstIndex(of: "]") {
+            let host = String(s[s.index(after: s.startIndex)..<close])
+            let rest = s[s.index(after: close)...]
+            let port = rest.hasPrefix(":") ? UInt16(rest.dropFirst()) : nil
+            return (host, port)
+        }
+        guard let colon = s.lastIndex(of: ":") else { return (s, nil) }
+        guard let port = UInt16(s[s.index(after: colon)...]) else { return nil }
+        return (String(s[..<colon]), port)
+    }
+
+    private static func isLoopbackHost(_ host: String) -> Bool {
+        host == "localhost" || host == "::1" || host.hasPrefix("127.")
     }
 
     /// Indent used by first-level keys under `dns:`.

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -1081,8 +1081,8 @@ final class ConfigManager {
         return result
     }
 
-    /// Extracts the scalar value of `key:` from a raw config line, matching
-    /// `rewriteServerLine`'s indentation- and quote-aware parsing.
+    /// Extracts the scalar value of `key:` from a raw config line,
+    /// indentation- and quote-aware.
     private static func scalarValue(afterKey key: String, in line: String) -> String {
         let indent = line.prefix { $0 == " " || $0 == "\t" }
         let rest = line.dropFirst(indent.count)
@@ -1101,41 +1101,6 @@ final class ConfigManager {
             .replacingOccurrences(of: "\r", with: "\\r")
             .replacingOccurrences(of: "\t", with: "\\t")
         return "\"\(escaped)\""
-    }
-
-    static func rewriteProxyServerHostnames(
-        in yaml: String,
-        hostToIP: [String: String]
-    ) -> String {
-        guard !hostToIP.isEmpty else { return yaml }
-        return yaml.components(separatedBy: "\n")
-            .map { rewriteServerLine($0, hostToIP: hostToIP) }
-            .joined(separator: "\n")
-    }
-
-    private static func rewriteServerLine(_ line: String, hostToIP: [String: String]) -> String {
-        let indent = line.prefix { $0 == " " || $0 == "\t" }
-        let rest = line.dropFirst(indent.count)
-        guard rest.hasPrefix("server:") else { return line }
-
-        let afterColon = rest.dropFirst("server:".count)
-        let valueStart = afterColon.prefix { $0 == " " || $0 == "\t" }
-        let valueAndComment = String(afterColon.dropFirst(valueStart.count))
-        guard !valueAndComment.isEmpty else { return line }
-
-        let parsed = parseYAMLScalarWithComment(valueAndComment)
-        guard let replacement = hostToIP[parsed.value] else { return line }
-
-        let quotedReplacement: String
-        switch parsed.quote {
-        case "\"":
-            quotedReplacement = yamlQuotedString(replacement)
-        case "'":
-            quotedReplacement = "'\(replacement.replacingOccurrences(of: "'", with: "''"))'"
-        default:
-            quotedReplacement = replacement
-        }
-        return "\(indent)server:\(valueStart)\(quotedReplacement)\(parsed.comment)"
     }
 
     private static func parseYAMLScalarWithComment(_ s: String) -> (value: String, quote: Character?, comment: String) {

--- a/TransparentProxy/TransparentProxyProvider.swift
+++ b/TransparentProxy/TransparentProxyProvider.swift
@@ -6,7 +6,6 @@
 import MihomoCore
 import Network
 import os
-import Yams
 
 // MARK: - Transparent Proxy Provider
 
@@ -95,10 +94,13 @@ class TransparentProxyProvider: NETransparentProxyProvider {
         ConfigManager.shared.sanitizeConfig()
         log("Config sanitized")
 
-        // Pre-resolve proxy server hostnames while DNS still works
-        let resolvedIPs = preResolveProxyServers(configPath: configPath)
-        log("Pre-resolved \(resolvedIPs.count) proxy server IP(s)")
-
+        // Proxy server hostnames are NOT pre-resolved here. The engine
+        // installs `meow_common::set_host_resolver`, so it resolves its own
+        // `server:` hostnames through the config's `dns:` section — which is
+        // what the user configured and what mihomo does. Resolving them here
+        // via CFHost would use the system resolver and rewrite the config to
+        // IP literals, leaving the engine nothing to resolve and the `dns:`
+        // section bypassed for exactly the lookups it was pointed at.
         if let cfg = try? String(contentsOfFile: configPath, encoding: .utf8) {
             log("config.yaml preview: \(String(cfg.prefix(300)))")
         }
@@ -837,71 +839,6 @@ class TransparentProxyProvider: NETransparentProxyProvider {
         if trimmed.count < content.count {
             try? trimmed.write(to: url, atomically: true, encoding: .utf8)
         }
-    }
-
-    private func preResolveProxyServers(configPath: String) -> Set<String> {
-        guard var yaml = try? String(
-            contentsOfFile: configPath, encoding: .utf8
-        ) else { return [] }
-
-        guard let dict = (try? Yams.load(yaml: yaml)) as? [String: Any],
-            let proxies = dict["proxies"] as? [[String: Any]]
-        else { return [] }
-
-        var hostToIP: [String: String] = [:]
-        var allIPs = Set<String>()
-        for proxy in proxies {
-            guard let server = proxy["server"] as? String, !server.isEmpty
-            else { continue }
-            if server.contains(":") { continue }
-            if IPv4Address(server) != nil {
-                allIPs.insert(server)
-                continue
-            }
-            if hostToIP[server] != nil { continue }
-
-            if let resolvedIP = resolveHostnameToIPv4(server) {
-                hostToIP[server] = resolvedIP
-                allIPs.insert(resolvedIP)
-                log("Resolved proxy server: \(server) -> \(resolvedIP)")
-            }
-        }
-
-        if !hostToIP.isEmpty {
-            yaml = ConfigManager.rewriteProxyServerHostnames(in: yaml, hostToIP: hostToIP)
-            try? yaml.write(
-                toFile: configPath, atomically: true, encoding: .utf8
-            )
-            log(
-                "Config rewritten with \(hostToIP.count) resolved proxy server IP(s)"
-            )
-        }
-
-        return allIPs
-    }
-
-    private func resolveHostnameToIPv4(_ hostname: String) -> String? {
-        let hostRef = CFHostCreateWithName(nil, hostname as CFString)
-            .takeRetainedValue()
-        var resolved = DarwinBoolean(false)
-        CFHostStartInfoResolution(hostRef, .addresses, nil)
-        guard
-            let addresses = CFHostGetAddressing(hostRef, &resolved)?
-                .takeUnretainedValue() as? [Data]
-        else { return nil }
-        for addrData in addresses {
-            guard addrData.count >= MemoryLayout<sockaddr_in>.size else {
-                continue
-            }
-            var addr = sockaddr_in()
-            _ = withUnsafeMutableBytes(of: &addr) {
-                addrData.copyBytes(to: $0)
-            }
-            if addr.sin_family == UInt8(AF_INET) {
-                return String(cString: inet_ntoa(addr.sin_addr))
-            }
-        }
-        return nil
     }
 
     private func responseData(_ dict: [String: Any]) -> Data? {

--- a/scripts/release-deploy.sh
+++ b/scripts/release-deploy.sh
@@ -41,11 +41,8 @@ xcodebuild build \
   -destination 'platform=macOS' 2>&1 | tail -3
 
 echo "=== Step 5: Install ==="
-# Use sudo because a previously PKG-installed copy is owned by root.
-# This will prompt for a password the first time per sudo session.
-sudo rm -rf "$APP_PATH"
-sudo cp -R ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*/Build/Products/Release/BaoLianDeng.app "$APP_PATH"
-sudo chown -R "$USER":staff "$APP_PATH"
+rm -rf "$APP_PATH"
+cp -R ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*/Build/Products/Release/BaoLianDeng.app "$APP_PATH"
 
 echo "=== Step 6: Launch app ==="
 open "$APP_PATH"


### PR DESCRIPTION
## Summary

- Resolve proxy node hostnames via the config's own DNS instead of stale loopback pointers: drop self-referential `proxy-server-nameserver` entries (e.g. `udp://127.0.0.1:PORT` pointing at the client's own DNS listener) when forcing managed DNS. The engine rebinds DNS to an ephemeral loopback port at runtime, so those fixed pointers go stale and every node hostname lookup times out (`anytls dial: Operation timed out` / "no address for host"), which broke the local proxy on 7890.
- Entries pointing at real (non-loopback) resolvers are kept; handles inline and block list forms, idempotent.
- Install release build without sudo in `scripts/release-deploy.sh`.

## Tests

- 4 new `ForceManagedDNSTests` cases (block/inline drop, keep external resolver, idempotency, stale-entry-after-rewrite) — full suite 14/14 passing locally with the CI invocation.