### PR TITLE
Enable boring-tls so client-fingerprint actually spoofs the Client Hello

### DIFF
--- a/Rust/meow-ffi/Cargo.lock
+++ b/Rust/meow-ffi/Cargo.lock
@@ -368,6 +368,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "boring"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47bf58283ad1560da95ab8dcbb6c71e18a89df30e6011e3582ddf755abe55c4a"
+dependencies = [
+ "bitflags",
+ "boring-sys",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+]
+
+[[package]]
+name = "boring-sys"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6993efa9d9f0ebf3b0c02c8e868cfe37d0854cd021d51204480a91ce23d6e444"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "fs_extra",
+ "fslock",
+]
+
+[[package]]
 name = "borsh"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +965,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +1013,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2122,6 +2184,8 @@ dependencies = [
  "aes-gcm",
  "async-trait",
  "base64",
+ "boring",
+ "boring-sys",
  "bytes",
  "futures-util",
  "h2",
@@ -2133,9 +2197,11 @@ dependencies = [
  "sha2",
  "thiserror 2.0.20",
  "tokio",
+ "tokio-boring",
  "tokio-rustls",
  "tokio-tungstenite",
  "tracing",
+ "webpki-root-certs",
  "webpki-roots 0.26.11",
  "x25519-dalek",
 ]
@@ -2349,6 +2415,17 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "parking_lot"
@@ -3463,6 +3540,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-boring"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80b0cb8797d5f375289c1d478929ac08f98c535d6d000dcd01de05ad703782cd"
+dependencies = [
+ "boring",
+ "boring-sys",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3969,6 +4057,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Rust/meow-ffi/Cargo.toml
+++ b/Rust/meow-ffi/Cargo.toml
@@ -15,19 +15,22 @@ crate-type = ["staticlib"]
 # meow-rs kernel crates, pinned to a single git rev (== local checkout HEAD).
 # Protocol features mirror meow-app's `full` protocol set, INCLUDING
 # `ech-tls-tunnel` (pulls rustls/aws_lc_rs via meow-transport's `ech` feature —
-# aws-lc-sys builds fine for both darwin arches). Only `boring-tls` is left
-# off (BoringSSL needs cmake/C++ per arch, breaking the universal-lipo build);
-# since meow-rs #377 REALITY rides with `vless` and no longer needs boring-tls.
+# aws-lc-sys builds fine for both darwin arches) and `boring-tls`, which is
+# what makes `client-fingerprint:` (uTLS Client Hello spoofing) actually take
+# effect; without it meow-transport parses the key, warns once, and falls back
+# to a plain rustls Client Hello. boring-sys vendors BoringSSL and builds it
+# with cmake per arch — both darwin arches compile, so the universal lipo
+# still works (see Makefile).
 meow-common = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d" }
-meow-config = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d", default-features = false, features = ["ss", "trojan", "vless", "vless-vision", "vless-encryption", "vmess", "snell", "hysteria2", "anytls", "ech-tls-tunnel"] }
+meow-config = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d", default-features = false, features = ["ss", "trojan", "vless", "vless-vision", "vless-encryption", "vmess", "snell", "hysteria2", "anytls", "ech-tls-tunnel", "boring-tls"] }
 meow-dns = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d" }
 meow-tunnel = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d" }
 meow-listener = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d", default-features = false, features = ["listener-mixed"] }
 meow-api = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d" }
 # meow-app is pulled in ONLY for its `health_check` lib helpers (url-test /
-# fallback group probing). default-features = false drops its `full` +
-# `boring-tls` bundle so no BoringSSL leaks in; protocol features come from
-# meow-config above and unify onto the shared crate instances.
+# fallback group probing). default-features = false drops its `full` bundle;
+# protocol features (including boring-tls) come from meow-config above and
+# unify onto the shared crate instances.
 meow-app = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d", default-features = false }
 
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "net", "time", "sync", "io-util", "macros"] }
@@ -37,7 +40,8 @@ anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "std", "registry"] }
 # ring-backed rustls for our own diagnostics client. Note aws_lc_rs is now in
-# the tree anyway via meow-transport's `ech` feature (ech-tls-tunnel above).
+# the tree anyway via meow-transport's `ech` feature (ech-tls-tunnel above),
+# and BoringSSL via `boring-tls`.
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
 # Diagnostics HTTP client: SOCKS5 + rustls(ring); no default (native-tls/openssl).
 reqwest = { version = "0.12", default-features = false, features = ["socks", "json", "rustls-tls"] }


### PR DESCRIPTION
## Problem

`meow-ffi` built `meow-rs` **without** the `boring-tls` feature, so `client-fingerprint:` was parsed, warned about once, and then ignored — every node handshaked with rustls's Client Hello regardless of the requested uTLS profile. The app even emits `client-fingerprint:` from a subscription URI's `fp=` param (`SubscriptionModels.swift`), so the key was reaching a no-op path.

## Fix

Add `boring-tls` to `meow-config`'s feature list in `Rust/meow-ffi/Cargo.toml` (and update the stale comments explaining why it was off).

The original reason for leaving it off — BoringSSL needs cmake/C++ per arch and broke the universal lipo — no longer holds: `boring-sys` 5.2.0 builds clean for both `aarch64-apple-darwin` and `x86_64-apple-darwin` with cmake 4.2.3, and `make framework` still lipos a fat archive (verified: `x86_64 arm64`).

## Effect

- Supported profiles: `chrome`/`chrome120`, `firefox`/`firefox120`, `safari`/`safari16`, `ios`, `android`, `edge`, `random`; unknown values fall back to BoringSSL defaults with a warning.
- **Backend split this activates** (`meow-transport/src/tls.rs`): a proxy carrying `client-fingerprint:` **or** `ech-opts:` now handshakes through BoringSSL instead of rustls. That includes every `ech-tls-tunnel` node, since the plugin defaults to `fingerprint=chrome`.
- **Cost**: ~+6 MB per universal binary (main app 55.3 → 61.4 MB, extension 42.2 → 48.3 MB), i.e. ~3 MB per arch.
- **New build prerequisite**: cmake, for the vendored BoringSSL build.

## Verification

- `make framework` — both darwin arches compile, `lipo -info` confirms `x86_64 arm64` in the fat archive
- `xcodebuild ... -configuration Release` — BUILD SUCCEEDED
- `xcodebuild test -only-testing:BaoLianDengTests` — 16 tests, 0 failures
- `swiftlint lint --strict` — 1 violation, pre-existing on `main` (the `TODO(#75)` in `ProxyGroupsViewModel.swift`), untouched here
- Release build installed to `/Applications` and launched on the host Mac