### PR TITLE
Inject the PROXY fallback group only when something references it

### DIFF
--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -321,17 +321,106 @@ struct MergeSubscriptionTests {
             proxies:
               - node
         rules:
-          - MATCH,Proxies
+          - DOMAIN-SUFFIX,example.com,Proxies
+          - MATCH,PROXY
         """
         let merged = ConfigManager.mergeSubscription(
             sub, baseConfig: Self.baseConfig, defaultConfig: Self.defaultConfig
         )
         #expect(merged.contains("icon: https://example.com/icon.png"))
-        #expect(merged.contains("MATCH,Proxies"))
+        #expect(merged.contains("example.com,Proxies"))
         let groups = ConfigManager.shared.parseProxyGroups(from: merged)
         #expect(groups.contains { $0.name == "Proxies" })
         let proxy = groups.first { $0.name == "PROXY" }
         #expect(proxy?.proxies.first == "DIRECT")
+    }
+
+    @Test("Subscription shipping its own rules and groups gets no decoy PROXY")
+    func noPROXYInjectedWhenNothingReferencesIt() {
+        let sub = """
+        proxies:
+          - {name: node, type: vless, server: 1.2.3.4, port: 443}
+        proxy-groups:
+          - name: Proxies
+            type: select
+            proxies:
+              - node
+        rules:
+          - DOMAIN-SUFFIX,example.com,Proxies
+          - GEOIP,CN,DIRECT
+          - MATCH,Proxies
+        """
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: Self.baseConfig, defaultConfig: Self.defaultConfig
+        )
+        let groups = ConfigManager.shared.parseProxyGroups(from: merged)
+        #expect(groups.contains { $0.name == "Proxies" })
+        #expect(!groups.contains { $0.name == "PROXY" })
+    }
+
+    @Test("A rule target of PROXY still triggers the fallback")
+    func ruleTargetTriggersFallback() {
+        let sub = """
+        proxies:
+          - {name: node, type: vless, server: 1.2.3.4, port: 443}
+        proxy-groups:
+          - name: Proxies
+            type: select
+            proxies:
+              - node
+        rules:
+          - IP-CIDR,91.108.0.0/16,PROXY,no-resolve
+          - MATCH,Proxies
+        """
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: Self.baseConfig, defaultConfig: Self.defaultConfig
+        )
+        let groups = ConfigManager.shared.parseProxyGroups(from: merged)
+        #expect(groups.first { $0.name == "PROXY" }?.proxies.first == "DIRECT")
+    }
+
+    @Test("A group listing PROXY as a member still triggers the fallback")
+    func groupMemberTriggersFallback() {
+        let sub = """
+        proxies:
+          - {name: node, type: vless, server: 1.2.3.4, port: 443}
+        proxy-groups:
+          - name: Proxies
+            type: select
+            proxies:
+              - PROXY
+              - node
+        rules:
+          - MATCH,Proxies
+        """
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: Self.baseConfig, defaultConfig: Self.defaultConfig
+        )
+        let groups = ConfigManager.shared.parseProxyGroups(from: merged)
+        #expect(groups.first { $0.name == "PROXY" }?.proxies.first == "DIRECT")
+    }
+
+    @Test("no-resolve is not mistaken for a rule target")
+    func noResolveIsNotATarget() {
+        let sub = """
+        proxies:
+          - {name: node, type: vless, server: 1.2.3.4, port: 443}
+        proxy-groups:
+          - name: no-resolve
+            type: select
+            proxies:
+              - node
+        rules:
+          - IP-CIDR,1.2.3.0/24,Proxies,no-resolve
+          - MATCH,Proxies
+        """
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: Self.baseConfig, defaultConfig: Self.defaultConfig
+        )
+        // `no-resolve` is a modifier on the rule above, not a target, so the
+        // group of that name is not what keeps PROXY from being injected.
+        let groups = ConfigManager.shared.parseProxyGroups(from: merged)
+        #expect(!groups.contains { $0.name == "PROXY" })
     }
 }
 

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -1004,21 +1004,31 @@ final class ConfigManager {
         // fake-ip-range). Nameservers, fallback, and nameserver-policy stay.
         forceManagedDNS(&result, engineMode: engineMode)
 
-        // Default rules target `PROXY`. A proxies-only subscription has
-        // no such group — insert one that defaults to DIRECT so traffic
-        // still flows instead of hitting a missing name.
+        // The app's own default rules target `PROXY`. When those rules are
+        // in play and no such group exists, insert one so traffic still
+        // flows instead of hitting a missing name.
         ensureProxyGroupFallback(&result)
 
         return result
     }
 
     /// Insert a `PROXY` select group defaulting to DIRECT when the merged
-    /// config does not already define one. Existing groups are left intact
-    /// (prepended, not rewritten) so subscription fields like `filter` /
-    /// `icon` survive. Leaf proxy names are listed after DIRECT so the
-    /// user can still pick a node later.
+    /// config resolves that name but does not define it. Existing groups are
+    /// left intact (prepended, not rewritten) so subscription fields like
+    /// `filter` / `icon` survive. Leaf proxy names are listed after DIRECT so
+    /// the user can still pick a node later.
+    ///
+    /// The name check alone is not enough to decide whether to inject. A
+    /// subscription that ships its own rules and primary group — commonly
+    /// named `Proxies`, differing from `PROXY` only in case and plural — has
+    /// no dangling reference to repair, so injecting anyway produced a decoy
+    /// group that no rule ever routes through. Worse, `ProxyGroupsViewModel`
+    /// sorts groups by name and `"PROXY" < "Proxies"`, so the decoy rendered
+    /// directly above the real one: picking a node in it silently changed
+    /// nothing while the live group stayed on its default first member.
     static func ensureProxyGroupFallback(_ config: inout String) {
         if hasNamedProxyGroup(config, name: "PROXY") { return }
+        guard referencesProxyName(config, name: "PROXY") else { return }
 
         var members = ["DIRECT"]
         if let dict = (try? Yams.load(yaml: config)) as? [String: Any],
@@ -1063,6 +1073,17 @@ final class ConfigManager {
 
     private static func hasNamedProxyGroup(_ yaml: String, name: String) -> Bool {
         ConfigManager.shared.parseProxyGroups(from: yaml).contains { $0.name == name }
+    }
+
+    /// Whether anything in the merged config resolves `name` as a proxy: a
+    /// rule target, or a member of another proxy group. Either one dangles if
+    /// the group is missing, so either one warrants the fallback.
+    private static func referencesProxyName(_ yaml: String, name: String) -> Bool {
+        let manager = ConfigManager.shared
+        if manager.parseRules(from: yaml).contains(where: { $0.target == name }) {
+            return true
+        }
+        return manager.parseProxyGroups(from: yaml).contains { $0.proxies.contains(name) }
     }
 
     /// Set interval to 0 in provider sections so Mihomo won't auto-refresh subscription URLs.


### PR DESCRIPTION
## Problem

`ensureProxyGroupFallback` injected a `PROXY` select group whenever the merged config had no group of that exact name. A subscription that ships its own rules and primary group — commonly named `Proxies`, differing from `PROXY` only in case and plural — has no dangling reference to repair, so it got a decoy group that no rule ever routes through.

`ProxyGroupsViewModel` sorts groups by name and `"PROXY" < "Proxies"`, so the decoy rendered directly above the real one in the picker. Selecting a node in it silently changed nothing while the live group stayed pinned to its default first member.

On a real subscription this black-holed everything. Rule targets in the affected config:

| Group | Rules targeting it |
|---|---|
| `🎯Direct` | 4532 |
| `Proxies` | 928 |
| `✈️Final` (MATCH → `Proxies`) | 1 |
| **`PROXY`** | **0** |

The saved selections were `"PROXY": "🇯🇵 Japan 03"` (the node actually picked) and `"Proxies": "6.47 G | 500.00 G"` — a traffic-quota *banner* pseudo-node that subscriptions front-load, which is nonetheless a real proxy. Its server happened to be unreachable, so every dial timed out and the local proxy port hung. Pointing `Proxies` at the same node made it work immediately.

## Fix

Guard the injection on whether anything actually **resolves** the name — a rule target or another group's member list. Either dangles without the group, so either warrants the fallback.

Proxies-only subscriptions fall back to the app's default rules, which do target `PROXY`, so they still get it. URI-list subscriptions build their own and are unaffected.

Reuses the existing `parseRules`, which reads the target as `parts[2]` rather than the last comma field — so a trailing `no-resolve` is never mistaken for a target.

## Tests

`injectsPROXYWithoutRewritingOtherGroups` encoded the bug (it asserted a decoy *should* appear), so its rules now point at `PROXY` — that keeps its real intent, the icon-preservation check, on a case where injection is legitimate.

Four new tests cover both directions:
- no decoy when the subscription ships its own rules
- `no-resolve` is not mistaken for a rule target
- a rule target of `PROXY` still triggers the fallback
- a group listing `PROXY` as a member still triggers the fallback

Removing the guard makes exactly the two negative tests fail and leaves the positives green.

Full suite (217) green, `swiftlint --strict` clean.