### PR TITLE
Bump meow-rs kernel to 0.21.1, enable sing-mux, and move to meow-rs/meow-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # BaoLianDeng
 
-macOS VPN proxy app powered by [meow-rs](https://github.com/madeye/meow-rs), a Clash/mihomo-compatible proxy kernel written in Rust.
+macOS VPN proxy app powered by [meow-rs](https://github.com/meow-rs/meow-rs), a Clash/mihomo-compatible proxy kernel written in Rust.
 
 **[App Store](https://apps.apple.com/app/baoliandeng/id6779101876)** · **[TestFlight Beta](https://testflight.apple.com/join/VpX3tHnS)** · **[Website](https://madeye.github.io/BaoLianDeng/)**
 
 ## Features
 
 - **Transparent Proxy** — Built on `NETransparentProxyProvider` for socket-level flow interception, faster than traditional TUN-based solutions
-- **meow-rs Engine** — Clash/mihomo-compatible proxy kernel written in Rust ([madeye/meow-rs](https://github.com/madeye/meow-rs)), compiled as a native xcframework
+- **meow-rs Engine** — Clash/mihomo-compatible proxy kernel written in Rust ([meow-rs/meow-rs](https://github.com/meow-rs/meow-rs)), compiled as a native xcframework
 - **Per-App Proxy** — Choose which apps go through the proxy (allowlist) or bypass it (blocklist)
 - **Subscription Management** — Add, refresh, and switch between proxy subscriptions (Clash YAML and base64 formats)
 - **Smart Proxy Routing** — Browse nodes with latency indicators, switch proxy groups, rule/global/direct modes
@@ -62,7 +62,7 @@ macOS VPN proxy app powered by [meow-rs](https://github.com/madeye/meow-rs), a C
 make framework    # macOS universal (arm64 + x86_64)
 ```
 
-This builds the Rust FFI bridge under `Rust/meow-ffi/` (a staticlib around the [meow-rs](https://github.com/madeye/meow-rs) engine) into `Framework/MihomoCore.xcframework`.
+This builds the Rust FFI bridge under `Rust/meow-ffi/` (a staticlib around the [meow-rs](https://github.com/meow-rs/meow-rs) engine) into `Framework/MihomoCore.xcframework`.
 
 #### 2. Configure signing
 

--- a/Rust/meow-ffi/Cargo.lock
+++ b/Rust/meow-ffi/Cargo.lock
@@ -1899,7 +1899,7 @@ dependencies = [
 [[package]]
 name = "meow-anytls"
 version = "0.21.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
+source = "git+https://github.com/meow-rs/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.21.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
+source = "git+https://github.com/meow-rs/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "axum",
  "base64",
@@ -1962,7 +1962,7 @@ dependencies = [
 [[package]]
 name = "meow-app"
 version = "0.21.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
+source = "git+https://github.com/meow-rs/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "anyhow",
  "base64",
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.21.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
+source = "git+https://github.com/meow-rs/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.21.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
+source = "git+https://github.com/meow-rs/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2049,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.21.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
+source = "git+https://github.com/meow-rs/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2100,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "meow-listener"
 version = "0.21.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
+source = "git+https://github.com/meow-rs/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "base64",
  "libc",
@@ -2115,7 +2115,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.21.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
+source = "git+https://github.com/meow-rs/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2165,7 +2165,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.21.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
+source = "git+https://github.com/meow-rs/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2182,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.21.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
+source = "git+https://github.com/meow-rs/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2212,12 +2212,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.21.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
+source = "git+https://github.com/meow-rs/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.21.1"
-source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
+source = "git+https://github.com/meow-rs/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "async-trait",
  "dashmap",

--- a/Rust/meow-ffi/Cargo.lock
+++ b/Rust/meow-ffi/Cargo.lock
@@ -1898,8 +1898,8 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.20.2"
-source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1928,8 +1928,8 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.20.2"
-source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "axum",
  "base64",
@@ -1961,8 +1961,8 @@ dependencies = [
 
 [[package]]
 name = "meow-app"
-version = "0.20.2"
-source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "anyhow",
  "base64",
@@ -1990,8 +1990,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.20.2"
-source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2014,8 +2014,8 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.20.2"
-source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2048,8 +2048,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.20.2"
-source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "meow-ffi"
-version = "0.20.2"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2099,8 +2099,8 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.20.2"
-source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "base64",
  "libc",
@@ -2114,8 +2114,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.20.2"
-source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2129,6 +2129,7 @@ dependencies = [
  "crc32fast",
  "ctr",
  "futures",
+ "h2",
  "h3",
  "h3-quinn",
  "hex",
@@ -2154,15 +2155,17 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tracing",
  "webpki-roots 0.26.11",
  "x25519-dalek",
+ "yamux",
 ]
 
 [[package]]
 name = "meow-rules"
-version = "0.20.2"
-source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2178,8 +2181,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.20.2"
-source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2208,13 +2211,13 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.20.2"
-source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 
 [[package]]
 name = "meow-tunnel"
-version = "0.20.2"
-source = "git+https://github.com/madeye/meow-rs.git?rev=7d7f8303ab8220b54fc7459860f9c5c31b1ab63d#7d7f8303ab8220b54fc7459860f9c5c31b1ab63d"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs.git?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2295,6 +2298,12 @@ dependencies = [
  "hybrid-array",
  "num-traits",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -3345,6 +3354,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3608,6 +3623,7 @@ checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "libc",
  "pin-project-lite",
@@ -4440,6 +4456,21 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.20",
  "time",
+]
+
+[[package]]
+name = "yamux"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767113d8f66a81e461362462aa71d8d0108cbf3430d4442fb88a04e31be81165"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "pin-project",
+ "static_assertions",
+ "web-time",
 ]
 
 [[package]]

--- a/Rust/meow-ffi/Cargo.toml
+++ b/Rust/meow-ffi/Cargo.toml
@@ -22,17 +22,17 @@ crate-type = ["staticlib"]
 # with cmake per arch — both darwin arches compile, so the universal lipo
 # still works (see Makefile). `mux` is sing-mux multiplexing (`smux:` on an
 # outbound); it is part of meow-app's `full` set, so it is listed here too.
-meow-common = { git = "https://github.com/madeye/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
-meow-config = { git = "https://github.com/madeye/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531", default-features = false, features = ["ss", "trojan", "vless", "vless-vision", "vless-encryption", "vmess", "snell", "hysteria2", "anytls", "ech-tls-tunnel", "mux", "boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
-meow-listener = { git = "https://github.com/madeye/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
+meow-common = { git = "https://github.com/meow-rs/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
+meow-config = { git = "https://github.com/meow-rs/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531", default-features = false, features = ["ss", "trojan", "vless", "vless-vision", "vless-encryption", "vmess", "snell", "hysteria2", "anytls", "ech-tls-tunnel", "mux", "boring-tls"] }
+meow-dns = { git = "https://github.com/meow-rs/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
+meow-tunnel = { git = "https://github.com/meow-rs/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
+meow-listener = { git = "https://github.com/meow-rs/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/meow-rs/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
 # meow-app is pulled in ONLY for its `health_check` lib helpers (url-test /
 # fallback group probing). default-features = false drops its `full` bundle;
 # protocol features (including boring-tls) come from meow-config above and
 # unify onto the shared crate instances.
-meow-app = { git = "https://github.com/madeye/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531", default-features = false }
+meow-app = { git = "https://github.com/meow-rs/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531", default-features = false }
 
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "net", "time", "sync", "io-util", "macros"] }
 parking_lot = "0.12"

--- a/Rust/meow-ffi/Cargo.toml
+++ b/Rust/meow-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meow-ffi"
-version = "0.20.2"
+version = "0.21.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
@@ -20,18 +20,19 @@ crate-type = ["staticlib"]
 # effect; without it meow-transport parses the key, warns once, and falls back
 # to a plain rustls Client Hello. boring-sys vendors BoringSSL and builds it
 # with cmake per arch — both darwin arches compile, so the universal lipo
-# still works (see Makefile).
-meow-common = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d" }
-meow-config = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d", default-features = false, features = ["ss", "trojan", "vless", "vless-vision", "vless-encryption", "vmess", "snell", "hysteria2", "anytls", "ech-tls-tunnel", "boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d" }
-meow-listener = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d" }
+# still works (see Makefile). `mux` is sing-mux multiplexing (`smux:` on an
+# outbound); it is part of meow-app's `full` set, so it is listed here too.
+meow-common = { git = "https://github.com/madeye/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
+meow-config = { git = "https://github.com/madeye/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531", default-features = false, features = ["ss", "trojan", "vless", "vless-vision", "vless-encryption", "vmess", "snell", "hysteria2", "anytls", "ech-tls-tunnel", "mux", "boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
+meow-listener = { git = "https://github.com/madeye/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
 # meow-app is pulled in ONLY for its `health_check` lib helpers (url-test /
 # fallback group probing). default-features = false drops its `full` bundle;
 # protocol features (including boring-tls) come from meow-config above and
 # unify onto the shared crate instances.
-meow-app = { git = "https://github.com/madeye/meow-rs.git", rev = "7d7f8303ab8220b54fc7459860f9c5c31b1ab63d", default-features = false }
+meow-app = { git = "https://github.com/madeye/meow-rs.git", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531", default-features = false }
 
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "net", "time", "sync", "io-util", "macros"] }
 parking_lot = "0.12"

--- a/docs/index.html
+++ b/docs/index.html
@@ -568,7 +568,7 @@ footer .footer-links {
     <div class="feature-card">
       <span class="feature-icon" aria-hidden="true">&#x2699;&#xFE0F;</span>
       <h3>Rust-Powered Engine</h3>
-      <p><a href="https://github.com/madeye/meow-rs">meow-rs</a>, a Clash/mihomo-compatible proxy kernel written in Rust, compiled as a native xcframework — no external binaries.</p>
+      <p><a href="https://github.com/meow-rs/meow-rs">meow-rs</a>, a Clash/mihomo-compatible proxy kernel written in Rust, compiled as a native xcframework — no external binaries.</p>
     </div>
     <div class="feature-card">
       <span class="feature-icon" aria-hidden="true">&#x1F517;</span>
@@ -636,10 +636,10 @@ footer .footer-links {
     <a href="https://github.com/madeye/BaoLianDeng">GitHub</a>
     <a href="https://github.com/madeye/BaoLianDeng/releases">Releases</a>
     <a href="https://testflight.apple.com/join/VpX3tHnS">TestFlight Beta</a>
-    <a href="https://github.com/madeye/meow-rs">meow-rs</a>
+    <a href="https://github.com/meow-rs/meow-rs">meow-rs</a>
     <a href="https://github.com/madeye/BaoLianDeng/blob/main/LICENSE">MIT License</a>
   </div>
-  <p>&copy; 2026 BaoLianDeng. Powered by <a href="https://github.com/madeye/meow-rs">meow-rs</a>.</p>
+  <p>&copy; 2026 BaoLianDeng. Powered by <a href="https://github.com/meow-rs/meow-rs">meow-rs</a>.</p>
 </footer>
 
 </body>


### PR DESCRIPTION
Moves the pinned kernel rev from `7d7f830` (0.20.2) to `bc38424` (0.21.1) — 86 upstream commits — and repoints every reference at the kernel's new home, `github.com/meow-rs/meow-rs`.

## Notable upstream fixes that reach this app

- **anytls** — auth record is written in a single TLS record, fixing servers that reject a split auth flight
- **dns** — fake-IP lookup is serialised across the store read and the allocation, closing a double-allocation race that could silently drop a host's live forward mapping; `del_by_ip` is now compare-and-delete
- **udp** — NAT key claimed atomically, eviction gated on session identity
- **config** — rule/proxy-provider paths contained inside the cache dir; direct HTTP fetches for rule-providers and geodata cap the body size
- **reality** — pre-auth server-flight transcript capped and ordered; unquoted numeric `short-id` accepted (mihomo compat)
- **vless** — the XTLS Vision + mux gate narrowed to sing-mux, so Mux.Cool is allowed again

## Feature change

`mux` is added to the `meow-config` feature list. sing-mux landed upstream and is part of meow-app's `full` protocol set, which this crate mirrors; nodes carrying `smux:` now multiplex instead of being rejected.

## Repo move

The kernel repo moved from `madeye/meow-rs` to `meow-rs/meow-rs`. The seven git dependencies, the lockfile, and the prose links in `README.md` and `docs/index.html` now use the new URL. The pinned rev is unchanged — `bc38424` is HEAD of the new remote and resolves identically there. GitHub still redirects the old path, but pinning the canonical URL keeps `cargo update` and fresh clones off that redirect.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean
- From-scratch fetch and release build of the FFI crate against the new remote — succeeds
- `make framework` — arm64 + x86_64, universal lipo OK
- Debug and Release app builds — succeed
- `swiftlint lint --strict` — 0 violations
- `BaoLianDengTests` — 212/213 pass

The one failure, `HTTP request through SOCKS5 proxy`, is environmental and **not a regression**. It curls `--socks5` (curl resolves the hostname locally, so the engine receives an IP literal) to gstatic, and the network this ran on cannot reach that Google IP directly at all — plain `curl --resolve` with no proxy in the path times out identically. Running the same minimal config against a `meow` binary built at the **previous** 0.20.2 rev reproduces the failure byte-for-byte, while `--socks5-hostname` and the HTTP-proxy path succeed on both revs.