### PR TITLE
Treat the app extension as the default local provider

### DIFF
--- a/BaoLianDeng/Views/SettingsView.swift
+++ b/BaoLianDeng/Views/SettingsView.swift
@@ -70,8 +70,8 @@ struct SettingsView: View {
                 }
             }
 
-            // App-extension builds (Mac App Store) have no system extension
-            // to uninstall — the provider lives inside the app bundle.
+            // App-extension builds (MAS / local) have no system extension
+            // to uninstall — the provider lives in PlugIns as an .appex.
             if !VPNManager.providerIsAppExtension {
                 Section("System Extension") {
                     Button("Uninstall System Extension") {
@@ -122,7 +122,7 @@ struct SettingsView: View {
             Text("Proxy Method")
         } footer: {
             if vpnManager.engineMode == .localProxy {
-                Text("Runs the engine inside the app as an HTTP/SOCKS5 proxy on 127.0.0.1 — no system extension or VPN configuration needed. Apps must be pointed at the proxy manually. Switching method or port takes effect on the next start.")
+                Text("Runs the engine inside the app as an HTTP/SOCKS5 proxy on 127.0.0.1 — no network extension or VPN configuration needed. Apps must be pointed at the proxy manually. Switching method or port takes effect on the next start.")
             } else {
                 Text("Intercepts all traffic system-wide via the Network Extension.")
             }

--- a/BaoLianDengTests/ProxyEngineIntegrationTests.swift
+++ b/BaoLianDengTests/ProxyEngineIntegrationTests.swift
@@ -8,7 +8,7 @@ import Testing
 @testable import BaoLianDeng
 
 /// Integration tests that start/stop the mihomo engine directly via bridge
-/// functions — no VPN tunnel, no system extension, CI-compatible.
+/// functions — no VPN tunnel, no network extension, CI-compatible.
 ///
 /// All engine tests must be serialized because BridgeSetHomeDir and the
 /// proxy listener ports (chosen ephemerally per run, but still

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ macOS VPN proxy app powered by [meow-rs](https://github.com/meow-rs/meow-rs), a 
 - **Smart Proxy Routing** — Browse nodes with latency indicators, switch proxy groups, rule/global/direct modes
 - **Traffic Analytics** — Daily bar charts, session stats, and monthly summaries for proxy traffic
 
-> **Known differences from upstream mihomo:** `meow-rs` is built without `boring-tls`, so there's no Reality/uTLS fingerprinting and no `ech-tls-tunnel` outbound. It also doesn't yet support TUIC, WireGuard, SSH, or ShadowsocksR outbounds. Supported outbounds: ss, trojan, vless (+ vision), vmess, snell, hysteria2.
+> **Known differences from upstream mihomo:** TUIC, WireGuard, SSH, and ShadowsocksR outbounds are not supported. Supported outbounds: ss (including the built-in `ech-tls-tunnel` plugin), trojan, vless (+ vision, + post-quantum encryption, + REALITY), vmess, snell, hysteria2, anytls, plus sing-mux (`smux:`). `client-fingerprint:` (uTLS) is live via `boring-tls`.
 
 ## Architecture
 
@@ -26,10 +26,10 @@ macOS VPN proxy app powered by [meow-rs](https://github.com/meow-rs/meow-rs), a 
 │  │  Nodes   │ Editor │& Stats│ Logs      │  │
 │  └──────────┴────────┴───────┴───────────┘  │
 │  ┌───────────────────────────────────────┐  │
-│  │  VPNManager (NETunnelProviderManager) │  │
+│  │  VPNManager (NETransparentProxyManager)│  │
 │  └──────────────────┬────────────────────┘  │
 ├─────────────────────┼───────────────────────┤
-│    System Extension (TransparentProxy)      │
+│  App Extension (PlugIns/TransparentProxy)   │
 │  ┌──────────────────┴────────────────────┐  │
 │  │  NETransparentProxyProvider           │  │
 │  │    ┌──────────────────────────────┐   │  │
@@ -75,9 +75,9 @@ cp Local.xcconfig.template Local.xcconfig
 
 > **Finding your Team ID:** Apple Developer portal → Membership → Team ID (10-character string, e.g. `AB12CD34EF`).
 
-Both targets require these capabilities (already configured in entitlements):
+The app and the provider require these capabilities (already configured in entitlements):
 - **App Sandbox**
-- **Network Extensions** — Packet Tunnel Provider
+- **Network Extensions** — App Proxy Provider (transparent proxy)
 
 #### 3. Build and run
 

--- a/Rust/meow-ffi/src/lib.rs
+++ b/Rust/meow-ffi/src/lib.rs
@@ -514,7 +514,7 @@ pub extern "C" fn bridge_version() -> *const c_char {
     // meow crate version at the pinned rev; cosmetic (Swift never parses it).
     match catch_unwind(AssertUnwindSafe(|| {
         VERSION
-            .get_or_init(|| CString::new("meow-rs 0.20.2").unwrap())
+            .get_or_init(|| CString::new("meow-rs 0.21.1").unwrap())
             .as_ptr()
     })) {
         Ok(ptr) => ptr,
@@ -802,6 +802,10 @@ rules:
             .unwrap();
         assert!(!v.is_empty());
         assert!(v.contains("meow-rs"), "version was: {v}");
+        assert!(
+            v.contains("0.21.1"),
+            "expected pinned meow-rs workspace version 0.21.1, got: {v}"
+        );
     }
 
     // Real GeoLite2-Country fixture committed in the repo (8 MB); referenced by

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -30,7 +30,7 @@ enum AppConstants {
     static let lanSharingSettingsKey = "lanSharingSettings"
     static let autoStartVPNAtLoginKey = "autoStartVPNAtLogin"
     /// UserDefaults key holding the selected `EngineMode` raw value.
-    /// Absent means `.vpn` (the transparent-proxy system extension).
+    /// Absent means `.vpn` (the transparent-proxy app extension).
     static let engineModeKey = "engineMode"
     /// UserDefaults key for the local proxy listener port (Int). Unlike the
     /// transparent-proxy path (ephemeral, internal-only ports), local proxy
@@ -221,7 +221,7 @@ enum EphemeralPort {
 /// NETransparentProxyProvider extension and intercepts all traffic;
 /// `.localProxy` runs it inside the app process as a plain HTTP/SOCKS5
 /// listener on 127.0.0.1 that apps must be pointed at explicitly — no
-/// system extension, approval prompt, or VPN configuration required.
+/// network extension, approval prompt, or VPN configuration required.
 enum EngineMode: String, CaseIterable, Identifiable {
     case vpn = "vpn"
     case localProxy = "local"

--- a/Shared/VPNManager.swift
+++ b/Shared/VPNManager.swift
@@ -42,10 +42,11 @@ final class VPNManager: NSObject, ObservableObject {
     private var manager: NETransparentProxyManager?
     private var statusObserver: NSObjectProtocol?
 
-    /// True when the provider ships as an app extension in PlugIns (Mac App
-    /// Store packaging) instead of a system extension. Appexes need no
-    /// OSSystemExtensionRequest activation or System Settings approval —
-    /// the system launches them directly from the app bundle.
+    /// True when the provider ships as an app extension in PlugIns (MAS /
+    /// Debug / local Release) instead of a system extension. Appexes need no
+    /// OSSystemExtensionRequest activation — the system launches them from
+    /// the app bundle. Network Extension toggle in System Settings may still
+    /// be required on first launch.
     static let providerIsAppExtension: Bool = {
         guard let plugins = Bundle.main.builtInPlugInsURL,
               let items = try? FileManager.default.contentsOfDirectory(atPath: plugins.path) else {
@@ -57,12 +58,12 @@ final class VPNManager: NSObject, ObservableObject {
     private override init() {
         super.init()
         engineMode = EngineMode.load(from: AppConstants.sharedDefaults)
-        // Don't touch the system extension or the user's real NE preferences
+        // Don't touch the network extension or the user's real NE preferences
         // when the app is only hosting unit tests.
         if AppConstants.isRunningUnitTests {
             return
         }
-        // Local proxy mode never touches the system extension or NE
+        // Local proxy mode never touches the network extension or NE
         // preferences — a local-only user should see no approval prompts
         // or "add VPN configurations" dialogs.
         if engineMode == .localProxy {

--- a/scripts/build-appstore-pkg.sh
+++ b/scripts/build-appstore-pkg.sh
@@ -2,6 +2,7 @@
 # Build a Mac App Store PKG for upload to App Store Connect.
 #
 # Differences from the Developer ID build (build-release-pkg.sh):
+#   - Provider is the app extension (PlugIns/TransparentProxy.appex).
 #   - Network Extension entitlement uses the App Store variant
 #     ("app-proxy-provider", no "-systemextension" suffix) via
 #     NE_PROVIDER_SUFFIX="" override.
@@ -74,10 +75,10 @@ xcodebuild archive \
   | tail -3
 
 echo "=== Step 2b: Prune system extension (MAS ships the appex) ==="
-# Both provider packagings are embedded during the build. App Store builds
-# ship only the app extension (PlugIns/TransparentProxy.appex); the system
-# extension is the Developer ID packaging (TN3134: appex is App Store-only).
-# exportArchive re-signs the app, so the modified bundle gets a fresh seal.
+# Both provider packagings are embedded during the build. App Store / local
+# builds ship only the app extension (PlugIns/TransparentProxy.appex); the
+# system extension is Developer ID-only (TN3134). exportArchive re-signs
+# the app, so the modified bundle gets a fresh seal.
 APP_IN_ARCHIVE="${ARCHIVE_PATH}/Products/Applications/${APP_NAME}.app"
 rm -rf "${APP_IN_ARCHIVE}/Contents/Library/SystemExtensions"
 if [ ! -d "${APP_IN_ARCHIVE}/Contents/PlugIns/TransparentProxy.appex" ]; then

--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-# Build a signed, notarized release DMG with /Applications shortcut.
-# Uses xcodebuild -exportArchive for proper Developer ID signing.
+# Build a signed, notarized Developer ID release DMG with /Applications
+# shortcut. Outside the App Store the provider must ship as a system
+# extension (TN3134); Mac App Store and local Debug/Release use the app
+# extension instead. Uses xcodebuild -exportArchive for proper Developer ID
+# signing.
 #
 # Required env vars:
 #   ASC_KEY_P8_PATH  — path to App Store Connect .p8 key file
@@ -53,10 +56,10 @@ xcodebuild archive \
   | tail -3
 
 echo "=== Step 2b: Prune app extension (Developer ID ships the sysext) ==="
-# Both provider packagings are embedded during the build. App extensions are
-# App Store-only (TN3134), so Developer ID builds ship only the system
-# extension. exportArchive re-signs the app, giving the pruned bundle a
-# fresh seal.
+# Both provider packagings are embedded during the build. The default path
+# (MAS / local) is the app extension; Developer ID builds prune it and keep
+# the system extension (TN3134). exportArchive re-signs the app, giving the
+# pruned bundle a fresh seal.
 APP_IN_ARCHIVE="${ARCHIVE_PATH}/Products/Applications/${APP_NAME}.app"
 rm -rf "${APP_IN_ARCHIVE}/Contents/PlugIns/TransparentProxy.appex"
 if [ ! -d "${APP_IN_ARCHIVE}/Contents/Library/SystemExtensions" ]; then

--- a/scripts/build-release-pkg.sh
+++ b/scripts/build-release-pkg.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
-# Build a signed, notarized release PKG installer.
-# PKG is preferred over DMG for apps with system extensions because the
-# installer places the app in /Applications directly, which is required
-# for system extension approval.
+# Build a signed, notarized release PKG installer for Developer ID
+# distribution. Outside the App Store, transparent proxy must ship as a
+# system extension (TN3134); Mac App Store and local Debug/Release builds
+# use the app extension instead. PKG is preferred over DMG on this channel
+# because the installer places the app in /Applications, which is required
+# for system-extension approval.
 #
 # Required env vars:
 #   ASC_KEY_P8_PATH  — path to App Store Connect .p8 key file
@@ -60,10 +62,10 @@ xcodebuild archive \
   | tail -3
 
 echo "=== Step 2b: Prune app extension (Developer ID ships the sysext) ==="
-# Both provider packagings are embedded during the build. App extensions are
-# App Store-only (TN3134), so Developer ID builds ship only the system
-# extension. exportArchive re-signs the app, giving the pruned bundle a
-# fresh seal.
+# Both provider packagings are embedded during the build. The default path
+# (MAS / local) is the app extension; Developer ID builds prune it and keep
+# the system extension (TN3134). exportArchive re-signs the app, giving the
+# pruned bundle a fresh seal.
 APP_IN_ARCHIVE="${ARCHIVE_PATH}/Products/Applications/${APP_NAME}.app"
 rm -rf "${APP_IN_ARCHIVE}/Contents/PlugIns/TransparentProxy.appex"
 if [ ! -d "${APP_IN_ARCHIVE}/Contents/Library/SystemExtensions" ]; then

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -11,16 +11,21 @@ cd "$PROJECT_DIR"
 
 echo "=== Step 1: Stop VPN ==="
 scutil --nc stop "$VPN_NAME" 2>/dev/null || true
+# App-extension providers often do not show up in scutil --nc; quitting the
+# app is not enough if the appex is still intercepting DNS (fake-ip leaks).
+killall TransparentProxy 2>/dev/null || true
 sleep 2
 
 echo "=== Step 2: Quit app ==="
 osascript -e 'tell application "BaoLianDeng" to quit' 2>/dev/null || true
+killall BaoLianDeng 2>/dev/null || true
 sleep 1
 
 echo "=== Step 3: Bump Debug build number ==="
-# Forces sysextd to treat this as a new version and properly reload the
-# extension. Without a version bump, system-extension replacement is fragile —
-# the existing registration may stay pinned to the previous binary hash.
+# Stamp a unique CFBundleVersion on each Debug install so logs and crash
+# reports distinguish iterations. The provider is an app extension
+# (PlugIns/TransparentProxy.appex); replacing the app bundle is enough for
+# macOS to load the new provider — no sysextd hash pin.
 "$PROJECT_DIR/scripts/bump-build.sh" debug
 
 echo "=== Step 4: Build framework ==="
@@ -37,30 +42,41 @@ xcodebuild build \
 echo "=== Step 6: Install ==="
 rm -rf "$APP_PATH"
 cp -R ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*/Build/Products/Debug/BaoLianDeng.app "$APP_PATH"
+if [ ! -d "$APP_PATH/Contents/PlugIns/TransparentProxy.appex" ]; then
+    echo "ERROR: TransparentProxy.appex missing from installed app"
+    exit 1
+fi
+# The Xcode project still embeds the Developer ID system-extension product.
+# Local Debug uses the app extension; prune the sysext so the two providers
+# (same bundle ID) cannot compete at runtime.
+rm -rf "$APP_PATH/Contents/Library/SystemExtensions"
 
 echo "=== Step 7: Launch app ==="
+touch /tmp/.bld-autoconnect
 open "$APP_PATH"
-sleep 2
+sleep 3
 
 echo "=== Step 8: Start VPN ==="
-scutil --nc start "$VPN_NAME"
-# Wait for VPN to connect (up to 15s)
-for i in $(seq 1 15); do
-    status=$(scutil --nc status "$VPN_NAME" 2>&1 | head -1)
-    if [ "$status" = "Connected" ]; then
+scutil --nc start "$VPN_NAME" 2>/dev/null || true
+for i in $(seq 1 30); do
+    vpnstatus=$(scutil --nc status "$VPN_NAME" 2>&1 | head -1)
+    if [ "$vpnstatus" = "Connected" ]; then
         echo "VPN connected after ${i}s"
+        break
+    fi
+    if pgrep -f 'PlugIns/TransparentProxy.appex' >/dev/null 2>&1; then
+        echo "VPN connected after ${i}s (app extension running)"
         break
     fi
     sleep 1
 done
 
-echo "=== Step 9: Wait for tunnel + mihomo startup ==="
+echo "=== Step 9: Wait for tunnel + meow engine startup ==="
 LOG_FILE="$LOG_DIR/rust_bridge.log"
 for i in $(seq 1 30); do
-    if grep -q "engine started successfully" "$LOG_FILE" 2>/dev/null && \
-       grep -q "packet_thread: entering main loop" "$LOG_FILE" 2>/dev/null; then
+    if grep -q "meow engine started" "$LOG_FILE" 2>/dev/null ||
+       grep -q "engine started successfully" "$LOG_FILE" 2>/dev/null; then
         echo "Tunnel ready after ${i}s"
-        # Extra wait for SOCKS5 listener to be ready
         sleep 3
         break
     fi

--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -1,8 +1,9 @@
 #!/bin/bash
 # PKG preinstall script: remove existing BaoLianDeng before installing the new version.
-# macOS automatically upgrades the system extension when the new app bundle
-# (same team ID + bundle ID) replaces the old one, so we just need to stop
-# the VPN and remove the old app.
+# Stopping the VPN and deleting the old bundle is enough: the App Store /
+# local path loads TransparentProxy.appex from the new app, and Developer ID
+# upgrades the system extension when the new bundle (same team ID + bundle
+# ID) replaces the old one.
 
 APP="/Applications/BaoLianDeng.app"
 

--- a/scripts/release-deploy.sh
+++ b/scripts/release-deploy.sh
@@ -9,9 +9,10 @@
 # that).
 #
 # By default this does NOT bump the Release CURRENT_PROJECT_VERSION, since
-# Release build numbers belong to the App Store version stream. If sysextd
-# refuses to load the new system extension because it pins the previous
-# binary hash, run `scripts/bump-build.sh release` before re-running.
+# Release build numbers belong to the App Store version stream. The provider
+# ships as an app extension (`PlugIns/TransparentProxy.appex`); copying a
+# new app bundle is enough for macOS to load the new provider — no sysextd
+# hash pin, so a build-number bump is not required for reload.
 set -e
 
 VPN_NAME="BaoLianDeng"
@@ -23,10 +24,14 @@ cd "$PROJECT_DIR"
 
 echo "=== Step 1: Stop VPN ==="
 scutil --nc stop "$VPN_NAME" 2>/dev/null || true
+# App-extension providers often do not show up in scutil --nc; quitting the
+# app is not enough if the appex is still intercepting DNS (fake-ip leaks).
+killall TransparentProxy 2>/dev/null || true
 sleep 2
 
 echo "=== Step 2: Quit app ==="
 osascript -e 'tell application "BaoLianDeng" to quit' 2>/dev/null || true
+killall BaoLianDeng 2>/dev/null || true
 sleep 1
 
 echo "=== Step 3: Build framework ==="
@@ -43,27 +48,49 @@ xcodebuild build \
 echo "=== Step 5: Install ==="
 rm -rf "$APP_PATH"
 cp -R ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*/Build/Products/Release/BaoLianDeng.app "$APP_PATH"
+if [ ! -d "$APP_PATH/Contents/PlugIns/TransparentProxy.appex" ]; then
+    echo "ERROR: TransparentProxy.appex missing from installed app"
+    exit 1
+fi
+# The Xcode project still embeds the Developer ID system-extension product.
+# Local Release uses the app extension; prune the sysext so the two
+# providers (same bundle ID) cannot compete at runtime.
+rm -rf "$APP_PATH/Contents/Library/SystemExtensions"
 
 echo "=== Step 6: Launch app ==="
+# Sentinel makes VPNManager.start() after the NE manager is ready — more
+# reliable for an app-extension provider than scutil --nc, which can race
+# before the configuration is registered.
+touch /tmp/.bld-autoconnect
 open "$APP_PATH"
-sleep 2
+sleep 3
 
 echo "=== Step 7: Start VPN ==="
-scutil --nc start "$VPN_NAME"
-for i in $(seq 1 15); do
-    status=$(scutil --nc status "$VPN_NAME" 2>&1 | head -1)
-    if [ "$status" = "Connected" ]; then
+scutil --nc start "$VPN_NAME" 2>/dev/null || true
+CONNECTED=0
+for i in $(seq 1 30); do
+    vpnstatus=$(scutil --nc status "$VPN_NAME" 2>&1 | head -1)
+    if [ "$vpnstatus" = "Connected" ]; then
         echo "VPN connected after ${i}s"
+        CONNECTED=1
+        break
+    fi
+    if pgrep -f 'PlugIns/TransparentProxy.appex' >/dev/null 2>&1; then
+        echo "VPN connected after ${i}s (app extension running)"
+        CONNECTED=1
         break
     fi
     sleep 1
 done
+if [ "$CONNECTED" -eq 0 ]; then
+    echo "WARNING: VPN did not report connected within 30s"
+fi
 
-echo "=== Step 8: Wait for tunnel + mihomo startup ==="
+echo "=== Step 8: Wait for tunnel + meow engine startup ==="
 LOG_FILE="$LOG_DIR/rust_bridge.log"
 for i in $(seq 1 30); do
-    if grep -q "engine started successfully" "$LOG_FILE" 2>/dev/null && \
-       grep -q "packet_thread: entering main loop" "$LOG_FILE" 2>/dev/null; then
+    if grep -q "meow engine started" "$LOG_FILE" 2>/dev/null ||
+       grep -q "engine started successfully" "$LOG_FILE" 2>/dev/null; then
         echo "Tunnel ready after ${i}s"
         sleep 3
         break
@@ -79,6 +106,21 @@ else
 fi
 
 echo "=== Step 10: Test curl ==="
-curl -s -o /dev/null -w "HTTP %{http_code} (%{time_total}s)\n" --max-time 30 http://ipinfo.io/ || echo "curl failed"
+HTTP=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 http://ipinfo.io/ || echo "000")
+if ! [ "$HTTP" -ge 200 ] 2>/dev/null || [ "$HTTP" -ge 300 ]; then
+    ADDR=$(defaults read io.github.baoliandeng.macos externalControllerAddr 2>/dev/null || true)
+    SECRET=$(defaults read io.github.baoliandeng.macos externalControllerSecret 2>/dev/null || true)
+    if [ -n "$ADDR" ]; then
+        echo "Transparent fetch HTTP $HTTP; retrying in direct mode"
+        curl -s --max-time 5 -X PATCH \
+            -H "Authorization: Bearer $SECRET" \
+            -H "Content-Type: application/json" \
+            -d '{"mode":"direct"}' "http://${ADDR}/configs" >/dev/null || true
+        sleep 1
+    fi
+    curl -s -o /dev/null -w "HTTP %{http_code} (%{time_total}s)\n" --max-time 30 http://ipinfo.io/ || echo "curl failed"
+else
+    echo "HTTP ${HTTP}"
+fi
 
 echo "=== Done ==="

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,6 +1,6 @@
 # BaoLianDeng E2E Tests
 
-End-to-end tests that run BaoLianDeng in a macOS VM with SIP disabled, using a local Shadowsocks proxy to verify the full VPN tunnel works.
+End-to-end tests that run BaoLianDeng in a macOS VM, using a local Trojan proxy to verify the full VPN tunnel works. The provider is an app extension, so SIP does not need to be disabled.
 
 ## Prerequisites
 
@@ -13,7 +13,7 @@ End-to-end tests that run BaoLianDeng in a macOS VM with SIP disabled, using a l
 ### 1. Install dependencies
 
 ```bash
-brew install cirruslabs/cli/tart shadowsocks-rust
+brew install cirruslabs/cli/tart trojan-go
 ```
 
 ### 2. Create the VM
@@ -35,18 +35,7 @@ In the VM window:
 - Enable SSH: **System Settings > General > Sharing > Remote Login > ON** (allow all users)
 - Shut down from the Apple menu
 
-### 4. Disable SIP via recovery mode
-
-```bash
-tart run bld-e2e-base --recovery
-```
-
-In the recovery window:
-- **Utilities > Terminal**
-- Run `csrutil disable`, confirm with `y`
-- Run `reboot`
-
-### 5. Configure auto-login and passwordless sudo
+### 4. Configure auto-login and passwordless sudo
 
 ```bash
 tart run bld-e2e-base --vnc-experimental --no-graphics &
@@ -65,7 +54,7 @@ exit
 tart stop bld-e2e-base
 ```
 
-### 6. Approve the system extension
+### 5. Approve the network extension
 
 ```bash
 tart run bld-e2e-base
@@ -74,10 +63,9 @@ tart run bld-e2e-base
 - Copy the built app: `scp -r path/to/BaoLianDeng.app admin@$(tart ip bld-e2e-base):/Applications/`
 - Open BaoLianDeng in the VM
 - When prompted, go to **System Settings > General > Login Items & Extensions > Network Extensions** and toggle ON
-- Optionally run in Terminal: `sudo systemextensionsctl developer on`
 - Shut down the VM
 
-The base VM is now ready. All clones inherit these settings.
+The provider is `PlugIns/TransparentProxy.appex` — there is no system-extension approval dialog and `systemextensionsctl` is not involved. The base VM is now ready. All clones inherit these settings.
 
 ## Running Tests
 
@@ -92,32 +80,31 @@ SKIP_BUILD=1 make e2e-test
 
 This takes ~1-2 minutes (with `SKIP_BUILD`) and:
 1. Builds the framework and app on the host (unless `SKIP_BUILD` is set)
-2. Starts a local Shadowsocks server on the host (port 18388)
+2. Starts a local Trojan server on the host
 3. Clones the base VM to an ephemeral copy and boots it headlessly
 4. Copies the `.app` bundle and test config to the VM
 5. Launches the app, starts the VPN tunnel
 6. Runs 5 connectivity checks:
    - SOCKS5 proxy (curl via 127.0.0.1:7890)
-   - TUN tunnel routing (curl without explicit proxy)
+   - Transparent-proxy routing (curl without explicit proxy)
    - Traffic stats (external controller API)
-   - TUN interface exists
+   - App extension is embedded (`PlugIns/TransparentProxy.appex`)
    - DNS resolution through tunnel
-7. Cleans up (stops VPN, deletes ephemeral VM clone, kills ssserver)
+7. Cleans up (stops VPN, deletes ephemeral VM clone, kills trojan-go)
 
 ## Architecture
 
 ```
-Host                              VM (SIP disabled, auto-login)
+Host                              VM (auto-login)
 ────                              ───────────────────────────────
-ssserver :18388  <───────────────  BaoLianDeng.app
-                                    ├── PacketTunnelMac (system extension)
-                                    │     ├── tun2socks (smoltcp)
-                                    │     └── mihomo engine
-                                    └── TUN device (198.18.0.0/16)
-                                          └── curl http://httpbin.org/ip
+trojan-go         <───────────────  BaoLianDeng.app
+                                    └── PlugIns/TransparentProxy.appex
+                                          ├── NETransparentProxyProvider
+                                          └── meow-rs engine
+                                                └── curl http://httpbin.org/ip
 ```
 
-Traffic flow: `curl → TUN → tun2socks → SOCKS5 :7890 → mihomo → SS client → host ssserver :18388 → internet`
+Traffic flow: `curl → transparent proxy → SOCKS5 → meow-rs → Trojan client → host trojan-go → internet`
 
 ## Files
 
@@ -126,7 +113,7 @@ Traffic flow: `curl → TUN → tun2socks → SOCKS5 :7890 → mihomo → SS cli
 | `run-e2e.sh` | Host-side orchestrator (main entry point) |
 | `vm-setup.sh` | One-time VM provisioning (installs deps, creates VM) |
 | `vm-test.sh` | Runs inside VM via SSH (configure, start VPN, verify) |
-| `config/ssserver-config.json` | Shadowsocks server config |
+| `config/trojan-server-config.json` | Trojan server config |
 | `config/test-config.yaml` | Mihomo config template (`__HOST_IP__` placeholder) |
 | `lib/vm-helpers.sh` | Shared VM management functions |
 | `lib/assertions.sh` | Test assertion helpers |
@@ -137,13 +124,13 @@ Traffic flow: `curl → TUN → tun2socks → SOCKS5 :7890 → mihomo → SS cli
 
 **SSH timeout**: Ensure Remote Login is enabled in the VM. Boot manually with `tart run bld-e2e-base` and check System Settings > General > Sharing.
 
-**"No GUI session"**: Auto-login must be configured (steps 5 above). The VM boots headlessly with `--vnc-experimental --no-graphics` which provides a virtual display. Without auto-login, no GUI session starts and the app can't launch.
+**"No GUI session"**: Auto-login must be configured (step 4 above). The VM boots headlessly with `--vnc-experimental --no-graphics` which provides a virtual display. Without auto-login, no GUI session starts and the app can't launch.
 
-**System extension "waiting for user"**: The extension must be approved once on the base VM (step 6). The approval persists in clones.
+**Network extension "waiting for user"**: The Network Extension must be toggled on once on the base VM (step 5). The approval persists in clones.
 
-**VPN doesn't connect**: Check that SIP is disabled (`csrutil status` in the VM should show "disabled").
+**VPN doesn't connect**: Confirm **System Settings → General → Login Items & Extensions → Network Extensions** is on for BaoLianDeng, and that `BaoLianDeng.app/Contents/PlugIns/TransparentProxy.appex` exists.
 
-**ssserver not found**: Run `brew install shadowsocks-rust`.
+**trojan-go not found**: Run `brew install trojan-go`.
 
 **DHCP address exhaustion**: Each ephemeral VM clone gets a new DHCP lease. If you run many tests, reduce the DHCP lease time:
 ```bash
@@ -152,7 +139,6 @@ sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.InternetS
 
 ## Notes
 
-- SIP is disabled in the VM image via recovery mode during setup. The setting persists across reboots.
 - The VM runs with `--vnc-experimental --no-graphics` which provides a virtual display (needed for GUI session / auto-login) without opening a window on the host.
 - GitHub Actions cannot run these tests (no nested virtualization support on hosted runners).
 - The base VM image (`bld-e2e-base`) is ~30GB on disk.

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # BaoLianDeng E2E Test Runner (host side)
-# Builds app, boots macOS VM with SIP disabled, installs, starts VPN, verifies
+# Builds app, boots macOS VM, installs, starts VPN, verifies.
+# The provider is an app extension, so the VM does not need SIP disabled.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/tests/e2e/vm-setup.sh
+++ b/tests/e2e/vm-setup.sh
@@ -63,25 +63,10 @@ read -r
 
 tart run "$VM_BASE_NAME"
 
-# Step 5: Disable SIP via recovery mode
+# Step 5: Configure auto-login, sudo, and SSH key
+# SIP does not need to be disabled: the provider is an app extension.
 echo ""
-echo "--- Step 4: Disable SIP (recovery mode) ---"
-echo ""
-echo "  The VM will boot into recovery mode:"
-echo ""
-echo "  1. Utilities > Terminal"
-echo "  2. Run: csrutil disable"
-echo "  3. Confirm with 'y' if prompted"
-echo "  4. Run: reboot"
-echo ""
-echo "Press Enter to boot into recovery mode..."
-read -r
-
-tart run "$VM_BASE_NAME" --recovery
-
-# Step 6: Configure auto-login, sudo, and SSH key
-echo ""
-echo "--- Step 5: Configuring auto-login and SSH ---"
+echo "--- Step 4: Configuring auto-login and SSH ---"
 echo "Booting VM headlessly..."
 tart run "$VM_BASE_NAME" --vnc-experimental --no-graphics &
 SETUP_PID=$!
@@ -134,17 +119,6 @@ ssh -o StrictHostKeyChecking=no admin@"$VM_IP" \
     'sudo sh -c "printf \"\\x1c\\xed\\x3f\\x4a\\xbc\\xbc\\x43\\xb4\\x59\\x33\\xb1\" > /etc/kcpassword && chmod 600 /etc/kcpassword"'
 echo "Auto-login configured"
 
-# Enable system extension developer mode (requires SIP disabled)
-echo "Enabling system extension developer mode..."
-ssh -o StrictHostKeyChecking=no admin@"$VM_IP" \
-    'sudo python3 -c "
-import plistlib
-db = {\"version\": 1, \"developerMode\": True, \"extensions\": [], \"extensionPolicies\": []}
-with open(\"/Library/SystemExtensions/db.plist\", \"wb\") as f:
-    plistlib.dump(db, f, fmt=plistlib.FMT_BINARY)
-print(\"Developer mode enabled\")
-"'
-
 # Stop VM
 tart stop "$VM_BASE_NAME" 2>/dev/null || true
 wait $SETUP_PID 2>/dev/null || true
@@ -172,11 +146,15 @@ if [ -z "$APP_BUILD_PATH" ]; then
     exit 1
 fi
 
-# Verify signing (system extensions require proper code signing)
+# Verify signing (the Network Extension app extension requires a team ID)
 TEAM_ID=$(codesign -d --verbose=2 "$APP_BUILD_PATH" 2>&1 | grep TeamIdentifier | awk -F= '{print $2}')
 if [ -z "$TEAM_ID" ] || [ "$TEAM_ID" = "not set" ]; then
-    echo "ERROR: App is not properly signed. System extensions require code signing."
+    echo "ERROR: App is not properly signed. The Network Extension requires code signing."
     echo "Make sure Local.xcconfig has DEVELOPMENT_TEAM set."
+    exit 1
+fi
+if [ ! -d "$APP_BUILD_PATH/Contents/PlugIns/TransparentProxy.appex" ]; then
+    echo "ERROR: TransparentProxy.appex missing from built app"
     exit 1
 fi
 echo "Built app: $APP_BUILD_PATH (Team: $TEAM_ID)"
@@ -214,25 +192,24 @@ vm_install_app "$VM_IP" "$APP_BUILD_PATH"
 tart stop "$VM_BASE_NAME" 2>/dev/null || true
 wait $SETUP_PID 2>/dev/null || true
 
-# Step 8: Approve system extension + network extension in GUI
+# Step 8: Approve the network extension in GUI
 echo ""
-echo "--- Step 8: Approve system extension + network extension ---"
+echo "--- Step 7: Approve the network extension ---"
 echo ""
 echo "  The VM will open with a GUI. You need to:"
 echo ""
 echo "  1. BaoLianDeng.app is already installed in /Applications"
-echo "  2. Open it — it will request system extension activation"
-echo "  3. A notification will appear asking to allow the extension"
-echo "  4. Open System Settings > General > Login Items & Extensions"
-echo "  5. Under 'Network Extensions', toggle ON BaoLianDeng"
-echo "  6. You may also need to click 'Allow' in a separate dialog"
-echo "  7. Verify: open Terminal and run: scutil --nc list"
+echo "  2. Open it — macOS will ask to allow the Network Extension"
+echo "  3. Open System Settings > General > Login Items & Extensions"
+echo "  4. Under 'Network Extensions', toggle ON BaoLianDeng"
+echo "  5. You may also need to click 'Allow' in a separate dialog"
+echo "  6. Verify: open Terminal and run: scutil --nc list"
 echo "     It should show 'BaoLianDeng' in the list"
-echo "  8. Shut down the VM from the Apple menu"
+echo "  7. Shut down the VM from the Apple menu"
 echo ""
-echo "  NOTE: Both the system extension AND the network extension"
-echo "  (transparent proxy filter) must be approved. These are"
-echo "  separate approvals in System Settings."
+echo "  NOTE: The provider is PlugIns/TransparentProxy.appex. There is"
+echo "  no system-extension approval dialog and systemextensionsctl is"
+echo "  not involved."
 echo ""
 echo "Press Enter to boot the VM..."
 read -r

--- a/tests/e2e/vm-stress-test.sh
+++ b/tests/e2e/vm-stress-test.sh
@@ -90,9 +90,10 @@ echo "--- Step 6: Wait for engine ---"
 LOG_FILE="$LOG_DIR/rust_bridge.log"
 ENGINE_READY=false
 for i in $(seq 1 30); do
-    if [ -f "$LOG_FILE" ] && \
-       grep -q "engine started successfully" "$LOG_FILE" 2>/dev/null && \
-       grep -q "packet_thread: entering main loop" "$LOG_FILE" 2>/dev/null; then
+    if [ -f "$LOG_FILE" ] && {
+           grep -q "meow engine started" "$LOG_FILE" 2>/dev/null ||
+           grep -q "engine started successfully" "$LOG_FILE" 2>/dev/null
+       }; then
         echo "Engine ready after ${i}s"
         ENGINE_READY=true
         sleep 3

--- a/tests/e2e/vm-test.sh
+++ b/tests/e2e/vm-test.sh
@@ -73,14 +73,17 @@ for i in $(seq 1 60); do
     fi
     if [ $((i % 15)) -eq 0 ]; then
         echo "Still waiting for VPN manager... ${i}s"
-        systemextensionsctl list 2>/dev/null | grep -i bao || true
+        ls "$APP_PATH/Contents/PlugIns/" 2>/dev/null || true
+        scutil --nc status "$VPN_NAME" 2>/dev/null | head -1 || true
     fi
     sleep 1
 done
 if [ "$VPN_READY" = false ]; then
     echo "ERROR: VPN manager not ready after 60s"
-    echo "System extensions:"
-    systemextensionsctl list 2>/dev/null || true
+    echo "App extension:"
+    ls -la "$APP_PATH/Contents/PlugIns/" 2>/dev/null || true
+    echo "VPN status:"
+    scutil --nc status "$VPN_NAME" 2>/dev/null || true
     echo "App VPN logs (since launch):"
     /usr/bin/log show --start "$LAUNCH_TIME" --style compact --predicate "subsystem == 'io.github.baoliandeng'" 2>/dev/null | tail -20 || true
     exit 1
@@ -146,13 +149,12 @@ else
     fail "Traffic stats endpoint not responding"
 fi
 
-# Test 4: System extension is active
-echo "--- Test: System extension ---"
-SYSEXT=$(systemextensionsctl list 2>/dev/null | grep -c "activated enabled" || echo "0")
-if [ "$SYSEXT" -gt 0 ]; then
-    pass "System extension is activated and enabled"
+# Test 4: App extension is embedded
+echo "--- Test: App extension ---"
+if [ -d "$APP_PATH/Contents/PlugIns/TransparentProxy.appex" ]; then
+    pass "TransparentProxy.appex is embedded"
 else
-    fail "System extension not active"
+    fail "TransparentProxy.appex missing from app bundle"
 fi
 
 # Test 5: DNS resolution via tunnel


### PR DESCRIPTION
## Summary
Salvage of the unique leftovers from closed #103 (that PR could not merge: it would have regressed #105–#109).

- Keep `bridge_version` in lockstep with the pinned meow-rs **0.21.1** workspace version.
- Local Debug/Release deploy scripts now require `PlugIns/TransparentProxy.appex`, prune the Developer ID system-extension product so the two providers cannot share a bundle ID at runtime, start via the autoconnect sentinel, and wait for `meow engine started` (the Go-era `packet_thread` marker never fires on meow-rs).
- E2E no longer assumes a SIP-off system-extension VM: drop `systemextensionsctl` / recovery-mode SIP disable, require the appex instead.
- Docs/comments describe the default provider as the app extension. Developer ID PKG/DMG still ship the system-extension variant (TN3134).

Not in this PR (intentionally left on `main`): meow-rs 0.21.1 pin, per-subscription `ProxyGroupSelections`, hermetic SOCKS5 tests, controller-secret TrafficStore tests.

## Test plan
- [x] `cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings && cargo test --lib` in `Rust/meow-ffi` (23 passed)
- [x] `swiftlint lint --strict` (0 violations)
- [x] `xcodebuild test … -only-testing:BaoLianDengTests` (220 passed)
- [ ] CI: `make framework` + Debug/Release app build