### PR TITLE
Bump version to 6.1 (20260827)

### DIFF
--- a/BaoLianDeng.xcodeproj/project.pbxproj
+++ b/BaoLianDeng.xcodeproj/project.pbxproj
@@ -740,7 +740,7 @@
 				CODE_SIGN_ENTITLEMENTS = TransparentProxyMac/TransparentProxyMac.entitlements;
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20260812;
+				CURRENT_PROJECT_VERSION = 20260827;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -753,7 +753,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 6.0;
+				MARKETING_VERSION = 6.1;
 				NE_PROVIDER_SUFFIX = "";
 				OTHER_LDFLAGS = (
 					"-lresolv",
@@ -778,7 +778,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 20260812;
+				CURRENT_PROJECT_VERSION = 20260827;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -791,7 +791,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 6.0;
+				MARKETING_VERSION = 6.1;
 				NE_PROVIDER_SUFFIX = "";
 				OTHER_LDFLAGS = (
 					"-lresolv",
@@ -825,7 +825,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 6.0;
+				MARKETING_VERSION = 6.1;
 				NE_PROVIDER_SUFFIX = "";
 				OTHER_LDFLAGS = (
 					"-lresolv",
@@ -863,7 +863,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 6.0;
+				MARKETING_VERSION = 6.1;
 				NE_PROVIDER_SUFFIX = "";
 				OTHER_LDFLAGS = (
 					"-lresolv",
@@ -894,7 +894,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = TransparentProxyAppex/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 6.0;
+				MARKETING_VERSION = 6.1;
 				NE_PROVIDER_SUFFIX = "";
 				OTHER_LDFLAGS = (
 					"-lresolv",
@@ -916,7 +916,7 @@
 				CODE_SIGN_ENTITLEMENTS = TransparentProxyMac/TransparentProxyMac.entitlements;
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20260812;
+				CURRENT_PROJECT_VERSION = 20260827;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -925,7 +925,7 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = TransparentProxyAppex/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 6.0;
+				MARKETING_VERSION = 6.1;
 				NE_PROVIDER_SUFFIX = "";
 				OTHER_LDFLAGS = (
 					"-lresolv",

--- a/BaoLianDeng/Info.plist
+++ b/BaoLianDeng/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0</string>
+	<string>6.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/TransparentProxyAppex/Info.plist
+++ b/TransparentProxyAppex/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0</string>
+	<string>6.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>

--- a/TransparentProxyMac/Info.plist
+++ b/TransparentProxyMac/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0</string>
+	<string>6.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Marketing version 6.1, Release build number `20260827` (Debug untouched at 105).

Ships everything merged since 6.0 build 20260812:
- Send the controller secret when TrafficStore polls /connections (#109)
- Inject the PROXY fallback group only when something references it (#108)
- Hermetic SOCKS5 proxy test target (#107)
- meow-rs 0.21.1, sing-mux enabled, repo move to meow-rs/meow-rs (#106)
- Proxy-group selections scoped per subscription; selectedNode retired (#105)
- mihomo User-Agent for subscription fetches (#104)
- boring-tls enabled so client-fingerprint spoofs the Client Hello (#102)
- Proxy node hostnames resolved via configured DNS (#101)
- GeoLite2-ASN.mmdb provisioning for IP-ASN rules (#100)
- NE TCP relay leak fix (#99)
- Subscription DNS blocks respected (#98)

Verified locally: `swiftlint lint --strict` clean, 220 unit tests pass, MAS PKG built and `altool` validation succeeded.

https://claude.ai/code/session_01RE96utCvf8jMzGGFNyFJsq