### PR TITLE
Fix the seven audit defects from #113

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,8 @@ xcuserdata/
 # Framework (built from Rust source)
 Framework/MihomoCore.xcframework/
 
-# Rust build artifacts
-Rust/meow-ffi/target/
+# Rust build artifacts (also matches a symlinked target directory)
+Rust/meow-ffi/target
 
 # Release artifacts
 *.dmg
@@ -61,3 +61,5 @@ GoogleService-Info.plist
 CLAUDE.md
 .claude/
 docs/superpowers/
+# Worktree-local DerivedData
+.dd/

--- a/BaoLianDeng.xcodeproj/project.pbxproj
+++ b/BaoLianDeng.xcodeproj/project.pbxproj
@@ -61,6 +61,10 @@
 		B10209 /* VPNToolbarContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10208 /* VPNToolbarContent.swift */; };
 		B10400A /* SOCKS5Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10400 /* SOCKS5Client.swift */; };
 		B10400B /* SOCKS5Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10400 /* SOCKS5Client.swift */; };
+		I113T0002 /* TCPRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = I113T0001 /* TCPRelay.swift */; };
+		I113T0003 /* TCPRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = I113T0001 /* TCPRelay.swift */; };
+		I113T0004 /* TCPRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = I113T0001 /* TCPRelay.swift */; };
+		I113T0011 /* TCPRelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = I113T0010 /* TCPRelayTests.swift */; };
 		C3DAB7AB1483CF34E41BAAFB /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10090 /* AppLogger.swift */; };
 		C715B3A41E6034141A9329BE /* MihomoCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = B10030 /* MihomoCore.xcframework */; };
 		CEE9200E5015BA697A46FD4A /* TransparentProxy.systemextension in Embed System Extensions */ = {isa = PBXBuildFile; fileRef = 259DB0A8D1BC3A31D635256A /* TransparentProxy.systemextension */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -208,6 +212,8 @@
 		B10206 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		B10208 /* VPNToolbarContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNToolbarContent.swift; sourceTree = "<group>"; };
 		B10400 /* SOCKS5Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SOCKS5Client.swift; sourceTree = "<group>"; };
+		I113T0001 /* TCPRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCPRelay.swift; sourceTree = "<group>"; };
+		I113T0010 /* TCPRelayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCPRelayTests.swift; sourceTree = "<group>"; };
 		EEB4B615F35B5B3D01F6349F /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		T10007 /* PerAppProxySettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerAppProxySettingsTests.swift; sourceTree = "<group>"; };
 		T10010 /* BaoLianDengTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BaoLianDengTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -341,6 +347,7 @@
 				B10020 /* TransparentProxyProvider.swift */,
 				B10021 /* UDPNATRelay.swift */,
 				B10400 /* SOCKS5Client.swift */,
+				I113T0001 /* TCPRelay.swift */,
 			);
 			path = TransparentProxy;
 			sourceTree = "<group>";
@@ -442,6 +449,7 @@
 				T10040 /* ProxyEngineIntegrationTests.swift */,
 				T10052 /* ProxyGroupsViewModelTests.swift */,
 				PGS10004 /* ProxyGroupSelectionsTests.swift */,
+				I113T0010 /* TCPRelayTests.swift */,
 			);
 			path = BaoLianDengTests;
 			sourceTree = "<group>";
@@ -647,6 +655,7 @@
 				A1B2C3D4E5F60718293A4B5E /* PerAppProxySection.swift in Sources */,
 				LS100004 /* LANSharingSection.swift in Sources */,
 				B10400B /* SOCKS5Client.swift in Sources */,
+				I113T0002 /* TCPRelay.swift in Sources */,
 				B10201 /* SubscriptionModels.swift in Sources */,
 				B10203 /* NodeRow.swift in Sources */,
 				B10205 /* MainContentView.swift in Sources */,
@@ -662,6 +671,7 @@
 				9EAAFF911784E9AE012953A3 /* TransparentProxyProvider.swift in Sources */,
 				A2B3C4D5E6F7A8B9C0D1E2F3 /* UDPNATRelay.swift in Sources */,
 				B10400A /* SOCKS5Client.swift in Sources */,
+				I113T0003 /* TCPRelay.swift in Sources */,
 				F0MAIN0001 /* main.swift in Sources */,
 				EBAC80D31A3CCD3F3C083FDA /* AppLogger.swift in Sources */,
 				9C1CFB15DEC224B8210EA2E9 /* Constants.swift in Sources */,
@@ -681,6 +691,7 @@
 				AX10020 /* TransparentProxyProvider.swift in Sources */,
 				AX10021 /* UDPNATRelay.swift in Sources */,
 				AX10022 /* SOCKS5Client.swift in Sources */,
+				I113T0004 /* TCPRelay.swift in Sources */,
 				AX10023 /* AppLogger.swift in Sources */,
 				AX10024 /* Constants.swift in Sources */,
 				AX10025 /* ConfigManager.swift in Sources */,
@@ -704,6 +715,7 @@
 				T10041 /* ProxyEngineIntegrationTests.swift in Sources */,
 				T10053 /* ProxyGroupsViewModelTests.swift in Sources */,
 				PGS10005 /* ProxyGroupSelectionsTests.swift in Sources */,
+				I113T0011 /* TCPRelayTests.swift in Sources */,
 				T10045 /* TestConfigs.swift in Sources */,
 				T10047 /* ProxyEngineHelper.swift in Sources */,
 			);

--- a/BaoLianDeng/Views/ConfigEditorView.swift
+++ b/BaoLianDeng/Views/ConfigEditorView.swift
@@ -19,6 +19,12 @@ struct ConfigEditorView: View {
     @State private var configText = ""
     @State private var proxyGroups: [EditableProxyGroup] = []
     @State private var rules: [EditableRule] = []
+    /// Snapshot taken by `reparseConfig()`. While the structured editor
+    /// still matches it, `configText` is used as-is instead of being
+    /// regenerated from the model, so an untouched config keeps its
+    /// comments and formatting byte-for-byte.
+    @State private var parsedProxyGroups: [EditableProxyGroup] = []
+    @State private var parsedRules: [EditableRule] = []
     @State private var subscriptionText = ""
     @State private var subscriptionProxyGroups: [EditableProxyGroup] = []
     @State private var subscriptionRules: [EditableRule] = []
@@ -174,15 +180,24 @@ struct ConfigEditorView: View {
         from oldMode: EditorMode, to newMode: EditorMode
     ) {
         if oldMode == .structured && newMode == .raw {
-            var yaml = configText
-            yaml = ConfigManager.shared.updateProxyGroups(
-                proxyGroups, in: yaml
-            )
-            yaml = ConfigManager.shared.updateRules(rules, in: yaml)
-            configText = yaml
+            configText = structuredYAML()
         } else if oldMode == .raw && newMode == .structured {
             reparseConfig()
         }
+    }
+
+    /// `configText` with the structured editor's changes written back —
+    /// or `configText` untouched when nothing was edited since the last
+    /// parse, so the proxy-groups / rules sections are not rewritten.
+    private func structuredYAML() -> String {
+        var yaml = configText
+        if proxyGroups != parsedProxyGroups {
+            yaml = ConfigManager.shared.updateProxyGroups(proxyGroups, in: yaml)
+        }
+        if rules != parsedRules {
+            yaml = ConfigManager.shared.updateRules(rules, in: yaml)
+        }
+        return yaml
     }
 
     private func autoSaveRawConfig() {
@@ -235,12 +250,11 @@ struct ConfigEditorView: View {
                 try ConfigManager.shared.saveConfig(configText)
                 reparseConfig()
             } else {
-                var yaml = configText
-                yaml = ConfigManager.shared.updateProxyGroups(
-                    proxyGroups, in: yaml)
-                yaml = ConfigManager.shared.updateRules(rules, in: yaml)
+                let yaml = structuredYAML()
                 try ConfigManager.shared.saveConfig(yaml)
                 configText = yaml
+                parsedProxyGroups = proxyGroups
+                parsedRules = rules
             }
             showSavedToast()
             if vpnManager.isConnected {
@@ -272,6 +286,8 @@ struct ConfigEditorView: View {
         proxyGroups = ConfigManager.shared.parseProxyGroups(
             from: configText)
         rules = ConfigManager.shared.parseRules(from: configText)
+        parsedProxyGroups = proxyGroups
+        parsedRules = rules
     }
 
     private func showSavedToast() {

--- a/BaoLianDeng/Views/ConfigEditorView.swift
+++ b/BaoLianDeng/Views/ConfigEditorView.swift
@@ -219,13 +219,15 @@ struct ConfigEditorView: View {
         selectedSubscription = sub
         subscriptionText = sub.rawContent ?? ""
         guard !subscriptionText.isEmpty else { source = .local; return }
-        try? ConfigManager.shared.applySubscriptionConfig(
-            subscriptionText)
-        configText = (try? ConfigManager.shared.loadConfig())
-            ?? ConfigManager.shared.defaultConfig()
-        reparseConfig()
-        subscriptionProxyGroups = proxyGroups
-        subscriptionRules = rules
+        // Render the read-only subscription view from an in-memory merge.
+        // Writing that merge to disk here (as this used to) replaced the
+        // user's saved rule/group edits every time the editor appeared;
+        // config.yaml only changes when a subscription is selected or
+        // fetched (see `ConfigManager.loadBaseConfig`).
+        let merged = ConfigManager.shared.mergeSubscription(subscriptionText)
+        subscriptionProxyGroups = ConfigManager.shared.parseProxyGroups(
+            from: merged)
+        subscriptionRules = ConfigManager.shared.parseRules(from: merged)
     }
 
     private func saveConfig() {

--- a/BaoLianDeng/Views/ConfigEditorView.swift
+++ b/BaoLianDeng/Views/ConfigEditorView.swift
@@ -22,7 +22,10 @@ struct ConfigEditorView: View {
     /// Snapshot taken by `reparseConfig()`. While the structured editor
     /// still matches it, `configText` is used as-is instead of being
     /// regenerated from the model, so an untouched config keeps its
-    /// comments and formatting byte-for-byte.
+    /// comments and formatting byte-for-byte. The comparison deliberately
+    /// includes each item's `id`: both sides come from the same parse, so
+    /// identity equality is exact, and a removed-then-re-added group
+    /// counts as an edit.
     @State private var parsedProxyGroups: [EditableProxyGroup] = []
     @State private var parsedRules: [EditableRule] = []
     @State private var subscriptionText = ""

--- a/BaoLianDeng/Views/HomeView.swift
+++ b/BaoLianDeng/Views/HomeView.swift
@@ -383,10 +383,11 @@ struct HomeView: View {
             subscriptions = result.subs
             if let id = result.selectedID {
                 selectedSubscriptionID = id
-                if let sub = result.subs.first(where: { $0.id == id }),
-                   let raw = sub.rawContent {
-                    try? ConfigManager.shared.applySubscriptionConfig(raw)
-                }
+                // The selected subscription was merged into config.yaml when
+                // it was selected/fetched; re-applying it on every launch
+                // would wipe the edits the Config Editor saved since. Only
+                // a missing file is (re)built here.
+                try? ConfigManager.shared.ensureBaseConfig()
             }
             fetchNewSubscriptions()
         }

--- a/BaoLianDeng/Views/HomeView.swift
+++ b/BaoLianDeng/Views/HomeView.swift
@@ -345,6 +345,25 @@ struct HomeView: View {
                 loadProxyGroups()
             }
         } else {
+            // Nothing to merge yet (the fetch re-selects once it lands).
+            // config.yaml still carries the previously selected
+            // subscription, so detach it rather than keep running its nodes
+            // behind a UI that shows this one as selected.
+            detachSubscriptionConfig()
+        }
+    }
+
+    /// Put the built-in defaults back into `config.yaml` and restart. Startup
+    /// runs the saved file as-is and never consults the selection (see
+    /// `ConfigManager.loadBaseConfig`), so whenever the selection goes away
+    /// the merged sections have to be cleared here explicitly — otherwise the
+    /// engine keeps routing through a subscription the UI no longer shows.
+    private func detachSubscriptionConfig() {
+        Task {
+            _ = await Task.detached {
+                try? ConfigManager.shared.clearSubscriptionConfig()
+            }.value
+            await Self.applyConfigByRestartingTunnel()
             loadProxyGroups()
         }
     }
@@ -511,6 +530,7 @@ struct HomeView: View {
     }
 
     private func deleteSubscription(at offsets: IndexSet) {
+        var deletedSelected = false
         for i in offsets {
             // Forget this subscription's per-group selections, so re-adding it
             // later starts from the config's own defaults.
@@ -520,9 +540,13 @@ struct HomeView: View {
             AppConstants.sharedDefaults
                 .removeObject(forKey: "selectedSubscriptionID")
             proxyGroupsVM.reloadSelectionsForActiveSubscription()
+            deletedSelected = true
         }
         subscriptions.remove(atOffsets: offsets)
         saveSubscriptions()
+        if deletedSelected {
+            detachSubscriptionConfig()
+        }
     }
 
     private func refreshSubscription(_ sub: inout Subscription) {

--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Testing
+import Yams
 @testable import BaoLianDeng
 
 // MARK: - YAML Section Extraction
@@ -1429,5 +1430,242 @@ struct BundledGeodataTests {
             let size = try #require(attributes[.size] as? NSNumber)
             #expect(size.intValue > 0)
         }
+    }
+}
+
+// MARK: - Effective config (issue #113)
+
+/// Regression coverage for madeye/BaoLianDeng#113: startup must run the
+/// user's saved `config.yaml`, not a rebuilt default / subscription merge.
+@Suite("buildEffectiveConfig")
+struct BuildEffectiveConfigTests {
+
+    /// A base the Config Editor could have saved: custom proxy, custom rule,
+    /// and a user-chosen DNS nameserver list.
+    static let editedBase = """
+    mixed-port: 0
+    mode: rule
+    log-level: info
+    allow-lan: false
+    bind-address: 127.0.0.1
+    external-controller: 127.0.0.1:0
+
+    geo-auto-update: false
+
+    dns:
+      enable: true
+      listen: 127.0.0.1:0
+      enhanced-mode: fake-ip
+      fake-ip-range: 28.0.0.0/8
+      nameserver:
+        - https://my.custom.dns/dns-query
+
+    proxies:
+      - {name: my-ss, type: ss, server: 10.9.8.7, port: 8388, cipher: aes-128-gcm, password: pw}
+
+    proxy-groups:
+      - name: PROXY
+        type: select
+        proxies:
+          - my-ss
+          - DIRECT
+
+    rules:
+      - DOMAIN-SUFFIX,my-custom-domain.example,PROXY
+      - MATCH,DIRECT
+    """
+
+    private func build(
+        _ base: String,
+        engineMode: EngineMode = .vpn,
+        logLevel: String? = nil,
+        proxyMode: String = "rule",
+        lan: LANSharingSettings = LANSharingSettings(),
+        localProxyPort: UInt16 = 7890
+    ) -> String {
+        ConfigManager.buildEffectiveConfig(
+            base: base, engineMode: engineMode,
+            settings: EngineRuntimeSettings(
+                logLevel: logLevel, proxyMode: proxyMode,
+                lanSharing: lan, localProxyPort: localProxyPort
+            )
+        )
+    }
+
+    @Test("Custom proxies, rules and DNS from the saved base survive (no subscription)")
+    func keepsUserEditsWithoutSubscription() {
+        let effective = build(Self.editedBase)
+        #expect(effective.contains("name: my-ss"))
+        #expect(effective.contains("DOMAIN-SUFFIX,my-custom-domain.example,PROXY"))
+        #expect(effective.contains("https://my.custom.dns/dns-query"))
+        // The built-in default rule set must not have been substituted in.
+        #expect(!effective.contains("DOMAIN-SUFFIX,google.com,PROXY"))
+        #expect(!effective.contains("MATCH,PROXY"))
+    }
+
+    @Test("Edits made on top of a merged subscription survive reconnect")
+    func keepsUserEditsOnTopOfSubscription() {
+        let sub = """
+        proxies:
+          - {name: sub-node, type: vless, server: 1.2.3.4, port: 443, uuid: u}
+        proxy-groups:
+          - name: Proxies
+            type: select
+            proxies:
+              - sub-node
+        rules:
+          - DOMAIN-SUFFIX,example.com,Proxies
+          - MATCH,DIRECT
+        """
+        let defaultCfg = ConfigManager.shared.defaultConfig()
+        // Selecting the subscription merges it INTO config.yaml …
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: defaultCfg, defaultConfig: defaultCfg
+        )
+        // … and the user then adds a rule and a nameserver in the editor.
+        var edited = merged.replacingOccurrences(
+            of: "  - DOMAIN-SUFFIX,example.com,Proxies",
+            with: "  - DOMAIN-KEYWORD,user-added,Proxies\n  - DOMAIN-SUFFIX,example.com,Proxies"
+        )
+        edited = edited.replacingOccurrences(
+            of: "  nameserver:\n",
+            with: "  nameserver:\n    - tls://user.dns.example\n"
+        )
+        #expect(edited.contains("DOMAIN-KEYWORD,user-added,Proxies"))
+        #expect(edited.contains("tls://user.dns.example"))
+
+        let effective = build(edited)
+        #expect(effective.contains("name: sub-node"))
+        #expect(effective.contains("DOMAIN-KEYWORD,user-added,Proxies"))
+        #expect(effective.contains("DOMAIN-SUFFIX,example.com,Proxies"))
+        #expect(effective.contains("tls://user.dns.example"))
+    }
+
+    @Test("Runtime settings are layered on without touching user sections")
+    func appliesRuntimeSettings() {
+        let lan = LANSharingSettings()
+        let effective = build(
+            Self.editedBase, logLevel: "debug", proxyMode: "global", lan: lan
+        )
+        #expect(effective.contains("log-level: debug"))
+        #expect(effective.contains("mode: global"))
+        #expect(effective.contains("allow-lan: false"))
+        #expect(effective.contains("name: my-ss"))
+
+        var lanOn = LANSharingSettings()
+        lanOn.enabled = true
+        lanOn.proxyPort = 17890
+        let shared = build(Self.editedBase, lan: lanOn)
+        #expect(shared.contains("allow-lan: true"))
+        #expect(shared.contains("bind-address: 0.0.0.0"))
+        #expect(shared.contains("mixed-port: 17890"))
+
+        let local = build(Self.editedBase, engineMode: .localProxy, localProxyPort: 7891)
+        #expect(local.contains("mixed-port: 7891"))
+    }
+
+    @Test("Engine-mode DNS invariants are re-applied to a base saved in the other mode")
+    func reappliesDNSInvariantsForCurrentMode() {
+        // editedBase was saved while in VPN mode (fake-ip).
+        let local = build(Self.editedBase, engineMode: .localProxy)
+        #expect(local.contains("enhanced-mode: redir-host"))
+        #expect(!local.contains("fake-ip-range"))
+        #expect(local.contains("https://my.custom.dns/dns-query"))
+
+        let vpn = build(Self.editedBase, engineMode: .vpn)
+        #expect(vpn.contains("enhanced-mode: fake-ip"))
+        #expect(vpn.contains("fake-ip-range: 28.0.0.0/8"))
+    }
+
+    @Test("Sanitizer invariants hold on the effective config")
+    func sanitizerInvariants() throws {
+        let base = """
+        mode: rule
+        tun:
+          enable: true
+        geo-auto-update: true
+        subscriptions:
+          - url: https://example.com/sub
+        proxies: []
+        proxy-groups:
+          - name: PROXY
+            type: select
+            proxies:
+              - DIRECT
+        rules:
+          - MATCH,PROXY
+        """
+        let effective = build(base)
+        let parsed = try #require(try Yams.load(yaml: effective) as? [String: Any])
+        let tun = try #require(parsed["tun"] as? [String: Any])
+        #expect(tun["enable"] as? Bool == false)
+        #expect(effective.contains("geo-auto-update: false"))
+        #expect(!effective.contains("subscriptions:"))
+        // No dns: block in the base → the managed fallback is inserted.
+        #expect(effective.contains("enhanced-mode: fake-ip"))
+    }
+
+    @Test("A PROXY group is injected when the base's rules dangle on it")
+    func injectsProxyFallback() {
+        let base = """
+        mode: rule
+        proxies:
+          - {name: n1, type: ss, server: 1.1.1.1, port: 1, cipher: aes-128-gcm, password: p}
+        rules:
+          - MATCH,PROXY
+        """
+        let effective = build(base)
+        let groups = ConfigManager.shared.parseProxyGroups(from: effective)
+        #expect(groups.contains { $0.name == "PROXY" })
+    }
+}
+
+@Suite("Local proxy runtime directory")
+struct RuntimeDirectoryTests {
+
+    @Test("Preparing the runtime directory never rewrites the saved config.yaml")
+    func doesNotClobberSavedConfig() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("bld-runtime-test-\(UUID().uuidString)", isDirectory: true)
+        let configDir = root.appendingPathComponent("mihomo", isDirectory: true)
+        let runtimeDir = configDir.appendingPathComponent("runtime", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let saved = "# user's saved config\nmode: rule\nproxies: []\n"
+        let savedURL = configDir.appendingPathComponent(AppConstants.configFileName)
+        try saved.write(to: savedURL, atomically: true, encoding: .utf8)
+
+        // A stand-in geodata file (any size) should get linked in beside the
+        // derived YAML.
+        let geoName = "\(ConfigManager.geodataFiles[0].name).\(ConfigManager.geodataFiles[0].ext)"
+        try Data("geo".utf8).write(to: configDir.appendingPathComponent(geoName))
+
+        let derived = "mode: global\nlog-level: debug\nproxies: []\n"
+        try ConfigManager.prepareRuntimeDirectory(
+            at: runtimeDir, geodataDir: configDir, runtimeYAML: derived
+        )
+
+        #expect(try String(contentsOf: savedURL, encoding: .utf8) == saved)
+        let runtimeConfig = runtimeDir.appendingPathComponent(AppConstants.configFileName)
+        #expect(try String(contentsOf: runtimeConfig, encoding: .utf8) == derived)
+        #expect(FileManager.default.fileExists(atPath: runtimeDir.appendingPathComponent(geoName).path))
+
+        // Re-preparing (next start) replaces the derived file and re-links
+        // geodata without erroring on the existing entries.
+        try Data("geo-v2".utf8).write(to: configDir.appendingPathComponent(geoName))
+        try ConfigManager.prepareRuntimeDirectory(
+            at: runtimeDir, geodataDir: configDir, runtimeYAML: derived + "allow-lan: true\n"
+        )
+        #expect(try String(contentsOf: savedURL, encoding: .utf8) == saved)
+        #expect(try Data(contentsOf: runtimeDir.appendingPathComponent(geoName)) == Data("geo-v2".utf8))
+    }
+
+    @Test("Runtime directory is a child of the config directory, distinct from config.yaml")
+    func runtimeDirectoryLayout() throws {
+        let configDir = try #require(ConfigManager.shared.configDirectoryURL)
+        let runtimeDir = try #require(ConfigManager.shared.runtimeDirectoryURL)
+        #expect(runtimeDir.deletingLastPathComponent().standardizedFileURL == configDir.standardizedFileURL)
+        #expect(runtimeDir.appendingPathComponent(AppConstants.configFileName) != ConfigManager.shared.configFileURL)
     }
 }

--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Testing
+import Yams
 @testable import BaoLianDeng
 
 // MARK: - YAML Section Extraction
@@ -115,6 +116,26 @@ struct ExtractYAMLSectionsTests {
         #expect(proxies.contains("node2"))
     }
 
+    @Test("A column-0 flow closer stays with its section")
+    func flowCloserStaysWithSection() {
+        let yaml = """
+        dns: {
+          enable: true,
+          nameserver: [1.1.1.1]
+        }
+        proxies: [
+        ]
+        rules:
+          - MATCH,DIRECT
+        """
+        let sections = ConfigManager.extractYAMLSections(
+            from: yaml, named: ["dns", "proxies", "rules"]
+        )
+        #expect(sections["dns"] == "dns: {\n  enable: true,\n  nameserver: [1.1.1.1]\n}")
+        #expect(sections["proxies"] == "proxies: [\n]")
+        #expect(sections["rules"] == "rules:\n  - MATCH,DIRECT")
+    }
+
     @Test("Indented lines not treated as top-level keys")
     func indentedLinesNotTopLevel() {
         // Regression: YAML generated with leading spaces should not match top-level keys
@@ -222,6 +243,28 @@ struct MergeSubscriptionTests {
         #expect(merged.contains("enhanced-mode: fake-ip"))
         #expect(merged.contains("fake-ip-range: 28.0.0.0/8"))
         #expect(!merged.contains("redir-host"))
+    }
+
+    @Test("Multi-line flow dns from a subscription is patched into a valid block")
+    func subscriptionMultiLineFlowDNS() throws {
+        let sub = """
+        proxies: []
+        dns: {
+          enable: true,
+          nameserver: [1.1.1.1]
+        }
+        rules:
+          - MATCH,DIRECT
+        """
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: Self.baseConfig, defaultConfig: Self.defaultConfig
+        )
+        let dict = try #require((try? Yams.load(yaml: merged)) as? [String: Any], "merged must parse:\n\(merged)")
+        let dns = try #require(dict["dns"] as? [String: Any])
+        #expect(dns["enhanced-mode"] as? String == "fake-ip")
+        #expect(dns["nameserver"] as? [String] == ["1.1.1.1"])
+        #expect(dict["rules"] as? [String] == ["MATCH,DIRECT"])
+        #expect(merged.components(separatedBy: "dns:").count - 1 == 1)
     }
 
     @Test("Falls back to default rules when subscription has none")
@@ -685,6 +728,127 @@ struct ForceManagedDNSTests {
         #expect(config == once)
         #expect(config.components(separatedBy: "dns:").count - 1 == 1)
     }
+
+    // MARK: Inline (flow-style) dns mappings — issue #113 finding 5
+
+    /// `dns:` section of `config` as parsed by a real YAML parser, or nil
+    /// when the document no longer parses at all.
+    private func dnsMapping(_ config: String) -> [String: Any]? {
+        guard let dict = (try? Yams.load(yaml: config)) as? [String: Any] else { return nil }
+        return dict["dns"] as? [String: Any]
+    }
+
+    @Test("Patches an inline dns mapping into valid block YAML")
+    func normalizesInlineDNSMapping() throws {
+        var config = """
+        proxies: []
+        proxy-groups: []
+        rules:
+          - MATCH,DIRECT
+        dns: {enable: true, nameserver: [1.1.1.1]}
+        """
+        ConfigManager.forceManagedDNS(&config)
+        let dns = try #require(dnsMapping(config), "sanitized config must stay parseable: \(config)")
+        #expect(dns["enable"] as? Bool == true)
+        #expect(dns["listen"] as? String == "127.0.0.1:0")
+        #expect(dns["enhanced-mode"] as? String == "fake-ip")
+        #expect(dns["fake-ip-range"] as? String == "28.0.0.0/8")
+        #expect(dns["nameserver"] as? [String] == ["1.1.1.1"])
+        #expect(config.contains("rules:\n  - MATCH,DIRECT"))
+
+        let once = config
+        ConfigManager.forceManagedDNS(&config)
+        #expect(config == once, "second pass must be a no-op")
+    }
+
+    @Test("Inline and block dns sections come out equivalent")
+    func inlineMatchesBlock() throws {
+        var inline = "mode: rule\ndns: {enable: false, listen: 0.0.0.0:53, nameserver: [1.1.1.1, 8.8.8.8], fallback: [tls://9.9.9.9]}\nproxies: []"
+        var block = """
+        mode: rule
+        dns:
+          enable: false
+          listen: 0.0.0.0:53
+          nameserver:
+            - 1.1.1.1
+            - 8.8.8.8
+          fallback:
+            - tls://9.9.9.9
+        proxies: []
+        """
+        ConfigManager.forceManagedDNS(&inline)
+        ConfigManager.forceManagedDNS(&block)
+        let a = try #require(dnsMapping(inline))
+        let b = try #require(dnsMapping(block))
+        #expect((a as NSDictionary).isEqual(to: b))
+        #expect(a["nameserver"] as? [String] == ["1.1.1.1", "8.8.8.8"])
+        #expect(a["fallback"] as? [String] == ["tls://9.9.9.9"])
+    }
+
+    @Test("Inline dns in local proxy mode gets redir-host")
+    func inlineLocalProxy() throws {
+        var config = "dns: {enable: true, fake-ip-range: 198.18.0.1/16, nameserver: [1.1.1.1]}\nproxies: []"
+        ConfigManager.forceManagedDNS(&config, engineMode: .localProxy)
+        let dns = try #require(dnsMapping(config))
+        #expect(dns["enhanced-mode"] as? String == "redir-host")
+        #expect(dns["fake-ip-range"] == nil)
+        #expect(dns["nameserver"] as? [String] == ["1.1.1.1"])
+    }
+
+    @Test("Multi-line flow dns mapping and a trailing comment survive")
+    func multiLineFlowMapping() throws {
+        var config = """
+        dns: {
+          enable: true,
+          nameserver: [1.1.1.1],
+          nameserver-policy: {"geosite:cn": 223.5.5.5}
+        }
+        # trailing note
+        proxies: []
+        """
+        ConfigManager.forceManagedDNS(&config)
+        let dns = try #require(dnsMapping(config))
+        #expect(dns["enhanced-mode"] as? String == "fake-ip")
+        #expect(dns["nameserver"] as? [String] == ["1.1.1.1"])
+        #expect((dns["nameserver-policy"] as? [String: Any])?["geosite:cn"] as? String == "223.5.5.5")
+        #expect(config.contains("# trailing note\nproxies: []"))
+    }
+
+    @Test("Empty inline dns mapping is filled in")
+    func emptyInlineMapping() throws {
+        var config = "dns: {}\nproxies: []"
+        ConfigManager.forceManagedDNS(&config)
+        let dns = try #require(dnsMapping(config))
+        #expect(dns["enable"] as? Bool == true)
+        #expect(dns["enhanced-mode"] as? String == "fake-ip")
+    }
+
+    @Test("Inline self-referential proxy-server-nameserver is dropped after normalization")
+    func inlineSelfReferenceDropped() throws {
+        var config = "dns: {enable: true, listen: 127.0.0.1:1053, nameserver: [1.1.1.1], proxy-server-nameserver: [udp://127.0.0.1:1053, 8.8.8.8]}\nproxies: []"
+        ConfigManager.forceManagedDNS(&config)
+        let dns = try #require(dnsMapping(config))
+        #expect(dns["proxy-server-nameserver"] as? [String] == ["8.8.8.8"])
+        #expect(dns["listen"] as? String == "127.0.0.1:0")
+    }
+
+    @Test("Block dns with nested flow values is patched in place, comments kept")
+    func blockWithNestedFlowUntouched() throws {
+        var config = """
+        dns:
+          # keep me
+          enable: true
+          nameserver-policy: {"geosite:cn": 223.5.5.5}
+          nameserver: [1.1.1.1]
+        proxies: []
+        """
+        ConfigManager.forceManagedDNS(&config)
+        #expect(config.contains("  # keep me"))
+        #expect(config.contains("nameserver-policy: {\"geosite:cn\": 223.5.5.5}"))
+        let dns = try #require(dnsMapping(config))
+        #expect(dns["enhanced-mode"] as? String == "fake-ip")
+        #expect(dns["nameserver"] as? [String] == ["1.1.1.1"])
+    }
 }
 
 @Suite("Proxy group serialization")
@@ -718,6 +882,139 @@ struct ProxyGroupSerializationTests {
         #expect(parsed[0].proxies == ["proxy: one", "line\nbreak"])
     }
 
+    // MARK: Unmodelled group fields — issue #113 finding 4
+
+    private let providerBackedConfig = """
+    proxy-providers:
+      provider:
+        type: http
+        url: https://example.com/sub.yaml
+        path: ./providers/provider.yaml
+    proxy-groups:
+      - name: Auto
+        type: url-test
+        use: [provider]
+        filter: test
+        exclude-filter: "slow|backup"
+        lazy: true
+        tolerance: 50
+        url: https://www.gstatic.com/generate_204
+        interval: 300
+      - name: Manual
+        type: select
+        include-all: true
+        proxies:
+          - Auto
+          - DIRECT
+      - name: Balance
+        type: load-balance
+        strategy: consistent-hashing
+        use:
+          - provider
+        expected-status: "204"
+    rules:
+      - MATCH,Manual
+    """
+
+    /// `proxy-groups` as generic parsed values, for semantic comparison.
+    private func groupDicts(_ yaml: String) -> [[String: Any]] {
+        ((try? Yams.load(yaml: yaml)) as? [String: Any])?["proxy-groups"] as? [[String: Any]] ?? []
+    }
+
+    @Test("Parsing keeps provider-group fields the editor does not model")
+    func parsesUnmodelledFields() {
+        let groups = ConfigManager.shared.parseProxyGroups(from: providerBackedConfig)
+        #expect(groups.count == 3)
+        #expect(groups[0].proxies.isEmpty)
+        #expect(groups[0].url == "https://www.gstatic.com/generate_204")
+        #expect(groups[0].interval == 300)
+        #expect(groups[0].extraFields.map(\.key) == ["use", "filter", "exclude-filter", "lazy", "tolerance"])
+        #expect(groups[0].extraFields.first?.value.array().compactMap(\.string) == ["provider"])
+        #expect(groups[1].extraFields.map(\.key) == ["include-all"])
+        #expect(groups[1].proxies == ["Auto", "DIRECT"])
+        #expect(groups[2].extraFields.map(\.key) == ["strategy", "use", "expected-status"])
+    }
+
+    @Test("No-edit round trip is semantically identical")
+    func noEditRoundTripPreservesGroups() {
+        let groups = ConfigManager.shared.parseProxyGroups(from: providerBackedConfig)
+        let rewritten = ConfigManager.shared.updateProxyGroups(groups, in: providerBackedConfig)
+
+        let before = groupDicts(providerBackedConfig)
+        let after = groupDicts(rewritten)
+        #expect(after.count == 3)
+        #expect((after as NSArray).isEqual(to: before), "rewritten groups differ:\n\(rewritten)")
+
+        // A provider-backed group must not gain an empty `proxies: []`.
+        #expect(after[0]["proxies"] == nil)
+        #expect(after[0]["use"] as? [String] == ["provider"])
+        #expect(after[0]["filter"] as? String == "test")
+        #expect(after[0]["lazy"] as? Bool == true)
+        #expect(after[0]["tolerance"] as? Int == 50)
+        #expect(after[2]["expected-status"] as? String == "204")
+
+        // Untouched sections are byte-identical.
+        #expect(rewritten.hasPrefix("proxy-providers:\n  provider:\n"))
+        #expect(rewritten.hasSuffix("rules:\n  - MATCH,Manual"))
+
+        // And a second round trip is stable.
+        let again = ConfigManager.shared.updateProxyGroups(
+            ConfigManager.shared.parseProxyGroups(from: rewritten), in: rewritten
+        )
+        #expect(again == rewritten)
+    }
+
+    @Test("Editing a modelled property leaves the other fields intact")
+    func editKeepsUnmodelledFields() {
+        var groups = ConfigManager.shared.parseProxyGroups(from: providerBackedConfig)
+        groups[0].interval = 600
+        groups[0].name = "Auto (fast)"
+        groups[1].proxies.append("REJECT")
+        let rewritten = ConfigManager.shared.updateProxyGroups(groups, in: providerBackedConfig)
+        let after = groupDicts(rewritten)
+
+        #expect(after[0]["name"] as? String == "Auto (fast)")
+        #expect(after[0]["interval"] as? Int == 600)
+        #expect(after[0]["use"] as? [String] == ["provider"])
+        #expect(after[0]["filter"] as? String == "test")
+        #expect(after[0]["exclude-filter"] as? String == "slow|backup")
+        #expect(after[0]["lazy"] as? Bool == true)
+        #expect(after[1]["proxies"] as? [String] == ["Auto", "DIRECT", "REJECT"])
+        #expect(after[1]["include-all"] as? Bool == true)
+        #expect(after[2]["strategy"] as? String == "consistent-hashing")
+    }
+
+    @Test("Nested mappings and quoted scalars in extra fields survive")
+    func nestedExtraFieldsSurvive() {
+        let yaml = """
+        proxy-groups:
+          - name: G
+            type: select
+            proxies: [a]
+            icon: "https://example.com/icon.png#x"
+            health-check: {enable: true, url: 'http://cp.cloudflare.com', interval: 60}
+            exclude-type: [ss, vmess]
+        """
+        let groups = ConfigManager.shared.parseProxyGroups(from: yaml)
+        let rewritten = ConfigManager.shared.updateProxyGroups(groups, in: yaml)
+        let after = groupDicts(rewritten)
+        #expect(after.count == 1)
+        #expect(after[0]["icon"] as? String == "https://example.com/icon.png#x")
+        let health = after[0]["health-check"] as? [String: Any]
+        #expect(health?["enable"] as? Bool == true)
+        #expect(health?["url"] as? String == "http://cp.cloudflare.com")
+        #expect(health?["interval"] as? Int == 60)
+        #expect(after[0]["exclude-type"] as? [String] == ["ss", "vmess"])
+        #expect(after[0]["proxies"] as? [String] == ["a"])
+    }
+
+    @Test("Groups built in the editor still serialize an empty proxies list")
+    func editorGroupsKeepEmptyProxies() {
+        let groups = [EditableProxyGroup(name: "Empty", type: "select", proxies: [])]
+        let yaml = ConfigManager.shared.updateProxyGroups(groups, in: "rules:\n  - MATCH,DIRECT")
+        #expect(yaml.contains("    proxies: []"))
+        #expect(groups[0].extraFields.isEmpty)
+    }
 }
 
 @Suite("Rule serialization")
@@ -875,6 +1172,20 @@ struct SanitizeConfigStringTests {
         #expect(config == once)
         #expect(config.components(separatedBy: "tun:").count - 1 == 1)
     }
+
+    @Test("Disables an inline tun mapping")
+    func disablesInlineTUN() throws {
+        var config = "tun: {enable: true, stack: system}\nproxies: []\nrules:\n  - MATCH,DIRECT"
+        ConfigManager.sanitizeConfigString(&config)
+        let dict = try #require((try? Yams.load(yaml: config)) as? [String: Any])
+        let tun = try #require(dict["tun"] as? [String: Any])
+        #expect(tun["enable"] as? Bool == false)
+        #expect(tun["stack"] as? String == "system")
+        #expect(config.components(separatedBy: "tun:").count - 1 == 1)
+        let once = config
+        ConfigManager.sanitizeConfigString(&config)
+        #expect(config == once)
+    }
 }
 
 // MARK: - Provider sanitization (untrusted subscription input)
@@ -991,6 +1302,36 @@ struct SanitizeProvidersTests {
         #expect(!result.contains("insecure"))
         #expect(!result.contains("rules1:"))
         #expect(result.contains("rule-providers:"))
+    }
+
+    @Test("Inline (flow-style) providers are still checked")
+    func sanitizesInlineProviders() throws {
+        let section = """
+        proxy-providers:
+          good: {type: http, url: "https://example.com/sub.yaml", path: ./providers/good.yaml, interval: 3600}
+          leak: {type: http, url: "file:///etc/passwd", path: ./providers/leak.yaml}
+          escape: {type: http, url: "https://example.com/e.yaml", path: ../../.ssh/id_rsa}
+        """
+        let result = ConfigManager.sanitizeProviders(section)
+        #expect(!result.contains("leak"))
+        #expect(!result.contains("file://"))
+        #expect(!result.contains("../../"))
+        let dict = try #require((try? Yams.load(yaml: result)) as? [String: Any])
+        let providers = try #require(dict["proxy-providers"] as? [String: Any])
+        #expect(Set(providers.keys) == ["good", "escape"])
+        let good = try #require(providers["good"] as? [String: Any])
+        #expect(good["url"] as? String == "https://example.com/sub.yaml")
+        #expect(good["path"] as? String == "./providers/good.yaml")
+        #expect(good["interval"] as? Int == 3600)
+        #expect((providers["escape"] as? [String: Any])?["path"] as? String == "id_rsa")
+    }
+
+    @Test("A fully inline providers section is still checked")
+    func sanitizesSingleLineProvidersSection() {
+        let section = "proxy-providers: {leak: {type: http, url: 'file:///etc/hosts', path: ./x.yaml}}"
+        let result = ConfigManager.sanitizeProviders(section)
+        #expect(!result.contains("file://"))
+        #expect(result.hasPrefix("proxy-providers:"))
     }
 }
 

--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -1669,3 +1669,111 @@ struct RuntimeDirectoryTests {
         #expect(runtimeDir.appendingPathComponent(AppConstants.configFileName) != ConfigManager.shared.configFileURL)
     }
 }
+
+/// The counterpart of the "merged INTO config.yaml" model: once the selection
+/// goes away (selected subscription deleted, or an unfetched one selected),
+/// the file must stop carrying the old subscription — startup no longer
+/// consults the selection, so nothing else would.
+@Suite("clearingSubscription")
+struct ClearingSubscriptionTests {
+
+    static let subscription = """
+    proxies:
+      - {name: sub-node, type: vless, server: 1.2.3.4, port: 443, uuid: u}
+    proxy-groups:
+      - name: Proxies
+        type: select
+        proxies:
+          - sub-node
+    proxy-providers:
+      remote:
+        type: http
+        url: https://example.com/nodes.yaml
+        path: nodes.yaml
+    rule-providers:
+      ads:
+        type: http
+        behavior: domain
+        url: https://example.com/ads.yaml
+        path: ads.yaml
+    rules:
+      - RULE-SET,ads,REJECT
+      - DOMAIN-SUFFIX,example.com,Proxies
+      - MATCH,DIRECT
+    dns:
+      enable: true
+      nameserver:
+        - https://sub.dns.example/dns-query
+    """
+
+    /// Simulate select → user edits the header → delete, and return the
+    /// cleared file.
+    private func cleared(engineMode: EngineMode = .vpn) -> String {
+        let defaultCfg = ConfigManager.shared.defaultConfig()
+        let merged = ConfigManager.mergeSubscription(
+            Self.subscription, baseConfig: defaultCfg, defaultConfig: defaultCfg
+        )
+        #expect(merged.contains("name: sub-node"))
+        #expect(merged.contains("https://sub.dns.example/dns-query"))
+        // The user then adds a nameserver in the editor on top of the merge.
+        let edited = merged.replacingOccurrences(
+            of: "  nameserver:\n",
+            with: "  nameserver:\n    - tls://user.dns.example\n"
+        )
+        #expect(edited.contains("tls://user.dns.example"))
+        return ConfigManager.clearingSubscription(
+            from: edited, defaultConfig: defaultCfg, engineMode: engineMode
+        )
+    }
+
+    @Test("Deleting the selected subscription puts the defaults back in the file")
+    func dropsSubscriptionSections() {
+        let result = cleared()
+        // Everything the subscription owned is gone …
+        #expect(!result.contains("sub-node"))
+        #expect(!result.contains("name: Proxies"))
+        #expect(!result.contains("proxy-providers:"))
+        #expect(!result.contains("rule-providers:"))
+        #expect(!result.contains("RULE-SET,ads,REJECT"))
+        #expect(!result.contains("DOMAIN-SUFFIX,example.com,Proxies"))
+        // … and the built-in defaults are what the next start runs.
+        #expect(result.contains("proxies: []"))
+        #expect(result.contains("DOMAIN-SUFFIX,google.com,PROXY"))
+        #expect(result.contains("MATCH,PROXY"))
+        let groups = ConfigManager.shared.parseProxyGroups(from: result)
+        #expect(groups.map(\.name) == ["PROXY"])
+        #expect(groups.first?.proxies == ["DIRECT"])
+        // The effective config the engine starts from agrees.
+        let effective = ConfigManager.buildEffectiveConfig(
+            base: result, engineMode: .vpn, settings: EngineRuntimeSettings()
+        )
+        #expect(!effective.contains("sub-node"))
+        #expect(effective.contains("MATCH,PROXY"))
+    }
+
+    @Test("Clearing keeps the header — including the user's DNS edits")
+    func keepsHeader() {
+        let result = cleared()
+        #expect(result.hasPrefix("mixed-port: 0\n"))
+        #expect(result.contains("geo-auto-update: false"))
+        // Unlike selecting a subscription, clearing never swaps in the
+        // defaults' dns block: what the user last saved stays.
+        #expect(result.contains("tls://user.dns.example"))
+        #expect(result.contains("https://sub.dns.example/dns-query"))
+        #expect(result.contains("enhanced-mode: fake-ip"))
+
+        let local = cleared(engineMode: .localProxy)
+        #expect(local.contains("enhanced-mode: redir-host"))
+        #expect(local.contains("tls://user.dns.example"))
+    }
+
+    @Test("Clearing a file that never had a subscription is a no-op on defaults")
+    func idempotentOnDefaults() {
+        let defaultCfg = ConfigManager.shared.defaultConfig()
+        let once = ConfigManager.clearingSubscription(from: defaultCfg, defaultConfig: defaultCfg)
+        let twice = ConfigManager.clearingSubscription(from: once, defaultConfig: defaultCfg)
+        #expect(once == twice)
+        #expect(once.contains("MATCH,PROXY"))
+        #expect(ConfigManager.shared.parseProxyGroups(from: once).map(\.name) == ["PROXY"])
+    }
+}

--- a/BaoLianDengTests/ConfigParserTests.swift
+++ b/BaoLianDengTests/ConfigParserTests.swift
@@ -267,6 +267,40 @@ struct MergeSubscriptionTests {
         #expect(merged.components(separatedBy: "dns:").count - 1 == 1)
     }
 
+    @Test("A provider with an inline http health-check survives the merge")
+    func subscriptionProviderWithInlineHealthCheck() throws {
+        let sub = """
+        proxies: []
+        proxy-providers:
+          good:
+            type: http
+            url: https://example.com/sub.yaml
+            path: ./providers/good.yaml
+            interval: 3600
+            health-check: {enable: true, url: http://www.gstatic.com/generate_204, interval: 300}
+        proxy-groups:
+          - name: Auto
+            type: url-test
+            use: [good]
+            url: http://www.gstatic.com/generate_204
+            interval: 300
+        rules:
+          - MATCH,Auto
+        """
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: Self.baseConfig, defaultConfig: Self.defaultConfig
+        )
+        let dict = try #require((try? Yams.load(yaml: merged)) as? [String: Any], "merged must parse:\n\(merged)")
+        let providers = try #require(dict["proxy-providers"] as? [String: Any], "providers section missing:\n\(merged)")
+        let good = try #require(providers["good"] as? [String: Any], "provider dropped:\n\(merged)")
+        #expect(good["url"] as? String == "https://example.com/sub.yaml")
+        #expect(good["interval"] as? Int == 0)
+        #expect((good["health-check"] as? [String: Any])?["url"] as? String == "http://www.gstatic.com/generate_204")
+        #expect((good["health-check"] as? [String: Any])?["interval"] as? Int == 300)
+        let groups = try #require(dict["proxy-groups"] as? [[String: Any]])
+        #expect(groups.contains { $0["name"] as? String == "Auto" && $0["use"] as? [String] == ["good"] })
+    }
+
     @Test("Falls back to default rules when subscription has none")
     func fallsBackToDefaultRules() {
         let sub = """
@@ -849,6 +883,33 @@ struct ForceManagedDNSTests {
         #expect(dns["enhanced-mode"] as? String == "fake-ip")
         #expect(dns["nameserver"] as? [String] == ["1.1.1.1"])
     }
+
+    @Test("Multi-line flow dns whose entries sit at column 0 is followed to its closer")
+    func columnZeroFlowContinuation() throws {
+        var config = """
+        dns: {
+        enable: true,
+        nameserver: [1.1.1.1], # "brace }" inside a comment must not close it
+        fallback: ["8.8.8.8"]
+        }
+        proxies: []
+        rules:
+          - MATCH,DIRECT
+        """
+        #expect((try? Yams.load(yaml: config)) != nil, "input must be valid YAML")
+        ConfigManager.forceManagedDNS(&config)
+        let dns = try #require(dnsMapping(config), "must stay parseable:\n\(config)")
+        #expect(dns["enhanced-mode"] as? String == "fake-ip")
+        #expect(dns["nameserver"] as? [String] == ["1.1.1.1"])
+        #expect(dns["fallback"] as? [String] == ["8.8.8.8"])
+        let dict = (try? Yams.load(yaml: config)) as? [String: Any]
+        #expect(dict?["rules"] as? [String] == ["MATCH,DIRECT"])
+        #expect(dict?["proxies"] is [Any])
+        let again = config
+        var repeated = config
+        ConfigManager.forceManagedDNS(&repeated)
+        #expect(repeated == again)
+    }
 }
 
 @Suite("Proxy group serialization")
@@ -1006,6 +1067,55 @@ struct ProxyGroupSerializationTests {
         #expect(health?["interval"] as? Int == 60)
         #expect(after[0]["exclude-type"] as? [String] == ["ss", "vmess"])
         #expect(after[0]["proxies"] as? [String] == ["a"])
+    }
+
+    @Test("Non-ASCII and long extra scalars are re-emitted verbatim, not escaped or folded")
+    func unicodeExtraFieldsStayReadable() throws {
+        let long = String(repeating: "abcdefghij ", count: 12).trimmingCharacters(in: .whitespaces)
+        let yaml = """
+        proxy-groups:
+          - name: 香港
+            type: url-test
+            use: [机场]
+            filter: "(?i)香港|HK|Hong Kong"
+            exclude-filter: "\(long)"
+        """
+        var groups = ConfigManager.shared.parseProxyGroups(from: yaml)
+        groups[0].interval = 300
+        let rewritten = ConfigManager.shared.updateProxyGroups(groups, in: yaml)
+        #expect(rewritten.contains("filter: \"(?i)香港|HK|Hong Kong\""))
+        #expect(rewritten.contains("use: [机场]") || rewritten.contains("- 机场"))
+        #expect(!rewritten.contains("\\u"))
+        #expect(rewritten.contains("exclude-filter: \"\(long)\""))
+        let after = groupDicts(rewritten)
+        #expect(after[0]["filter"] as? String == "(?i)香港|HK|Hong Kong")
+        #expect(after[0]["exclude-filter"] as? String == long)
+        #expect(after[0]["use"] as? [String] == ["机场"])
+    }
+
+    @Test("A null url is dropped rather than re-emitted as the string \"null\"")
+    func nullModelledScalarIsOmitted() {
+        let yaml = """
+        proxy-groups:
+          - name: A
+            type: select
+            proxies: [DIRECT]
+            url: null
+          - name: B
+            type: select
+            proxies: [DIRECT]
+            url: ~
+          - name: C
+            type: select
+            proxies: [DIRECT]
+            url:
+        """
+        let groups = ConfigManager.shared.parseProxyGroups(from: yaml)
+        #expect(groups.map(\.url) == [nil, nil, nil])
+        let rewritten = ConfigManager.shared.updateProxyGroups(groups, in: yaml)
+        #expect(!rewritten.contains("null"))
+        #expect(!rewritten.contains("url:"))
+        #expect(groupDicts(rewritten).count == 3)
     }
 
     @Test("Groups built in the editor still serialize an empty proxies list")
@@ -1332,6 +1442,115 @@ struct SanitizeProvidersTests {
         let result = ConfigManager.sanitizeProviders(section)
         #expect(!result.contains("file://"))
         #expect(result.hasPrefix("proxy-providers:"))
+    }
+
+    @Test("A quoted provider name does not hide an inline provider from the checks")
+    func sanitizesQuotedKeyInlineProvider() {
+        let section = """
+        proxy-providers:
+          "leak": {type: http, url: 'file:///etc/hosts', path: ./x.yaml}
+          'leak2': {type: http, url: "http://evil/sub", path: ./y.yaml}
+          "ok # not a comment": {type: http, url: "https://example.com/sub", path: ../z.yaml}
+        """
+        let result = ConfigManager.sanitizeProviders(section)
+        #expect(!result.contains("file://"))
+        #expect(!result.contains("evil"))
+        #expect(!result.contains("../"))
+        #expect(result.contains("example.com/sub"))
+        #expect(result.contains("ok # not a comment"))
+    }
+
+    static let providerWithInlineHealthCheck = """
+    proxy-providers:
+      good:
+        type: http
+        url: https://example.com/sub.yaml
+        path: ./providers/good.yaml
+        interval: 3600
+        health-check: {enable: true, url: http://www.gstatic.com/generate_204, interval: 300}
+        header: {User-Agent: [clash.meta], X-Note: ["http://not-a-provider-url"]}
+    """
+
+    @Test("A nested http health-check url does not get a block provider dropped")
+    func keepsProviderWithInlineHealthCheck() throws {
+        let result = ConfigManager.sanitizeProviders(Self.providerWithInlineHealthCheck)
+        let dict = try #require((try? Yams.load(yaml: result)) as? [String: Any], "must parse:\n\(result)")
+        let providers = try #require(dict["proxy-providers"] as? [String: Any])
+        let good = try #require(providers["good"] as? [String: Any], "provider must survive:\n\(result)")
+        #expect(good["url"] as? String == "https://example.com/sub.yaml")
+        #expect(good["path"] as? String == "./providers/good.yaml")
+        let health = try #require(good["health-check"] as? [String: Any])
+        #expect(health["enable"] as? Bool == true)
+        #expect(health["url"] as? String == "http://www.gstatic.com/generate_204")
+        #expect(health["interval"] as? Int == 300)
+        let header = try #require(good["header"] as? [String: Any])
+        #expect(header["User-Agent"] as? [String] == ["clash.meta"])
+    }
+
+    @Test("A block-style nested health-check url is not mistaken for the provider url either")
+    func keepsProviderWithBlockHealthCheck() throws {
+        let section = """
+        proxy-providers:
+          good:
+            type: http
+            url: https://example.com/sub.yaml
+            path: ./providers/good.yaml
+            health-check:
+              enable: true
+              url: http://www.gstatic.com/generate_204
+              interval: 300
+          bad:
+            type: http
+            url: http://evil.com/sub.yaml
+            path: ./providers/bad.yaml
+            health-check:
+              url: https://looks-fine.example/generate_204
+        """
+        let result = ConfigManager.sanitizeProviders(section)
+        // Block-style sections pass through verbatim.
+        #expect(result.contains("      url: http://www.gstatic.com/generate_204"))
+        #expect(result.contains("  good:"))
+        #expect(!result.contains("bad:"))
+        #expect(!result.contains("evil.com"))
+        #expect(!result.contains("looks-fine"))
+    }
+
+    @Test("A fully inline provider with a nested http health-check survives")
+    func keepsInlineProviderWithNestedHealthCheck() throws {
+        let section = """
+        proxy-providers:
+          good: {type: http, url: "https://example.com/sub.yaml", path: ./providers/good.yaml, health-check: {enable: true, url: http://www.gstatic.com/generate_204, interval: 300}}
+        """
+        let result = ConfigManager.sanitizeProviders(section)
+        let dict = try #require((try? Yams.load(yaml: result)) as? [String: Any], "must parse:\n\(result)")
+        let providers = try #require(dict["proxy-providers"] as? [String: Any])
+        let good = try #require(providers["good"] as? [String: Any], "provider must survive:\n\(result)")
+        #expect((good["health-check"] as? [String: Any])?["url"] as? String == "http://www.gstatic.com/generate_204")
+    }
+
+    @Test("disableProviderRefresh zeroes only the provider's own interval")
+    func refreshDisableLeavesNestedInterval() throws {
+        let sanitized = ConfigManager.sanitizeProviders(Self.providerWithInlineHealthCheck)
+        let result = ConfigManager.disableProviderRefresh(sanitized)
+        let dict = try #require((try? Yams.load(yaml: result)) as? [String: Any], "must parse:\n\(result)")
+        let good = try #require((dict["proxy-providers"] as? [String: Any])?["good"] as? [String: Any])
+        #expect(good["interval"] as? Int == 0)
+        #expect((good["health-check"] as? [String: Any])?["interval"] as? Int == 300)
+
+        let block = """
+        rule-providers:
+          r:
+            type: http
+            url: https://example.com/r.yaml
+            path: ./r.yaml
+            interval: 86400
+            health-check:
+              interval: 60
+        """
+        let blockResult = ConfigManager.disableProviderRefresh(block)
+        #expect(blockResult.contains("    interval: 0"))
+        #expect(blockResult.contains("      interval: 60"))
+        #expect(!blockResult.contains("86400"))
     }
 }
 

--- a/BaoLianDengTests/MihomoCoreIntegrationTests.swift
+++ b/BaoLianDengTests/MihomoCoreIntegrationTests.swift
@@ -240,4 +240,104 @@ struct MihomoCoreIntegrationTests {
         BridgeValidateConfig(config, &err)
         #expect(err == nil, "Default config failed validation: \(err?.localizedDescription ?? "")")
     }
+
+    // MARK: - Issue #113: flow-style sections and structured group edits
+
+    @Test("Sanitized inline dns mapping is accepted by the engine")
+    func inlineDNSSanitizesToValidConfig() {
+        var config = """
+        proxies: []
+        proxy-groups: []
+        rules:
+          - MATCH,DIRECT
+        dns: {enable: true, nameserver: [1.1.1.1]}
+        """
+        ConfigManager.sanitizeConfigString(&config)
+        var err: NSError?
+        BridgeValidateConfig(config, &err)
+        #expect(err == nil, "sanitized inline dns rejected: \(err?.localizedDescription ?? "")\n\(config)")
+        #expect(config.contains("enhanced-mode: fake-ip"))
+        #expect(config.contains("1.1.1.1"))
+
+        // Repeated sanitization stays valid and stable.
+        let once = config
+        ConfigManager.sanitizeConfigString(&config)
+        #expect(config == once)
+        BridgeValidateConfig(config, &err)
+        #expect(err == nil)
+    }
+
+    @Test("Inline dns merged from a subscription validates")
+    func inlineSubscriptionDNSValidates() {
+        let sub = """
+        proxies: []
+        proxy-groups: []
+        rules:
+          - MATCH,DIRECT
+        dns: {enable: true, nameserver: [1.1.1.1]}
+        """
+        let defaultCfg = ConfigManager.shared.defaultConfig()
+        let merged = ConfigManager.mergeSubscription(
+            sub, baseConfig: defaultCfg, defaultConfig: defaultCfg
+        )
+        var err: NSError?
+        BridgeValidateConfig(merged, &err)
+        #expect(err == nil, "merged inline dns rejected: \(err?.localizedDescription ?? "")\n\(merged)")
+    }
+
+    @Test("Structured round trip of groups with unmodelled fields stays engine-valid")
+    func structuredGroupRoundTripValidates() {
+        let config = """
+        mixed-port: 7890
+        mode: rule
+        proxies:
+          - name: node-a
+            type: ss
+            server: 1.2.3.4
+            port: 8388
+            cipher: aes-128-gcm
+            password: secret
+          - name: node-b
+            type: ss
+            server: 1.2.3.5
+            port: 8388
+            cipher: aes-128-gcm
+            password: secret
+        proxy-groups:
+          - name: Auto
+            type: url-test
+            proxies: [node-a, node-b]
+            url: http://www.gstatic.com/generate_204
+            interval: 300
+            tolerance: 50
+            lazy: true
+          - name: Balance
+            type: load-balance
+            strategy: consistent-hashing
+            proxies:
+              - node-a
+              - node-b
+          - name: PROXY
+            type: select
+            proxies:
+              - Auto
+              - Balance
+              - DIRECT
+        rules:
+          - MATCH,PROXY
+        """
+        var err: NSError?
+        BridgeValidateConfig(config, &err)
+        #expect(err == nil, "fixture must validate: \(err?.localizedDescription ?? "")")
+
+        var groups = ConfigManager.shared.parseProxyGroups(from: config)
+        #expect(groups[0].extraFields.map(\.key) == ["tolerance", "lazy"])
+        groups[2].proxies.append("REJECT")
+        let rewritten = ConfigManager.shared.updateProxyGroups(groups, in: config)
+        BridgeValidateConfig(rewritten, &err)
+        #expect(err == nil, "rewritten config rejected: \(err?.localizedDescription ?? "")\n\(rewritten)")
+        #expect(rewritten.contains("tolerance: 50"))
+        #expect(rewritten.contains("lazy: true"))
+        #expect(rewritten.contains("strategy: consistent-hashing"))
+    }
 }

--- a/BaoLianDengTests/TCPRelayTests.swift
+++ b/BaoLianDengTests/TCPRelayTests.swift
@@ -1,0 +1,407 @@
+// Copyright (c) 2026 Max Lv <max.c.lv@gmail.com>
+//
+// Licensed under the MIT License. See the LICENSE file for details.
+
+import Darwin
+import Foundation
+import Network
+import XCTest
+@testable import BaoLianDeng
+
+/// Regression tests for madeye/BaoLianDeng#113 finding 6: the TCP relay used
+/// to tear both directions down as soon as *either* hit EOF, so a client that
+/// half-closed after its request (`shutdown(SHUT_WR)`) never saw the reply.
+///
+/// The relay core is exercised two ways: with an in-memory fake on both sides
+/// (deterministic control of EOF ordering, errors, and the idle bound), and
+/// with the production `NWConnectionRelayEndpoint` talking to a real loopback
+/// TCP server, which proves the FIN is actually sent and that receives keep
+/// working after it.
+final class TCPRelayTests: XCTestCase {
+
+    // MARK: - Request EOF, then response (the audit repro)
+
+    /// Loopback server reads until EOF, then sends 5 bytes. A plain socket
+    /// with `shutdown(SHUT_WR)` gets all 5; the old relay got 0.
+    func testRequestEOFThenResponseIsDelivered() async throws {
+        let server = try LoopbackServer()
+        server.serve { srv, sock in
+            _ = srv.readUntilEOF(sock)
+            LoopbackServer.writeAll(sock, Data("reply".utf8))
+        }
+        defer { server.close() }
+
+        let connection = try await SOCKS5Client.connectTCP(host: "127.0.0.1", port: server.port)
+        defer { connection.cancel() }
+
+        let app = FakeRelayEndpoint()
+        app.push(.success(.data(Data("GET / HTTP/1.0\r\n\r\n".utf8))))
+        app.push(.success(.eof))
+
+        let outcome = await TCPRelay.run(
+            app: app,
+            proxy: NWConnectionRelayEndpoint(connection: connection),
+            halfCloseIdleTimeout: 5
+        )
+
+        XCTAssertEqual(outcome, .completed)
+        XCTAssertEqual(app.written, Data("reply".utf8))
+        XCTAssertTrue(app.finishedWriting, "server EOF must be propagated to the app as a half-close")
+        XCTAssertEqual(server.received, Data("GET / HTTP/1.0\r\n\r\n".utf8))
+    }
+
+    // MARK: - Reverse half-close: server closes write first, client keeps sending
+
+    func testServerHalfCloseFirstClientKeepsSending() async throws {
+        let server = try LoopbackServer()
+        server.serve { srv, sock in
+            LoopbackServer.writeAll(sock, Data("hello".utf8))
+            shutdown(sock, SHUT_WR)
+            _ = srv.readUntilEOF(sock)
+        }
+        defer { server.close() }
+
+        let connection = try await SOCKS5Client.connectTCP(host: "127.0.0.1", port: server.port)
+        defer { connection.cancel() }
+
+        // The app only starts its upload once the server's half-close has
+        // reached it, so the bytes are provably sent *after* the relay saw
+        // EOF in the other direction.
+        let app = FakeRelayEndpoint()
+        app.onFinishWriting = {
+            app.push(.success(.data(Data("late upload".utf8))))
+            app.push(.success(.eof))
+        }
+
+        let outcome = await TCPRelay.run(
+            app: app,
+            proxy: NWConnectionRelayEndpoint(connection: connection),
+            halfCloseIdleTimeout: 5
+        )
+
+        XCTAssertEqual(outcome, .completed)
+        XCTAssertEqual(app.written, Data("hello".utf8))
+        XCTAssertTrue(app.finishedWriting)
+        XCTAssertEqual(server.received, Data("late upload".utf8))
+    }
+
+    /// The server's last bytes and its FIN can land in one `receive`
+    /// callback (`data` non-empty, `isComplete == true`). Network.framework
+    /// then never reports `isComplete` again — the next receive fails with
+    /// ENODATA — so the endpoint must remember that trailing EOF instead of
+    /// turning it into an error. Sleeping before the relay starts makes both
+    /// arrive before the first receive is even issued.
+    func testTrailingEOFDeliveredWithLastBytesIsAnOrderlyClose() async throws {
+        let server = try LoopbackServer()
+        server.serve { srv, sock in
+            LoopbackServer.writeAll(sock, Data("reply".utf8))
+            shutdown(sock, SHUT_WR)
+            _ = srv.readUntilEOF(sock)
+        }
+        defer { server.close() }
+
+        let connection = try await SOCKS5Client.connectTCP(host: "127.0.0.1", port: server.port)
+        defer { connection.cancel() }
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        let app = FakeRelayEndpoint()
+        app.onFinishWriting = { app.push(.success(.eof)) }
+
+        let outcome = await TCPRelay.run(
+            app: app,
+            proxy: NWConnectionRelayEndpoint(connection: connection),
+            halfCloseIdleTimeout: 5
+        )
+
+        XCTAssertEqual(outcome, .completed)
+        XCTAssertEqual(app.written, Data("reply".utf8))
+        XCTAssertTrue(app.finishedWriting)
+        XCTAssertEqual(server.received, Data())
+    }
+
+    // MARK: - Pure in-memory ordering checks
+
+    func testAppEOFForwardsFINAndKeepsDrainingProxy() async {
+        let app = FakeRelayEndpoint()
+        let proxy = FakeRelayEndpoint()
+        app.push(.success(.data(Data("req".utf8))))
+        app.push(.success(.eof))
+        // Proxy answers only after it has seen the app's FIN, and not
+        // instantly: a relay that tears down on the first EOF must be shown
+        // to lose a response that arrives a moment later.
+        proxy.onFinishWriting = {
+            Task {
+                try? await Task.sleep(nanoseconds: 50_000_000)
+                proxy.push(.success(.data(Data("resp-1".utf8))))
+                proxy.push(.success(.data(Data("resp-2".utf8))))
+                proxy.push(.success(.eof))
+            }
+        }
+
+        let outcome = await TCPRelay.run(app: app, proxy: proxy, halfCloseIdleTimeout: 5)
+
+        XCTAssertEqual(outcome, .completed)
+        XCTAssertEqual(proxy.written, Data("req".utf8))
+        XCTAssertTrue(proxy.finishedWriting)
+        XCTAssertEqual(app.written, Data("resp-1resp-2".utf8))
+        XCTAssertTrue(app.finishedWriting)
+    }
+
+    func testProxyEOFHalfClosesFlowAndKeepsForwardingApp() async {
+        let app = FakeRelayEndpoint()
+        let proxy = FakeRelayEndpoint()
+        proxy.push(.success(.data(Data("banner".utf8))))
+        proxy.push(.success(.eof))
+        app.onFinishWriting = {
+            Task {
+                try? await Task.sleep(nanoseconds: 50_000_000)
+                app.push(.success(.data(Data("tail".utf8))))
+                app.push(.success(.eof))
+            }
+        }
+
+        let outcome = await TCPRelay.run(app: app, proxy: proxy, halfCloseIdleTimeout: 5)
+
+        XCTAssertEqual(outcome, .completed)
+        XCTAssertEqual(app.written, Data("banner".utf8))
+        XCTAssertTrue(app.finishedWriting)
+        XCTAssertEqual(proxy.written, Data("tail".utf8))
+        XCTAssertTrue(proxy.finishedWriting)
+    }
+
+    // MARK: - Safeguards
+
+    /// A read error is not an EOF: the sibling direction, parked on a read
+    /// that will never resolve, must be cancelled promptly.
+    func testErrorInOneDirectionCancelsTheOther() async {
+        let app = FakeRelayEndpoint()   // never produces anything
+        let proxy = FakeRelayEndpoint()
+        proxy.push(.failure(SOCKS5Error.unexpectedEOF))
+
+        let start = Date()
+        let outcome = await TCPRelay.run(app: app, proxy: proxy, halfCloseIdleTimeout: 30)
+
+        XCTAssertEqual(outcome, .failed)
+        XCTAssertLessThan(Date().timeIntervalSince(start), 5)
+        XCTAssertFalse(app.finishedWriting, "an error must not be reported to the app as an orderly EOF")
+    }
+
+    /// After a half-close, a peer that never closes its side cannot pin the
+    /// relay forever: the idle bound tears it down.
+    func testHalfCloseIdleTimeoutStopsSilentPeer() async {
+        let app = FakeRelayEndpoint()
+        let proxy = FakeRelayEndpoint()   // accepts the FIN, then goes silent
+        app.push(.success(.eof))
+
+        let start = Date()
+        let outcome = await TCPRelay.run(app: app, proxy: proxy, halfCloseIdleTimeout: 0.3)
+
+        XCTAssertEqual(outcome, .halfCloseTimedOut)
+        XCTAssertTrue(proxy.finishedWriting)
+        XCTAssertLessThan(Date().timeIntervalSince(start), 5)
+    }
+
+    /// Data flowing on the remaining direction keeps resetting the idle bound.
+    func testHalfCloseIdleTimeoutIsIdleNotAbsolute() async {
+        let app = FakeRelayEndpoint()
+        let proxy = FakeRelayEndpoint()
+        app.push(.success(.eof))
+
+        let feeder = Task {
+            for i in 0..<6 {
+                try await Task.sleep(nanoseconds: 100_000_000)
+                proxy.push(.success(.data(Data("chunk\(i)".utf8))))
+            }
+            proxy.push(.success(.eof))
+        }
+        defer { feeder.cancel() }
+
+        // 0.6 s of traffic spaced 0.1 s apart, against a 0.3 s idle bound.
+        let outcome = await TCPRelay.run(app: app, proxy: proxy, halfCloseIdleTimeout: 0.3)
+
+        XCTAssertEqual(outcome, .completed)
+        XCTAssertEqual(app.written, Data("chunk0chunk1chunk2chunk3chunk4chunk5".utf8))
+    }
+
+    /// Cancelling the task that runs the relay must unblock both pending reads.
+    func testExternalCancellationUnblocksPendingReads() async {
+        let app = FakeRelayEndpoint()
+        let proxy = FakeRelayEndpoint()
+        let task = Task {
+            await TCPRelay.run(app: app, proxy: proxy, halfCloseIdleTimeout: 30)
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+
+        let start = Date()
+        let outcome = await task.value
+        XCTAssertEqual(outcome, .failed)
+        XCTAssertLessThan(Date().timeIntervalSince(start), 5)
+    }
+}
+
+// MARK: - Fake endpoint
+
+/// In-memory `TCPRelayEndpoint`: reads are served from a queue the test
+/// pushes into (a pending read parks until something is pushed, and honours
+/// task cancellation through the production `withCancellableResult`); writes
+/// and `finishWriting` are recorded.
+private final class FakeRelayEndpoint: TCPRelayEndpoint, @unchecked Sendable {
+    private let lock = NSLock()
+    private var queue: [Result<TCPRelayRead, Error>] = []
+    private var waiter: ((Result<TCPRelayRead, Error>) -> Void)?
+    private var writtenData = Data()
+    private var finished = false
+
+    /// Invoked (synchronously, on the relay's task) when the peer's EOF is
+    /// propagated to this endpoint. Tests use it to sequence "send only
+    /// after the other side half-closed".
+    var onFinishWriting: (() -> Void)?
+
+    var written: Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return writtenData
+    }
+
+    var finishedWriting: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return finished
+    }
+
+    func push(_ item: Result<TCPRelayRead, Error>) {
+        lock.lock()
+        if let waiter = waiter {
+            self.waiter = nil
+            lock.unlock()
+            waiter(item)
+        } else {
+            queue.append(item)
+            lock.unlock()
+        }
+    }
+
+    func read() async throws -> TCPRelayRead {
+        try await SOCKS5Client.withCancellableResult(TCPRelayRead.self) { resume in
+            lock.lock()
+            if !queue.isEmpty {
+                let item = queue.removeFirst()
+                lock.unlock()
+                resume(item)
+            } else {
+                waiter = resume
+                lock.unlock()
+            }
+        }
+    }
+
+    func write(_ data: Data) async throws {
+        lock.lock()
+        writtenData.append(data)
+        lock.unlock()
+    }
+
+    func finishWriting() async throws {
+        lock.lock()
+        finished = true
+        lock.unlock()
+        onFinishWriting?()
+    }
+}
+
+// MARK: - Loopback TCP server
+
+/// Minimal blocking POSIX server on 127.0.0.1:<ephemeral>. `serve` accepts
+/// one connection on a background thread and hands it to the handler;
+/// everything the handler reads via `readUntilEOF` is exposed through
+/// `received`.
+private final class LoopbackServer: @unchecked Sendable {
+    let port: UInt16
+    private let listenFD: Int32
+    private let lock = NSLock()
+    private var receivedData = Data()
+    private let done = DispatchSemaphore(value: 0)
+
+    var received: Data {
+        // Wait for the handler to finish so the assertion sees the full read.
+        _ = done.wait(timeout: .now() + 5)
+        done.signal()
+        lock.lock()
+        defer { lock.unlock() }
+        return receivedData
+    }
+
+    init() throws {
+        let fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+        guard fd >= 0 else { throw POSIXError(.EIO) }
+        var one: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, socklen_t(MemoryLayout<Int32>.size))
+
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0, listen(fd, 1) == 0 else {
+            Darwin.close(fd)
+            throw POSIXError(.EADDRINUSE)
+        }
+
+        var bound = sockaddr_in()
+        var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+        _ = withUnsafeMutablePointer(to: &bound) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(fd, $0, &len)
+            }
+        }
+        listenFD = fd
+        port = UInt16(bigEndian: bound.sin_port)
+    }
+
+    func serve(_ handler: @escaping (LoopbackServer, Int32) -> Void) {
+        let fd = listenFD
+        Thread.detachNewThread { [self] in
+            let client = accept(fd, nil, nil)
+            if client >= 0 {
+                handler(self, client)
+                Darwin.close(client)
+            }
+            done.signal()
+        }
+    }
+
+    func readUntilEOF(_ sock: Int32) -> Data {
+        var data = Data()
+        var buf = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let n = recv(sock, &buf, buf.count, 0)
+            if n <= 0 { break }
+            data.append(contentsOf: buf[0..<n])
+        }
+        lock.lock()
+        receivedData.append(data)
+        lock.unlock()
+        return data
+    }
+
+    static func writeAll(_ sock: Int32, _ data: Data) {
+        data.withUnsafeBytes { buf in
+            var offset = 0
+            while offset < buf.count {
+                let n = send(sock, buf.baseAddress! + offset, buf.count - offset, 0)
+                if n <= 0 { return }
+                offset += n
+            }
+        }
+    }
+
+    func close() {
+        Darwin.close(listenFD)
+    }
+}

--- a/Rust/meow-ffi/objc/MihomoCore.h
+++ b/Rust/meow-ffi/objc/MihomoCore.h
@@ -2,6 +2,12 @@
 
 FOUNDATION_EXPORT void BridgeSetHomeDir(NSString * _Nullable dir);
 FOUNDATION_EXPORT void BridgeSetLogFile(NSString * _Nullable path);
+/// Keeps only the last `maxLines` lines of the file set by BridgeSetLogFile,
+/// rotating it under the engine's own writer lock and reopening the handle.
+/// Use this instead of rewriting the file from Swift: an external atomic
+/// replace would leave the engine logging into the unlinked old inode.
+/// No-op (returns YES) when no log file is set or it is within the cap.
+FOUNDATION_EXPORT BOOL BridgeTrimLogFile(int32_t maxLines, NSError * _Nullable * _Nullable error);
 /// Starts the mihomo proxy engine on the caller-supplied 127.0.0.1
 /// ports. The caller (main app) picks the ports up-front so its REST
 /// clients know the controller endpoint without an IPC round-trip.

--- a/Rust/meow-ffi/objc/MihomoCore.m
+++ b/Rust/meow-ffi/objc/MihomoCore.m
@@ -4,6 +4,7 @@
 // C FFI declarations (from the Rust staticlib)
 extern void bridge_set_home_dir(const char *dir);
 extern int32_t bridge_set_log_file(const char *path);
+extern int32_t bridge_trim_log_file(int32_t max_lines);
 extern int32_t bridge_start_with_ports(int32_t socks_port, int32_t dns_port, const char *controller_addr, const char *secret);
 extern int32_t bridge_get_socks_port(void);
 extern int32_t bridge_get_dns_port(void);
@@ -36,6 +37,15 @@ void BridgeSetHomeDir(NSString * _Nullable dir) {
 
 void BridgeSetLogFile(NSString * _Nullable path) {
     bridge_set_log_file([path UTF8String]);
+}
+
+BOOL BridgeTrimLogFile(int32_t maxLines, NSError * _Nullable * _Nullable error) {
+    int32_t rc = bridge_trim_log_file(maxLines);
+    if (rc != 0) {
+        if (error) *error = makeError();
+        return NO;
+    }
+    return YES;
 }
 
 BOOL BridgeStartWithPorts(int32_t socksPort, int32_t dnsPort, NSString * _Nonnull controllerAddr, NSString * _Nullable secret, NSError * _Nullable * _Nullable error) {

--- a/Rust/meow-ffi/src/engine.rs
+++ b/Rust/meow-ffi/src/engine.rs
@@ -2,15 +2,22 @@
 //!
 //! meow-rs exposes no stop/lifecycle API (its `run()` spawns bare
 //! `tokio::spawn` tasks and blocks on a signal), so this module hand-rolls the
-//! wiring and keeps every `JoinHandle` for abort-on-stop. The caller-supplied
-//! SOCKS/DNS/controller endpoints are forced onto the parsed config before any
-//! listener starts, ignoring whatever ports the YAML declared — except
-//! Clash-compatible `allow-lan` / `bind-address` / `mixed-port`, which control
-//! whether a LAN-facing mixed listener is also exposed.
+//! wiring. Every engine generation runs on its **own** tokio runtime, owned by
+//! [`EngineState`]: the kernel detaches work with bare `tokio::spawn` all over
+//! the place (each accepted connection in the mixed listener, url-test /
+//! fallback health-check loops, the UDP NAT sweeper, provider refreshers, DNS
+//! client tasks), none of which is reachable from the handful of top-level
+//! `JoinHandle`s we could keep. Shutting the runtime down is the only way to
+//! cancel *and* await all of it, so stop leaves nothing behind. The caller-
+//! supplied SOCKS/DNS/controller endpoints are forced onto the parsed config
+//! before any listener starts, ignoring whatever ports the YAML declared —
+//! except Clash-compatible `allow-lan` / `bind-address` / `mixed-port`, which
+//! control whether a LAN-facing mixed listener is also exposed.
 
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 
 use dashmap::DashMap;
 use meow_api::log_stream::LogMessage;
@@ -22,23 +29,72 @@ use meow_dns::DnsServer;
 use meow_listener::{MixedListener, SnifferRuntime};
 use meow_tunnel::Tunnel;
 use parking_lot::RwLock;
+use tokio::runtime::Runtime;
 use tokio::sync::broadcast;
-use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
-/// Live engine instance. Dropping it (via [`crate` stop]) releases the tunnel
-/// and its statistics; the tokio runtime itself is process-global and reused.
+/// How long [`EngineState::shutdown`] waits for the generation's worker
+/// threads to wind down. Every task future is dropped as part of the shutdown
+/// regardless; the bound only caps the wait for a task stuck in a synchronous
+/// poll (or a `spawn_blocking` job), so stop can never hang the caller.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Live engine instance: one generation of tunnel + listeners + background
+/// tasks, all running on `runtime`. Tear it down with [`EngineState::shutdown`]
+/// — that cancels and awaits everything the generation spawned (accepted
+/// connections and health-check loops included) before releasing the tunnel.
 pub struct EngineState {
     pub tunnel: Tunnel,
-    pub handles: Vec<JoinHandle<()>>,
+    /// Runtime private to this generation. Every task the kernel spawned
+    /// while assembling and serving this engine lives here and dies with it.
+    pub runtime: Runtime,
     pub socks_port: i32,
     pub dns_port: i32,
     pub controller_addr: String,
 }
 
+impl EngineState {
+    /// Stop this generation: cancel every task on its runtime and wait
+    /// (bounded) for the worker threads to drop them. Returns the tunnel —
+    /// now quiescent, no relay or probe holds a clone any more — so the
+    /// caller can take its final traffic snapshot before dropping it (which
+    /// releases the statistics / NAT table / proxies with it).
+    ///
+    /// Waiting for a runtime from inside another runtime's context would
+    /// panic (tokio forbids blocking there). The bridge's C entry points are
+    /// always called from Swift's own threads, so that never happens in the
+    /// app; the guard just keeps a misuse from turning into a panic that
+    /// leaks the generation.
+    pub fn shutdown(self) -> Tunnel {
+        let EngineState {
+            tunnel, runtime, ..
+        } = self;
+        if tokio::runtime::Handle::try_current().is_ok() {
+            runtime.shutdown_background();
+        } else {
+            runtime.shutdown_timeout(SHUTDOWN_TIMEOUT);
+        }
+        tunnel
+    }
+}
+
+/// Build the runtime for one engine generation — 2 workers to stay lean
+/// under the Network Extension's ~15 MB memory ceiling.
+pub fn build_runtime() -> anyhow::Result<Runtime> {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .thread_name("meow-engine")
+        .enable_all()
+        .build()
+        .map_err(|e| anyhow::anyhow!("build engine runtime: {e}"))
+}
+
 /// Load `<config_path>`, force the runtime endpoints, and start the tunnel,
-/// DNS server, REST API, and mixed (SOCKS5+HTTP) listener on the shared
-/// runtime. Returns the assembled [`EngineState`] with all task handles.
+/// DNS server, REST API, and mixed (SOCKS5+HTTP) listener on the *current*
+/// runtime — the caller drives this future on the generation's own runtime
+/// (see [`build_runtime`]) so every task spawned below belongs to it.
+/// Returns the assembled [`EngineState`] (the runtime is attached by the
+/// caller, which owns it while this future runs).
 ///
 /// SOCKS / DNS / controller ports always bind loopback at the caller-supplied
 /// addresses (transparent-proxy and REST clients need stable, private
@@ -60,7 +116,7 @@ pub async fn assemble(
     dns_port: i32,
     controller_addr: String,
     secret: String,
-) -> anyhow::Result<EngineState> {
+) -> anyhow::Result<AssembledEngine> {
     clear_saved_global_selection(&home).await?;
     let mut config = load_config_pinned(&config_path, &home).await?;
 
@@ -191,16 +247,14 @@ pub async fn assemble(
     let sniffer = Arc::new(SnifferRuntime::new(config.sniffer));
     let auth = config.auth;
 
-    let mut handles: Vec<JoinHandle<()>> = Vec::new();
-
     // DNS UDP server (fake-ip pool and reverse mapping live inside the resolver).
     {
         let dns_server = DnsServer::new(resolver, dns_addr);
-        handles.push(tokio::spawn(async move {
+        tokio::spawn(async move {
             if let Err(e) = dns_server.run().await {
                 error!("DNS server error: {e}");
             }
-        }));
+        });
     }
 
     // REST API server. The /logs broadcast channel is created but not fed by a
@@ -219,11 +273,11 @@ pub async fn assemble(
             named_for_api,
             external_ui,
         );
-        handles.push(tokio::spawn(async move {
+        tokio::spawn(async move {
             if let Err(e) = api_server.run().await {
                 error!("API server error: {e}");
             }
-        }));
+        });
     }
 
     // Mixed (SOCKS5 + HTTP) listener(s) — primary (+ optional LAN) forced above.
@@ -237,11 +291,11 @@ pub async fn assemble(
             .with_sniffer(Arc::clone(&sniffer))
             .with_auth(Arc::clone(&auth))
             .with_max_connections(nl.max_connections);
-        handles.push(tokio::spawn(async move {
+        tokio::spawn(async move {
             if let Err(e) = listener.run().await {
                 error!("Listener error: {e}");
             }
-        }));
+        });
     }
 
     info!(
@@ -249,13 +303,34 @@ pub async fn assemble(
          allow_lan={allow_lan} lan_proxy={lan_proxy_port}"
     );
 
-    Ok(EngineState {
+    Ok(AssembledEngine {
         tunnel,
-        handles,
         socks_port,
         dns_port,
         controller_addr,
     })
+}
+
+/// Output of [`assemble`]: everything in [`EngineState`] except the runtime
+/// the caller was already holding while it drove the future.
+pub struct AssembledEngine {
+    pub tunnel: Tunnel,
+    pub socks_port: i32,
+    pub dns_port: i32,
+    pub controller_addr: String,
+}
+
+impl AssembledEngine {
+    /// Attach the runtime this engine was assembled on.
+    pub fn with_runtime(self, runtime: Runtime) -> EngineState {
+        EngineState {
+            tunnel: self.tunnel,
+            runtime,
+            socks_port: self.socks_port,
+            dns_port: self.dns_port,
+            controller_addr: self.controller_addr,
+        }
+    }
 }
 
 /// Resolve the LAN bind address from Clash-style `allow-lan` / `bind-address`.

--- a/Rust/meow-ffi/src/lib.rs
+++ b/Rust/meow-ffi/src/lib.rs
@@ -33,8 +33,13 @@ use std::sync::OnceLock;
 use tokio::runtime::Runtime;
 
 // ---------------------------------------------------------------------------
-// Shared runtime (process-global, reused across start/stop — 2 workers to
-// stay lean under the NE ~15 MB memory ceiling).
+// Utility runtime (process-global; 2 workers to stay lean under the NE ~15 MB
+// memory ceiling). Used ONLY for config validation and the `bridge_test_*`
+// diagnostics. The engine itself never runs here: each engine generation owns
+// a private runtime inside `EngineState` (see engine.rs) so that stopping the
+// engine can cancel and await every task the kernel spawned, not just the
+// top-level ones — a shared, never-shut-down runtime would keep accepted
+// connections and health-check loops alive across stop/start.
 // ---------------------------------------------------------------------------
 
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
@@ -43,6 +48,7 @@ pub(crate) fn runtime() -> &'static Runtime {
     RUNTIME.get_or_init(|| {
         tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
+            .thread_name("meow-ffi-util")
             .enable_all()
             .build()
             .expect("failed to build tokio runtime")
@@ -190,6 +196,23 @@ pub unsafe extern "C" fn bridge_set_log_file(path: *const c_char) -> i32 {
                 set_error(e);
                 -1
             }
+        }
+    })
+}
+
+/// Keep only the last `max_lines` lines of the active log file, rotating it
+/// under the sink's own lock and reopening the handle (see
+/// `logging::trim_log_file`). Returns 0 on success (including the no-op cases:
+/// no log file set, file already within the cap), -1 with a last-error
+/// otherwise. Callers must use this instead of rewriting the file themselves:
+/// an external atomic replace leaves the sink writing to the unlinked inode.
+#[no_mangle]
+pub extern "C" fn bridge_trim_log_file(max_lines: i32) -> i32 {
+    guard(-1, || match logging::trim_log_file(max_lines as i64) {
+        Ok(()) => 0,
+        Err(e) => {
+            set_error(e);
+            -1
         }
     })
 }
@@ -384,7 +407,18 @@ pub unsafe extern "C" fn bridge_start_with_ports(
         // Publish the secret so in-process diagnostics can authenticate against
         // the controller; cleared again if start fails or on stop.
         *CONTROLLER_SECRET.lock() = Some(secret_s.clone());
-        match runtime().block_on(engine::assemble(
+        // A fresh runtime per generation: everything `assemble` (and the
+        // kernel underneath it) spawns lands here, so stop can tear it all
+        // down by shutting the runtime down.
+        let rt = match engine::build_runtime() {
+            Ok(rt) => rt,
+            Err(e) => {
+                *CONTROLLER_SECRET.lock() = None;
+                set_error(format!("start proxy: {e}"));
+                return -1;
+            }
+        };
+        match rt.block_on(engine::assemble(
             config_path,
             home,
             socks_port,
@@ -392,8 +426,8 @@ pub unsafe extern "C" fn bridge_start_with_ports(
             addr,
             secret_s,
         )) {
-            Ok(state) => {
-                *engine = Some(state);
+            Ok(assembled) => {
+                *engine = Some(assembled.with_runtime(rt));
                 0
             }
             Err(e) => {
@@ -402,6 +436,9 @@ pub unsafe extern "C" fn bridge_start_with_ports(
                 // failing (a listener bind error comes later); don't leave a
                 // hook pointing at a resolver whose engine never started.
                 meow_common::clear_host_resolver();
+                // Likewise it may have spawned some tasks (DNS server, API)
+                // before the failing step; they die with the runtime.
+                rt.shutdown_timeout(std::time::Duration::from_secs(2));
                 set_error(format!("start proxy: {e}"));
                 -1
             }
@@ -419,33 +456,23 @@ pub extern "C" fn bridge_stop_proxy() {
         // and leaving it installed would keep serving lookups (and pin the
         // old DNS cache) after `BridgeStopProxy`.
         meow_common::clear_host_resolver();
-        if let Some(mut state) = engine.take() {
+        if let Some(state) = engine.take() {
+            // Shut the generation's runtime down: this cancels AND awaits
+            // every task it ever spawned — listeners, each accepted
+            // connection's relay, url-test / fallback health-check loops,
+            // the NAT sweeper, DNS/API servers — so no session keeps flowing
+            // through a stopped engine, no probe keeps firing, and the
+            // listener sockets are released before we return (an immediate
+            // restart on the same ports must not race an "address in use").
+            // Bounded so a task stuck in a synchronous poll can't hang stop.
+            let tunnel = state.shutdown();
             // Fold the final traffic snapshot into the process-lifetime base
-            // before dropping the engine (and its per-instance Statistics).
-            let (up, down) = state.tunnel.statistics().snapshot();
+            // only now, after every relay has stopped counting, then drop
+            // the tunnel (and its per-instance Statistics).
+            let (up, down) = tunnel.statistics().snapshot();
             TRAFFIC_UP_BASE.fetch_add(up, Ordering::Relaxed);
             TRAFFIC_DOWN_BASE.fetch_add(down, Ordering::Relaxed);
-            for handle in &state.handles {
-                handle.abort();
-            }
-            // abort() only *requests* cancellation; the task (and its
-            // listener socket) isn't guaranteed to be dropped until the
-            // runtime actually polls it again. Wait for every handle to
-            // finish so the sockets are released before we return — otherwise
-            // an immediate restart on the same ports can race and fail with
-            // "address in use". Bounded per-handle so a stuck task can't hang
-            // shutdown forever; we're called from an external (non-runtime)
-            // thread, so block_on here is safe and won't deadlock a worker.
-            let handles = std::mem::take(&mut state.handles);
-            runtime().block_on(async {
-                for handle in handles {
-                    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
-                    // Ok(Err(JoinError)) is expected (task was cancelled);
-                    // Err(Elapsed) means the task didn't wind down in time —
-                    // nothing more we can safely do from here, so proceed.
-                }
-            });
-            // `state` drops here: tunnel, listeners all released.
+            drop(tunnel);
         }
     });
 }
@@ -570,14 +597,20 @@ pub unsafe extern "C" fn bridge_test_selected_proxy(api_addr: *const c_char) -> 
 // Tests (loopback-only; no external network).
 // ---------------------------------------------------------------------------
 
+/// Engine start/stop and the log sink mutate process-global state; every
+/// test that touches either (here and in `logging`) serializes on this —
+/// including config validation, which logs through the sink while it loads.
+#[cfg(test)]
+pub(crate) static TEST_LOCK: Mutex<()> = Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::ffi::CString;
-
-    // Engine start/stop mutate process-global state; serialize the tests that
-    // touch it.
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
+    use std::io::{Read, Write};
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     fn free_port() -> i32 {
         std::net::TcpListener::bind("127.0.0.1:0")
@@ -610,6 +643,7 @@ rules:
 
     #[test]
     fn validates_minimal_config() {
+        let _g = TEST_LOCK.lock();
         let yaml = "mode: rule\nproxies: []\nproxy-groups:\n  - name: PROXY\n    type: select\n    proxies:\n      - DIRECT\nrules:\n  - MATCH,DIRECT\n";
         assert_eq!(validate(yaml), 0);
     }
@@ -625,6 +659,7 @@ rules:
     // (public key material only) — TlsLayer::new parses it structurally.
     #[test]
     fn validates_ss_ech_tls_tunnel_plugin() {
+        let _g = TEST_LOCK.lock();
         let yaml = "\
 mode: rule
 proxies:
@@ -653,6 +688,7 @@ rules:
 
     #[test]
     fn rejects_undefined_group_by_name() {
+        let _g = TEST_LOCK.lock();
         let yaml = "proxies: []\nproxy-groups: []\nrules:\n  - MATCH,NONEXISTENT\n";
         assert_eq!(validate(yaml), -1);
         let err = unsafe { CStr::from_ptr(bridge_get_last_error()) }
@@ -664,6 +700,7 @@ rules:
 
     #[test]
     fn rejects_invalid_yaml() {
+        let _g = TEST_LOCK.lock();
         assert_eq!(validate("proxies: [[[invalid yaml\n"), -1);
     }
 
@@ -1098,6 +1135,223 @@ rules:
             assert!(bridge_get_download_traffic() >= last_down);
         }
 
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn start_engine(dir: &std::path::Path) -> (i32, i32) {
+        let dir_c = CString::new(dir.to_str().unwrap()).unwrap();
+        unsafe { bridge_set_home_dir(dir_c.as_ptr()) };
+        let socks = free_port();
+        let dns = free_port();
+        let ctrl_c = CString::new(format!("127.0.0.1:{}", free_port())).unwrap();
+        let secret_c = CString::new("").unwrap();
+        let rc = unsafe { bridge_start_with_ports(socks, dns, ctrl_c.as_ptr(), secret_c.as_ptr()) };
+        let err = unsafe { CStr::from_ptr(bridge_get_last_error()) }
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(rc, 0, "start failed: {err}");
+        assert!(
+            wait_accept(&format!("127.0.0.1:{socks}")),
+            "mixed listener not up"
+        );
+        (socks, dns)
+    }
+
+    /// Loopback TCP echo server on an ephemeral port; runs until the test
+    /// process exits (a stuck accept is harmless there).
+    fn spawn_echo_server() -> u16 {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            for stream in listener.incoming().flatten() {
+                std::thread::spawn(move || {
+                    let mut stream = stream;
+                    let mut buf = [0u8; 1024];
+                    while let Ok(n) = stream.read(&mut buf) {
+                        if n == 0 || stream.write_all(&buf[..n]).is_err() {
+                            break;
+                        }
+                    }
+                });
+            }
+        });
+        port
+    }
+
+    /// Minimal loopback HTTP server answering every request with 204 and
+    /// counting them — a stand-in for the url-test probe target.
+    fn spawn_http_204_server() -> (u16, Arc<AtomicUsize>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&hits);
+        std::thread::spawn(move || {
+            for stream in listener.incoming().flatten() {
+                let counter = Arc::clone(&counter);
+                std::thread::spawn(move || {
+                    let mut stream = stream;
+                    let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+                    let mut buf = [0u8; 2048];
+                    let mut got = Vec::new();
+                    // Read until the end of the request head.
+                    while let Ok(n) = stream.read(&mut buf) {
+                        if n == 0 {
+                            return;
+                        }
+                        got.extend_from_slice(&buf[..n]);
+                        if got.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    let _ = stream.write_all(
+                        b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                    );
+                });
+            }
+        });
+        (port, hits)
+    }
+
+    /// SOCKS5 CONNECT to 127.0.0.1:`dst_port` through the engine's mixed
+    /// listener; returns the client side of the established session.
+    fn socks5_connect(socks_port: i32, dst_port: u16) -> std::net::TcpStream {
+        let mut s = std::net::TcpStream::connect(format!("127.0.0.1:{socks_port}")).unwrap();
+        s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        s.write_all(&[0x05, 0x01, 0x00]).unwrap();
+        let mut reply = [0u8; 2];
+        s.read_exact(&mut reply).unwrap();
+        assert_eq!(reply, [0x05, 0x00], "SOCKS5 method negotiation");
+        let mut req = vec![0x05, 0x01, 0x00, 0x01, 127, 0, 0, 1];
+        req.extend_from_slice(&dst_port.to_be_bytes());
+        s.write_all(&req).unwrap();
+        let mut head = [0u8; 4];
+        s.read_exact(&mut head).unwrap();
+        assert_eq!(head[1], 0x00, "SOCKS5 CONNECT rejected: {:?}", head);
+        let bnd_len = match head[3] {
+            0x01 => 4 + 2,
+            0x04 => 16 + 2,
+            other => panic!("unexpected BND ATYP {other:#x}"),
+        };
+        let mut bnd = vec![0u8; bnd_len];
+        s.read_exact(&mut bnd).unwrap();
+        s
+    }
+
+    fn wait_for_hits(hits: &AtomicUsize, at_least: usize, within: Duration) -> bool {
+        let deadline = Instant::now() + within;
+        while Instant::now() < deadline {
+            if hits.load(Ordering::SeqCst) >= at_least {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        false
+    }
+
+    // Regression (issue #113, finding 2): the mixed listener detaches every
+    // accepted connection with a bare `tokio::spawn`, so aborting only the
+    // listener task left established sessions relaying through the stopped
+    // engine (the app reported "disconnected" while traffic kept flowing).
+    // Stop must close them.
+    #[test]
+    fn stop_closes_established_socks5_sessions() {
+        let _g = TEST_LOCK.lock();
+        let dir = std::env::temp_dir().join(format!("meow-ffi-stopconn-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("config.yaml"), MINIMAL_CONFIG).unwrap();
+        let echo_port = spawn_echo_server();
+        let (socks, _dns) = start_engine(&dir);
+
+        let mut session = socks5_connect(socks, echo_port);
+        session.write_all(b"ping").unwrap();
+        let mut buf = [0u8; 4];
+        session.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"ping", "echo through the engine before stop");
+
+        bridge_stop_proxy();
+        assert!(!bridge_is_running());
+
+        // The relay task must be gone: the client's next read sees EOF (or a
+        // reset), never a timeout with the session still alive. Write first so
+        // a still-running relay would have something to echo back. (The 5 s
+        // read timeout from `socks5_connect` is still in force.)
+        let _ = session.write_all(b"after-stop");
+        let mut out = [0u8; 16];
+        match session.read(&mut out) {
+            Ok(0) | Err(_) => {}
+            Ok(n) => panic!(
+                "session still relaying after stop: got {:?}",
+                String::from_utf8_lossy(&out[..n])
+            ),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// url-test group with a 1 s non-lazy probe against a local target.
+    /// Real newlines (no `\` continuation) so the YAML indentation survives.
+    const HEALTH_CHECK_CONFIG: &str = "mode: rule
+dns:
+  enable: true
+  listen: 127.0.0.1:1053
+  enhanced-mode: fake-ip
+  fake-ip-range: 28.0.0.0/8
+  nameserver:
+    - 127.0.0.1:5353
+proxies: []
+proxy-groups:
+  - name: AUTO
+    type: url-test
+    url: http://127.0.0.1:PROBE_PORT/generate_204
+    interval: 1
+    lazy: false
+    proxies:
+      - DIRECT
+rules:
+  - MATCH,AUTO
+";
+
+    fn write_health_check_config(dir: &std::path::Path, probe_port: u16) {
+        let yaml = HEALTH_CHECK_CONFIG.replace("PROBE_PORT", &probe_port.to_string());
+        std::fs::write(dir.join("config.yaml"), yaml).unwrap();
+    }
+
+    // Regression (issue #113, finding 2): url-test / fallback health-check
+    // loops are spawned before the engine's task handles existed and own a
+    // cloned tunnel, so they outlived stop and accumulated across restarts
+    // (N generations → N probe loops, each pinning its dead tunnel). Every
+    // stop must silence the probes; a restart must not bring the old ones back.
+    #[test]
+    fn stop_halts_health_check_probes_and_restart_does_not_accumulate() {
+        let _g = TEST_LOCK.lock();
+        let dir = std::env::temp_dir().join(format!("meow-ffi-hc-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let (probe_port, hits) = spawn_http_204_server();
+        write_health_check_config(&dir, probe_port);
+
+        const QUIET: Duration = Duration::from_millis(2500);
+        for generation in 0..3 {
+            let before = hits.load(Ordering::SeqCst);
+            start_engine(&dir);
+            // A non-lazy 1 s url-test group probes right away and keeps going.
+            assert!(
+                wait_for_hits(&hits, before + 2, Duration::from_secs(10)),
+                "generation {generation}: health checks never probed the local target"
+            );
+            bridge_stop_proxy();
+            assert!(!bridge_is_running());
+
+            // A live loop would hit the target at least twice more in QUIET.
+            let at_stop = hits.load(Ordering::SeqCst);
+            std::thread::sleep(QUIET);
+            let after = hits.load(Ordering::SeqCst);
+            assert_eq!(
+                after, at_stop,
+                "generation {generation}: {} probe(s) fired after stop — a health-check loop outlived the engine",
+                after - at_stop
+            );
+        }
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/Rust/meow-ffi/src/logging.rs
+++ b/Rust/meow-ffi/src/logging.rs
@@ -2,14 +2,24 @@
 //!
 //! A single global subscriber is installed lazily (first `set_log_file` or
 //! first engine start). It has one fmt layer whose writer routes through a
-//! global `Mutex<Option<File>>` (swapped by `set_log_file`) and whose event
-//! format is `[Mihomo/<level>] <message>\n` — matching the Go bridge's
-//! engine-log sink. Swift concatenates the file as raw text, so the format is
-//! cosmetic only. A `reload`-wrapped level filter backs `set_level`.
+//! global `Mutex<Option<LogFile>>` (swapped by `set_log_file`, rotated in
+//! place by `trim_log_file`) and whose event format is
+//! `[Mihomo/<level>] <message>\n` — matching the Go bridge's engine-log sink.
+//! Swift concatenates the file as raw text, so the format is cosmetic only. A
+//! `reload`-wrapped level filter backs `set_level`.
+//!
+//! Trimming lives here, not in Swift, on purpose: the sink keeps an open
+//! append-mode handle, so a rewrite done by *another* process — Swift's
+//! atomic `String.write(to:)` renames a fresh file over the path — would
+//! leave the sink writing to the unlinked old inode: new engine lines vanish
+//! from the viewer while the orphan keeps growing. [`trim_log_file`] rewrites
+//! and reopens under the sink's own lock, so every line logged after it lands
+//! in the file the viewer reads.
 
 use parking_lot::Mutex;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use std::sync::{Once, OnceLock};
 use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::filter::LevelFilter;
@@ -17,7 +27,15 @@ use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, MakeWriter};
 use tracing_subscriber::registry::LookupSpan;
 
-static LOG_FILE: Mutex<Option<File>> = Mutex::new(None);
+/// The active sink: the append handle plus the path it was opened at, so the
+/// file can be rotated and the handle reopened without the caller having to
+/// know (or repeat) the path.
+struct LogFile {
+    path: PathBuf,
+    file: File,
+}
+
+static LOG_FILE: Mutex<Option<LogFile>> = Mutex::new(None);
 static INIT: Once = Once::new();
 static SET_LEVEL: OnceLock<Box<dyn Fn(LevelFilter) + Send + Sync>> = OnceLock::new();
 
@@ -29,13 +47,13 @@ struct FileSink;
 impl Write for FileSink {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match LOG_FILE.lock().as_mut() {
-            Some(f) => f.write(buf),
+            Some(lf) => lf.file.write(buf),
             None => Ok(buf.len()),
         }
     }
     fn flush(&mut self) -> io::Result<()> {
         match LOG_FILE.lock().as_mut() {
-            Some(f) => f.flush(),
+            Some(lf) => lf.file.flush(),
             None => Ok(()),
         }
     }
@@ -97,16 +115,110 @@ pub fn ensure_subscriber() {
     });
 }
 
-/// Open (create/append) `path` and make it the active log sink.
-pub fn set_log_file(path: &str) -> Result<(), String> {
-    ensure_subscriber();
-    let file = OpenOptions::new()
+fn open_append(path: &Path) -> Result<File, String> {
+    OpenOptions::new()
         .create(true)
         .append(true)
         .open(path)
-        .map_err(|e| format!("open log file: {e}"))?;
-    *LOG_FILE.lock() = Some(file);
+        .map_err(|e| format!("open log file: {e}"))
+}
+
+/// Open (create/append) `path` and make it the active log sink.
+pub fn set_log_file(path: &str) -> Result<(), String> {
+    ensure_subscriber();
+    let path = PathBuf::from(path);
+    let file = open_append(&path)?;
+    *LOG_FILE.lock() = Some(LogFile { path, file });
     Ok(())
+}
+
+/// Keep only the last `max_lines` lines of the active log file, atomically
+/// (write a sibling temp file, rename over the path), and reopen the sink on
+/// the new file — all under the sink's writer lock, so no line is lost or
+/// written to an orphaned inode. A no-op when no log file is set or the file
+/// is already within the cap. `max_lines <= 0` is rejected.
+pub fn trim_log_file(max_lines: i64) -> Result<(), String> {
+    if max_lines <= 0 {
+        return Err(format!("max_lines must be > 0, got {max_lines}"));
+    }
+    let max_lines = max_lines as usize;
+    let mut slot = LOG_FILE.lock();
+    let Some(lf) = slot.as_mut() else {
+        return Ok(());
+    };
+    // Push any buffered bytes out first so the read below sees them.
+    lf.file
+        .flush()
+        .map_err(|e| format!("flush log file: {e}"))?;
+    let content = match std::fs::read(&lf.path) {
+        Ok(bytes) => bytes,
+        // Deleted out from under us (the app cleared it): just reopen so
+        // subsequent lines become visible at the path again.
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            lf.file = open_append(&lf.path)?;
+            return Ok(());
+        }
+        Err(e) => return Err(format!("read log file: {e}")),
+    };
+    let Some(tail) = tail_lines(&content, max_lines) else {
+        // Nothing to cut. Still make sure the handle is on the file that is
+        // at the path: if something replaced it underneath us, reattach.
+        if detached(lf) {
+            lf.file = open_append(&lf.path)?;
+        }
+        return Ok(());
+    };
+    let tmp = lf.path.with_extension("log.trim");
+    let mut new_file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&tmp)
+        .map_err(|e| format!("create trimmed log file: {e}"))?;
+    new_file
+        .write_all(tail)
+        .and_then(|()| new_file.sync_data())
+        .map_err(|e| format!("write trimmed log file: {e}"))?;
+    if let Err(e) = std::fs::rename(&tmp, &lf.path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("replace log file: {e}"));
+    }
+    // Reopen at the path so the sink writes to the file that is now there,
+    // never to the unlinked inode the old handle still points at.
+    lf.file = open_append(&lf.path)?;
+    Ok(())
+}
+
+/// True when the file at `lf.path` is no longer the one `lf.file` has open
+/// (replaced by rename, or gone) — i.e. the sink is writing into an orphan.
+fn detached(lf: &LogFile) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    match (std::fs::metadata(&lf.path), lf.file.metadata()) {
+        (Ok(at_path), Ok(held)) => at_path.dev() != held.dev() || at_path.ino() != held.ino(),
+        _ => true,
+    }
+}
+
+/// The suffix of `content` holding its last `max_lines` lines (a trailing
+/// newline does not start a new line), or `None` when it is already within
+/// the cap and nothing needs rewriting.
+fn tail_lines(content: &[u8], max_lines: usize) -> Option<&[u8]> {
+    let body = content.strip_suffix(b"\n").unwrap_or(content);
+    if body.is_empty() {
+        return None;
+    }
+    // Walk newlines from the end; the cut lands just after the newline that
+    // precedes the `max_lines`-th line from the back.
+    let mut newlines_seen = 0usize;
+    for (idx, &b) in body.iter().enumerate().rev() {
+        if b == b'\n' {
+            newlines_seen += 1;
+            if newlines_seen == max_lines {
+                return Some(&content[idx + 1..]);
+            }
+        }
+    }
+    None
 }
 
 /// Update the active level filter. Mihomo level names → tracing filters;
@@ -122,5 +234,118 @@ pub fn set_level(level: &str) {
     };
     if let Some(apply) = SET_LEVEL.get() {
         apply(filter);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line_count(path: &Path) -> usize {
+        std::fs::read_to_string(path)
+            .unwrap_or_default()
+            .lines()
+            .count()
+    }
+
+    #[test]
+    fn tail_lines_keeps_only_the_last_n() {
+        assert_eq!(tail_lines(b"a\nb\nc\n", 2), Some(&b"b\nc\n"[..]));
+        assert_eq!(tail_lines(b"a\nb\nc", 2), Some(&b"b\nc"[..]));
+        assert_eq!(tail_lines(b"a\nb\nc\n", 3), None, "exactly at cap");
+        assert_eq!(tail_lines(b"a\nb\nc\n", 5), None, "under cap");
+        assert_eq!(tail_lines(b"", 1), None);
+        assert_eq!(tail_lines(b"\n", 1), None, "one empty line is within cap");
+        assert_eq!(tail_lines(b"a\nb\n", 1), Some(&b"b\n"[..]));
+    }
+
+    // Regression (issue #113, finding 7): the provider used to trim
+    // rust_bridge.log with an atomic replace from Swift, which left this
+    // sink's open append handle on the unlinked old inode — every engine
+    // line logged afterwards disappeared from the file the viewer reads.
+    // Trimming through the sink must keep the file bounded AND keep later
+    // lines visible at the path.
+    #[test]
+    fn trim_keeps_file_bounded_and_later_lines_visible() {
+        let _g = crate::TEST_LOCK.lock();
+        let dir = std::env::temp_dir().join(format!("meow-ffi-logtrim-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("rust_bridge.log");
+        set_log_file(path.to_str().unwrap()).unwrap();
+
+        const CAP: usize = 50;
+        for i in 0..(CAP * 3) {
+            tracing::info!("filler line {i}");
+        }
+        assert!(
+            line_count(&path) > CAP,
+            "sink did not write through: {} lines",
+            line_count(&path)
+        );
+
+        trim_log_file(CAP as i64).unwrap();
+        let after_trim = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            after_trim.lines().count(),
+            CAP,
+            "trim must keep exactly the cap"
+        );
+        assert!(
+            after_trim.contains(&format!("filler line {}", CAP * 3 - 1)),
+            "trim must keep the newest lines"
+        );
+        assert!(
+            !after_trim.contains("filler line 0\n"),
+            "trim must drop the oldest lines"
+        );
+
+        // A line logged AFTER the trim must land in the file at the path,
+        // not in an orphaned inode.
+        let marker = format!("post-trim marker {}", std::process::id());
+        tracing::info!("{marker}");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains(&marker),
+            "engine log written after trim is not visible at the log path"
+        );
+        assert_eq!(content.lines().count(), CAP + 1, "file stays bounded");
+
+        // Within the cap: no rewrite, nothing lost.
+        trim_log_file((CAP * 4) as i64).unwrap();
+        assert!(std::fs::read_to_string(&path).unwrap().contains(&marker));
+
+        assert!(trim_log_file(0).is_err(), "non-positive cap is rejected");
+
+        *LOG_FILE.lock() = None;
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A trim must never be silently defeated by an external replace that
+    /// happened before it: reopening puts the sink back on the live path.
+    #[test]
+    fn trim_reattaches_after_external_replace() {
+        let _g = crate::TEST_LOCK.lock();
+        let dir = std::env::temp_dir().join(format!("meow-ffi-logreattach-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("rust_bridge.log");
+        set_log_file(path.to_str().unwrap()).unwrap();
+        tracing::info!("before external replace");
+
+        // Simulate the old Swift-side atomic rewrite (new inode at the path).
+        let tmp = dir.join("swap.tmp");
+        std::fs::write(&tmp, "kept by external rewrite\n").unwrap();
+        std::fs::rename(&tmp, &path).unwrap();
+
+        trim_log_file(1000).unwrap();
+        tracing::info!("after trim reattach");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("kept by external rewrite"));
+        assert!(
+            content.contains("after trim reattach"),
+            "sink still writes to the unlinked inode after trim: {content:?}"
+        );
+
+        *LOG_FILE.lock() = None;
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -264,7 +264,8 @@ final class ConfigManager {
     /// Patch the on-disk config.yaml to disable geo data downloads, which would
     /// block the Network Extension during startup. Safe to call on every launch.
     func sanitizeConfig() {
-        guard let yaml = try? loadConfig() else { return }
+        guard var yaml = try? loadConfig() else { return }
+        Self.normalizeFlowSection(&yaml, key: "tun")
         var lines = yaml.components(separatedBy: "\n")
         var hasGeoAutoUpdate = false
 
@@ -313,6 +314,9 @@ final class ConfigManager {
     static func sanitizeConfigString(_ config: inout String, engineMode: EngineMode = .vpn) {
         // Disable TUN and geo-auto-update — transparent proxy intercepts at
         // socket level, and geo downloads would block tunnel startup.
+        // An inline `tun: {enable: true}` has no `enable:` line to rewrite,
+        // so spell it out in block style first.
+        normalizeFlowSection(&config, key: "tun")
         var lines = config.components(separatedBy: "\n")
         var inTunBlock = false
         lines = lines.map { line in
@@ -390,6 +394,7 @@ final class ConfigManager {
     /// fallback, nameserver-policy, fake-ip-filter, and comments stay as
     /// the user or subscription wrote them.
     static func forceManagedDNS(_ config: inout String, engineMode: EngineMode = .vpn) {
+        normalizeFlowSection(&config, key: "dns")
         var lines = config.components(separatedBy: "\n")
         if let range = topLevelSectionRange(in: lines, key: "dns") {
             var section = Array(lines[range])
@@ -414,9 +419,85 @@ final class ConfigManager {
         config = lines.joined(separator: "\n")
     }
 
+    /// Rewrite the top-level `key:` section in block style when its header
+    /// carries an inline flow mapping — `dns: {enable: true, nameserver:
+    /// [1.1.1.1]}` — or, with `includingNested`, when any line inside it
+    /// opens one (`p: {type: http, url: …}`). The line-based patchers only
+    /// address block keys: `setSectionScalar` would push indented entries
+    /// under an inline mapping (invalid YAML), the tun scan never sees an
+    /// inline `enable:`, and `sanitizeProviders` cannot find `url:` /
+    /// `path:` inside a flow provider. Block-style sections pass through
+    /// untouched, so comments there stay put; a section that fails to
+    /// parse is left as-is for the engine to reject.
+    static func normalizeFlowSection(
+        _ config: inout String, key: String, includingNested: Bool = false
+    ) {
+        var lines = config.components(separatedBy: "\n")
+        guard let range = topLevelSectionRange(in: lines, key: key) else { return }
+        let opensFlow = { (line: String) in
+            opensFlowMapping(line.trimmingCharacters(in: .whitespaces))
+        }
+        guard opensFlow(lines[range.lowerBound])
+            || (includingNested && lines[range].dropFirst().contains(where: opensFlow))
+        else { return }
+
+        // Trailing blank and comment lines sit outside the mapping; keep
+        // them verbatim.
+        var end = range.upperBound
+        while end > range.lowerBound + 1 {
+            let trimmed = lines[end - 1].trimmingCharacters(in: .whitespaces)
+            guard trimmed.isEmpty || trimmed.hasPrefix("#") else { break }
+            end -= 1
+        }
+        let text = lines[range.lowerBound..<end].joined(separator: "\n")
+        guard let node = try? Yams.compose(yaml: text),
+              let root = node.mapping, root.count == 1,
+              let value = root[key]?.mapping else { return }
+        var block: [String]
+        if value.isEmpty {
+            // libyaml still emits an empty mapping as `{}`; a bare key
+            // lets the patchers add children under it.
+            block = ["\(key):"]
+        } else {
+            guard let text = try? Yams.serialize(node: blockStyled(node)) else { return }
+            block = text.components(separatedBy: "\n")
+            while block.last?.isEmpty == true { block.removeLast() }
+        }
+        lines.replaceSubrange(range.lowerBound..<end, with: block)
+        config = lines.joined(separator: "\n")
+    }
+
+    /// True for a `key: {…`, `- {…`, or bare `{…` line.
+    private static func opensFlowMapping(_ trimmed: String) -> Bool {
+        var rest = Substring(trimmed)
+        if rest.hasPrefix("-") {
+            rest = rest.dropFirst().drop { $0 == " " || $0 == "\t" }
+        }
+        if rest.hasPrefix("{") { return true }
+        guard let first = rest.first, first != "#", first != "\"", first != "'",
+              let colon = rest.firstIndex(of: ":") else { return false }
+        let value = rest[rest.index(after: colon)...].drop { $0 == " " || $0 == "\t" }
+        return value.hasPrefix("{")
+    }
+
+    /// Copy of `node` with every mapping and sequence forced to block style.
+    /// Scalars keep their quoting; empty collections still emit as `{}`/`[]`.
+    private static func blockStyled(_ node: Yams.Node) -> Yams.Node {
+        switch node {
+        case .scalar, .alias:
+            return node
+        case .mapping(let mapping):
+            let pairs = mapping.map { ($0.key, blockStyled($0.value)) }
+            return .mapping(Yams.Node.Mapping(pairs, mapping.tag, .block))
+        case .sequence(let sequence):
+            return .sequence(Yams.Node.Sequence(sequence.map(blockStyled), sequence.tag, .block))
+        }
+    }
+
     /// Inclusive range of a top-level YAML mapping section named `key`.
     /// The range starts at `key:` and ends before the next top-level key
-    /// (comments and blanks stay with the section).
+    /// (comments, blanks, and a column-0 `}` / `]` closing a multi-line
+    /// flow collection stay with the section).
     private static func topLevelSectionRange(
         in lines: [String], key: String
     ) -> Range<Int>? {
@@ -429,6 +510,7 @@ final class ConfigManager {
             let line = lines[i]
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             if !trimmed.isEmpty && !trimmed.hasPrefix("#")
+                && !trimmed.hasPrefix("}") && !trimmed.hasPrefix("]")
                 && !line.hasPrefix(" ") && !line.hasPrefix("\t") {
                 end = i
                 break
@@ -542,8 +624,11 @@ final class ConfigManager {
                 i += 1
                 continue
             }
+            // A `- item` at the key's own indent still belongs to it (YAML
+            // allows an unindented block sequence there, and the flow
+            // normalizer emits that shape).
             let indent = String(line.prefix { $0 == " " || $0 == "\t" })
-            guard indent.count > keyIndent.count, trimmed.hasPrefix("-") else { break }
+            guard indent.count >= keyIndent.count, trimmed.hasPrefix("-") else { break }
             let entry = trimmed.dropFirst().trimmingCharacters(in: .whitespaces)
             if isSelfReference(entry) {
                 drop.append(i)
@@ -745,12 +830,14 @@ final class ConfigManager {
             $0.trimmingCharacters(in: .whitespaces).hasPrefix("subscriptions:")
                 && !$0.hasPrefix(" ") && !$0.hasPrefix("\t")
         }) else { return }
-        // Find end: next top-level key or end of file
+        // Find end: next top-level key or end of file (a column-0 `}` / `]`
+        // closing a multi-line flow value belongs to the section)
         var end = lines.count
         for i in (start + 1)..<lines.count {
             let line = lines[i]
             let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if !trimmed.isEmpty && !line.hasPrefix(" ") && !line.hasPrefix("\t") {
+            if !trimmed.isEmpty && !line.hasPrefix(" ") && !line.hasPrefix("\t")
+                && !trimmed.hasPrefix("}") && !trimmed.hasPrefix("]") {
                 end = i
                 break
             }
@@ -1028,6 +1115,13 @@ final class ConfigManager {
     /// special-cases the `url:`/`path:` keys and otherwise passes provider
     /// blocks through untouched. Valid providers are preserved as-is.
     static func sanitizeProviders(_ section: String) -> String {
+        // A flow-style provider (`p: {type: http, url: file:///…}`) keeps
+        // its `url:` / `path:` off their own lines, which would let it
+        // slip past the checks below untouched.
+        var section = section
+        if let key = mappingKeyName(section.components(separatedBy: "\n")[0]) {
+            normalizeFlowSection(&section, key: key, includingNested: true)
+        }
         var lines = section.components(separatedBy: "\n")
         guard lines.count > 1 else { return section }
         let header = lines.removeFirst()
@@ -1164,8 +1258,11 @@ final class ConfigManager {
             .replacingOccurrences(of: "\r", with: "\n")
 
         for line in normalized.components(separatedBy: "\n") {
+            // A column-0 `}` / `]` closes a multi-line flow collection and
+            // stays with the section it ends.
             let isTopLevel = !line.hasPrefix(" ") && !line.hasPrefix("\t")
                 && !line.isEmpty && !line.hasPrefix("-") && !line.hasPrefix("#")
+                && !line.hasPrefix("}") && !line.hasPrefix("]")
             if isTopLevel {
                 flush()
                 let key = String(line.prefix(while: { $0 != ":" }))
@@ -1283,16 +1380,42 @@ final class ConfigManager {
 
 // MARK: - Editable Config Models
 
-struct EditableProxyGroup: Identifiable {
+struct EditableProxyGroup: Identifiable, Equatable {
     var id = UUID()
     var name: String
     var type: String
     var proxies: [String]
     var url: String?
     var interval: Int?
+    /// Group fields the structured editor does not model (`use`, `filter`,
+    /// `lazy`, `tolerance`, `include-all`, …), in source order. They are
+    /// re-emitted verbatim on save so a structured edit — or a mere
+    /// Structured → Raw switch — cannot strip provider-backed membership
+    /// or tuning options the editor never showed.
+    var extraFields: [ProxyGroupField] = []
+
+    /// Keys the structured editor maps onto dedicated properties. Anything
+    /// else lands in `extraFields`.
+    static let modelledKeys: Set<String> = ["name", "type", "proxies", "url", "interval"]
+
+    /// Whether the group's members come from somewhere other than
+    /// `proxies:` — a provider list or an include-all flag. Such a group
+    /// legitimately has no `proxies:` key, so none is synthesized for it.
+    var hasProviderMembership: Bool {
+        extraFields.contains {
+            ["use", "include-all", "include-all-proxies", "include-all-providers"].contains($0.key)
+        }
+    }
 }
 
-struct EditableRule: Identifiable {
+/// One unmodelled `key: value` pair of a proxy group, held as a parsed
+/// YAML node so nested lists and mappings survive the round trip.
+struct ProxyGroupField: Hashable {
+    var key: String
+    var value: Yams.Node
+}
+
+struct EditableRule: Identifiable, Equatable {
     var id = UUID()
     var type: String
     var value: String
@@ -1305,17 +1428,28 @@ struct EditableRule: Identifiable {
 extension ConfigManager {
 
     func parseProxyGroups(from yaml: String) -> [EditableProxyGroup] {
-        guard let dict = (try? Yams.load(yaml: yaml)) as? [String: Any],
-              let groupList = dict["proxy-groups"] as? [[String: Any]] else {
+        // Composed nodes (not `Yams.load`'s `[String: Any]`) so unmodelled
+        // fields keep their order, nesting, and scalar quoting for re-emit.
+        guard let root = try? Yams.compose(yaml: yaml),
+              let groupList = root["proxy-groups"]?.sequence else {
             return []
         }
         return groupList.compactMap { group -> EditableProxyGroup? in
-            guard let name = group["name"] as? String,
-                  let type = group["type"] as? String else { return nil }
-            let proxies = group["proxies"] as? [String] ?? []
-            let url = group["url"] as? String
-            let interval = group["interval"] as? Int
-            return EditableProxyGroup(name: name, type: type, proxies: proxies, url: url, interval: interval)
+            guard let mapping = group.mapping,
+                  let name = mapping["name"]?.string,
+                  let type = mapping["type"]?.string else { return nil }
+            let proxies = mapping["proxies"]?.sequence?.compactMap(\.string) ?? []
+            let url = mapping["url"]?.string
+            let interval = mapping["interval"]?.int
+            let extras = mapping.compactMap { pair -> ProxyGroupField? in
+                guard let key = pair.key.string,
+                      !EditableProxyGroup.modelledKeys.contains(key) else { return nil }
+                return ProxyGroupField(key: key, value: pair.value)
+            }
+            return EditableProxyGroup(
+                name: name, type: type, proxies: proxies, url: url, interval: interval,
+                extraFields: extras
+            )
         }
     }
 
@@ -1364,7 +1498,8 @@ extension ConfigManager {
         while endIdx < lines.count {
             let line = lines[endIdx]
             let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if !line.hasPrefix(" ") && !line.hasPrefix("\t") && !trimmed.isEmpty && !trimmed.hasPrefix("#") {
+            if !line.hasPrefix(" ") && !line.hasPrefix("\t") && !trimmed.isEmpty && !trimmed.hasPrefix("#")
+                && !trimmed.hasPrefix("}") && !trimmed.hasPrefix("]") {
                 break
             }
             endIdx += 1
@@ -1415,16 +1550,31 @@ extension ConfigManager {
             if let interval = group.interval {
                 result.append("    interval: \(interval)")
             }
-            if group.proxies.isEmpty {
-                result.append("    proxies: []")
-            } else {
+            if !group.proxies.isEmpty {
                 result.append("    proxies:")
                 for proxy in group.proxies {
                     result.append("      - \(Self.yamlQuotedString(proxy))")
                 }
+            } else if !group.hasProviderMembership {
+                result.append("    proxies: []")
+            }
+            for field in group.extraFields {
+                result.append(contentsOf: Self.serializeProxyGroupField(field))
             }
         }
         return result
+    }
+
+    /// Emit one unmodelled group field as indented YAML lines. The node is
+    /// serialized on its own (`use: [p]`, `filter: test`, a block list…)
+    /// and every line shifted under the group entry, which keeps nested
+    /// structure intact whatever its style.
+    private static func serializeProxyGroupField(_ field: ProxyGroupField) -> [String] {
+        let node = Yams.Node.mapping(Yams.Node.Mapping([(Yams.Node(field.key), field.value)]))
+        guard let text = try? Yams.serialize(node: node) else { return [] }
+        var lines = text.components(separatedBy: "\n")
+        while lines.last?.isEmpty == true { lines.removeLast() }
+        return lines.map { "    " + $0 }
     }
 
     private func serializeRules(_ rules: [EditableRule]) -> [String] {

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -459,7 +459,9 @@ final class ConfigManager {
             // lets the patchers add children under it.
             block = ["\(key):"]
         } else {
-            guard let text = try? Yams.serialize(node: blockStyled(node)) else { return }
+            guard let text = try? Yams.serialize(
+                node: blockStyled(node), width: -1, allowUnicode: true
+            ) else { return }
             block = text.components(separatedBy: "\n")
             while block.last?.isEmpty == true { block.removeLast() }
         }
@@ -467,15 +469,21 @@ final class ConfigManager {
         config = lines.joined(separator: "\n")
     }
 
-    /// True for a `key: {…`, `- {…`, or bare `{…` line.
+    /// True for a `key: {…`, `"key": {…`, `- {…`, or bare `{…` line.
     private static func opensFlowMapping(_ trimmed: String) -> Bool {
         var rest = Substring(trimmed)
         if rest.hasPrefix("-") {
             rest = rest.dropFirst().drop { $0 == " " || $0 == "\t" }
         }
         if rest.hasPrefix("{") { return true }
-        guard let first = rest.first, first != "#", first != "\"", first != "'",
-              let colon = rest.firstIndex(of: ":") else { return false }
+        guard let first = rest.first, first != "#" else { return false }
+        if first == "\"" || first == "'" {
+            // Quoted key: the colon we want follows the closing quote.
+            let (_, quote, after) = parseYAMLScalarWithComment(String(rest))
+            guard quote != nil else { return false }
+            rest = Substring(after)
+        }
+        guard let colon = rest.firstIndex(of: ":") else { return false }
         let value = rest[rest.index(after: colon)...].drop { $0 == " " || $0 == "\t" }
         return value.hasPrefix("{")
     }
@@ -497,7 +505,10 @@ final class ConfigManager {
     /// Inclusive range of a top-level YAML mapping section named `key`.
     /// The range starts at `key:` and ends before the next top-level key
     /// (comments, blanks, and a column-0 `}` / `]` closing a multi-line
-    /// flow collection stay with the section).
+    /// flow collection stay with the section). A flow collection left open
+    /// on the `key:` line — `dns: {` with its entries on the following
+    /// lines, even at column 0 — is followed to its closing bracket first,
+    /// since YAML lets flow entries ignore indentation.
     private static func topLevelSectionRange(
         in lines: [String], key: String
     ) -> Range<Int>? {
@@ -505,8 +516,14 @@ final class ConfigManager {
             isYAMLKey($0.trimmingCharacters(in: .whitespaces), key)
                 && !$0.hasPrefix(" ") && !$0.hasPrefix("\t")
         }) else { return nil }
+        var first = start + 1
+        var depth = flowNestingDelta(of: lines[start])
+        while depth > 0 && first < lines.count {
+            depth += flowNestingDelta(of: lines[first])
+            first += 1
+        }
         var end = lines.count
-        for i in (start + 1)..<lines.count {
+        for i in first..<lines.count {
             let line = lines[i]
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             if !trimmed.isEmpty && !trimmed.hasPrefix("#")
@@ -517,6 +534,44 @@ final class ConfigManager {
             }
         }
         return start..<end
+    }
+
+    /// Net number of flow collections (`{` / `[`) opened minus closed on
+    /// `line`, ignoring brackets inside quoted scalars and after a `#`
+    /// comment. Positive means the line leaves a flow collection open.
+    private static func flowNestingDelta(of line: String) -> Int {
+        var delta = 0
+        var quote: Character?
+        var previous: Character = " "
+        var escaped = false
+        for character in line {
+            defer { previous = character }
+            if let open = quote {
+                if open == "\"" && escaped {
+                    escaped = false
+                } else if open == "\"" && character == "\\" {
+                    escaped = true
+                } else if character == open {
+                    quote = nil
+                }
+                continue
+            }
+            switch character {
+            case "#" where previous == " " || previous == "\t":
+                return delta
+            case "\"", "'":
+                // A quote opens a scalar only at a token boundary; an
+                // apostrophe inside a plain scalar (`it's`) is literal.
+                if " \t{[,:".contains(previous) { quote = character }
+            case "{", "[":
+                delta += 1
+            case "}", "]":
+                delta -= 1
+            default:
+                break
+            }
+        }
+        return delta
     }
 
     /// Replace or insert a top-level YAML section. `body` should start with
@@ -1088,15 +1143,20 @@ final class ConfigManager {
     }
 
     /// Set interval to 0 in provider sections so Mihomo won't auto-refresh subscription URLs.
+    /// Only each provider's own `interval:` is rewritten; a nested one
+    /// (`health-check: {interval: 300}`) is the provider's business.
     static func disableProviderRefresh(_ section: String) -> String {
-        section.components(separatedBy: "\n").map { line in
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("interval:") {
+        guard let (header, blocks) = splitProviderBlocks(section) else { return section }
+        let rewritten = blocks.flatMap { block -> [String] in
+            let depth = providerChildIndent(of: block)
+            return block.map { line in
                 let indent = line.prefix(while: { $0 == " " || $0 == "\t" })
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                guard indent.count == depth, trimmed.hasPrefix("interval:") else { return line }
                 return indent + "interval: 0"
             }
-            return line
-        }.joined(separator: "\n")
+        }
+        return ([header] + rewritten).joined(separator: "\n")
     }
 
     /// Validate/sanitize subscription-controlled provider entries
@@ -1115,15 +1175,25 @@ final class ConfigManager {
     /// special-cases the `url:`/`path:` keys and otherwise passes provider
     /// blocks through untouched. Valid providers are preserved as-is.
     static func sanitizeProviders(_ section: String) -> String {
-        // A flow-style provider (`p: {type: http, url: file:///…}`) keeps
-        // its `url:` / `path:` off their own lines, which would let it
-        // slip past the checks below untouched.
+        guard let (header, blocks) = splitProviderBlocks(section) else { return section }
+        let kept = blocks.compactMap { sanitizeProviderBlock($0) }
+        guard !kept.isEmpty else { return header }
+        return ([header] + kept.flatMap { $0 }).joined(separator: "\n")
+    }
+
+    /// Split a `proxy-providers:` / `rule-providers:` section into its
+    /// header line and one line group per provider entry (each starting
+    /// at the `name:` line). Flow-style entries are first re-emitted in
+    /// block style: `p: {type: http, url: file:///…}` keeps its `url:` /
+    /// `path:` off their own lines, which would let it slip past the
+    /// checks untouched. Nil when the section has no entries.
+    private static func splitProviderBlocks(_ section: String) -> (String, [[String]])? {
         var section = section
         if let key = mappingKeyName(section.components(separatedBy: "\n")[0]) {
             normalizeFlowSection(&section, key: key, includingNested: true)
         }
         var lines = section.components(separatedBy: "\n")
-        guard lines.count > 1 else { return section }
+        guard lines.count > 1 else { return nil }
         let header = lines.removeFirst()
 
         // The indentation of the first provider-name line (e.g. 2 spaces)
@@ -1132,7 +1202,7 @@ final class ConfigManager {
             .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty })
             .map({ line in line.prefix(while: { $0 == " " }).count })
         else {
-            return section
+            return nil
         }
 
         func isBlockStart(_ line: String) -> Bool {
@@ -1152,18 +1222,37 @@ final class ConfigManager {
             }
         }
         if !current.isEmpty { blocks.append(current) }
+        return (header, blocks)
+    }
 
-        let kept = blocks.compactMap { sanitizeProviderBlock($0) }
-        guard !kept.isEmpty else { return header }
-        return ([header] + kept.flatMap { $0 }).joined(separator: "\n")
+    /// Indentation of a provider entry's own keys: the first non-blank,
+    /// non-comment line after the `name:` line. Deeper lines belong to a
+    /// nested mapping such as `health-check:` or `header:`, whose `url:` /
+    /// `interval:` must not be mistaken for the provider's.
+    private static func providerChildIndent(of block: [String]) -> Int {
+        for line in block.dropFirst() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+            return line.prefix(while: { $0 == " " || $0 == "\t" }).count
+        }
+        return Int.max
     }
 
     /// Returns the (possibly rewritten) lines of a single provider block, or
-    /// nil if the whole block should be dropped (non-https `url:`).
+    /// nil if the whole block should be dropped (non-https `url:`). Only the
+    /// provider's first-level keys are inspected — `health-check: {url:
+    /// http://www.gstatic.com/generate_204}` is a probe target, not a
+    /// download URL, and must not get the provider dropped.
     private static func sanitizeProviderBlock(_ block: [String]) -> [String]? {
+        let depth = providerChildIndent(of: block)
         var result: [String] = []
         for line in block {
+            let indent = line.prefix { $0 == " " || $0 == "\t" }
             let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard indent.count == depth else {
+                result.append(line)
+                continue
+            }
             if trimmed.hasPrefix("url:") {
                 let value = scalarValue(afterKey: "url", in: line)
                 guard value.lowercased().hasPrefix("https://") else { return nil }
@@ -1173,7 +1262,6 @@ final class ConfigManager {
             if trimmed.hasPrefix("path:") {
                 let value = scalarValue(afterKey: "path", in: line)
                 if value.contains("..") || value.hasPrefix("/") || value.hasPrefix("~") {
-                    let indent = line.prefix { $0 == " " || $0 == "\t" }
                     var safeName = (value as NSString).lastPathComponent
                         .replacingOccurrences(of: "..", with: "_")
                     if safeName.isEmpty || safeName == "/" {
@@ -1439,7 +1527,7 @@ extension ConfigManager {
                   let name = mapping["name"]?.string,
                   let type = mapping["type"]?.string else { return nil }
             let proxies = mapping["proxies"]?.sequence?.compactMap(\.string) ?? []
-            let url = mapping["url"]?.string
+            let url = Self.presentScalar(mapping["url"])?.string
             let interval = mapping["interval"]?.int
             let extras = mapping.compactMap { pair -> ProxyGroupField? in
                 guard let key = pair.key.string,
@@ -1451,6 +1539,14 @@ extension ConfigManager {
                 extraFields: extras
             )
         }
+    }
+
+    /// `node`'s scalar unless it is a YAML null (`url: null`, `url: ~`,
+    /// or a bare `url:`), whose `Node.string` would still hand back the
+    /// raw text and re-emit it as the string `"null"`.
+    private static func presentScalar(_ node: Yams.Node?) -> Yams.Node.Scalar? {
+        guard let scalar = node?.scalar, NSNull.construct(from: scalar) == nil else { return nil }
+        return scalar
     }
 
     func parseRules(from yaml: String) -> [EditableRule] {
@@ -1571,7 +1667,9 @@ extension ConfigManager {
     /// structure intact whatever its style.
     private static func serializeProxyGroupField(_ field: ProxyGroupField) -> [String] {
         let node = Yams.Node.mapping(Yams.Node.Mapping([(Yams.Node(field.key), field.value)]))
-        guard let text = try? Yams.serialize(node: node) else { return [] }
+        // Unlimited width and raw unicode: a `filter: "(?i)香港|HK"` regex
+        // must not come back as `\u9999\u6E2F` folded across lines.
+        guard let text = try? Yams.serialize(node: node, width: -1, allowUnicode: true) else { return [] }
         var lines = text.components(separatedBy: "\n")
         while lines.last?.isEmpty == true { lines.removeLast() }
         return lines.map { "    " + $0 }

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -43,7 +43,11 @@ final class ConfigManager {
     /// the derived runtime YAML (`config.yaml` = base + user settings) plus
     /// links to the shared geodata files. The engine only ever loads
     /// `<home>/config.yaml`, so giving it its own home is what keeps startup
-    /// from overwriting `configFileURL` with a derived artifact.
+    /// from overwriting `configFileURL` with a derived artifact. Files the
+    /// engine writes relative to its config — provider `path:` caches,
+    /// `selector-cache.json` — land here too, so local-proxy mode refetches
+    /// providers once on its first start after this directory appears
+    /// (saved group selections are replayed over REST, not read from disk).
     var runtimeDirectoryURL: URL? {
         configDirectoryURL?.appendingPathComponent("runtime", isDirectory: true)
     }
@@ -212,8 +216,9 @@ final class ConfigManager {
     /// How the saved local config and the selected subscription compose:
     ///
     /// `config.yaml` (`configFileURL`) is the one authoritative, editable
-    /// base. The selected subscription is merged INTO it — header (ports,
-    /// `dns:`) kept from the file, proxies / proxy-groups / providers /
+    /// base. The selected subscription is merged INTO it — header kept from
+    /// the file (ports, and `dns:` unless the subscription ships its own
+    /// `dns:` block, which replaces it), proxies / proxy-groups / providers /
     /// rules taken from the subscription — by `applySubscriptionConfig`,
     /// which runs when a subscription is selected or (re)fetched. Between
     /// those events the file is the user's: whatever the Config Editor
@@ -224,6 +229,17 @@ final class ConfigManager {
     /// `rawContent` (and, with no subscription, with the built-in
     /// defaults). Refreshing a subscription still overwrites the merged
     /// sections — that is the documented cost of the "merged into" model.
+    ///
+    /// Because startup never consults the selection, the file must be
+    /// detached explicitly when the selection goes away: deleting the
+    /// selected subscription, or selecting one whose content has not been
+    /// fetched yet, runs `clearSubscriptionConfig` (defaults' proxies /
+    /// groups / rules back, providers dropped, header kept) so the engine
+    /// cannot keep routing through nodes the UI no longer shows as selected.
+    /// The one deliberate divergence left is the editor's Reset Default +
+    /// Save: it puts the built-in defaults in the file while the Home tab
+    /// still shows the subscription as selected, until it is re-selected or
+    /// refreshed — the editor's Save is authoritative by design.
     ///
     /// Runtime-only settings (log level, routing mode, Allow LAN, the local
     /// proxy port) and the engine-mode DNS invariants are layered on top by
@@ -963,6 +979,39 @@ final class ConfigManager {
         } catch {
             return false
         }
+    }
+
+    /// Detach the subscription from `config.yaml` — the inverse of
+    /// `applySubscriptionConfig`. Keeps the header (ports, `dns:` as the user
+    /// last saved it), puts the built-in default proxies / proxy-groups /
+    /// rules back, and drops any providers. Returns the YAML that was saved.
+    /// See `loadBaseConfig` for when this must run.
+    @discardableResult
+    func clearSubscriptionConfig() throws -> String {
+        let base = (try? loadConfig()) ?? defaultConfig()
+        let cleared = Self.clearingSubscription(
+            from: base, defaultConfig: defaultConfig(),
+            engineMode: EngineMode.load(from: AppConstants.sharedDefaults)
+        )
+        try saveConfig(cleared)
+        return cleared
+    }
+
+    /// Pure half of `clearSubscriptionConfig`: merges the defaults' own
+    /// proxies / proxy-groups / rules over `baseConfig` exactly as a
+    /// subscription would be, so the header (a user-edited `dns:` included)
+    /// survives and every subscription-owned section — providers included —
+    /// is gone. The default `dns:` is deliberately not part of the stub, so
+    /// unlike a real subscription it never replaces the user's DNS.
+    static func clearingSubscription(
+        from baseConfig: String, defaultConfig: String, engineMode: EngineMode = .vpn
+    ) -> String {
+        let keys = ["proxies", "proxy-groups", "rules"]
+        let stock = extractYAMLSections(from: defaultConfig, named: keys)
+        let stub = keys.compactMap { stock[$0] }.joined(separator: "\n\n")
+        return mergeSubscription(
+            stub, baseConfig: baseConfig, defaultConfig: defaultConfig, engineMode: engineMode
+        )
     }
 
     /// Off-main wrapper for `validateSubscriptionConfig`. SwiftUI views are

--- a/Shared/ConfigManager.swift
+++ b/Shared/ConfigManager.swift
@@ -32,8 +32,20 @@ final class ConfigManager {
         return containerPath.appendingPathComponent("BaoLianDeng/mihomo", isDirectory: true)
     }
 
+    /// The user's editable base configuration — the single authoritative
+    /// input to BOTH engine start paths (VPN provider and in-process local
+    /// proxy). See `loadBaseConfig` for how it composes with subscriptions.
     var configFileURL: URL? {
         configDirectoryURL?.appendingPathComponent(AppConstants.configFileName)
+    }
+
+    /// Directory the in-process engine (local proxy mode) runs from. It holds
+    /// the derived runtime YAML (`config.yaml` = base + user settings) plus
+    /// links to the shared geodata files. The engine only ever loads
+    /// `<home>/config.yaml`, so giving it its own home is what keeps startup
+    /// from overwriting `configFileURL` with a derived artifact.
+    var runtimeDirectoryURL: URL? {
+        configDirectoryURL?.appendingPathComponent("runtime", isDirectory: true)
     }
 
     func ensureConfigDirectory() throws {
@@ -193,6 +205,132 @@ final class ConfigManager {
     func configExists() -> Bool {
         guard let fileURL = configFileURL else { return false }
         return fileManager.fileExists(atPath: fileURL.path)
+    }
+
+    // MARK: - Base config (what the engine actually starts from)
+
+    /// How the saved local config and the selected subscription compose:
+    ///
+    /// `config.yaml` (`configFileURL`) is the one authoritative, editable
+    /// base. The selected subscription is merged INTO it — header (ports,
+    /// `dns:`) kept from the file, proxies / proxy-groups / providers /
+    /// rules taken from the subscription — by `applySubscriptionConfig`,
+    /// which runs when a subscription is selected or (re)fetched. Between
+    /// those events the file is the user's: whatever the Config Editor
+    /// saved (custom proxies, rules, DNS nameservers, …) is exactly what
+    /// the next tunnel start or reload runs, with or without a selected
+    /// subscription. Startup therefore never re-merges the subscription;
+    /// doing so would replace the user's edits with the stored
+    /// `rawContent` (and, with no subscription, with the built-in
+    /// defaults). Refreshing a subscription still overwrites the merged
+    /// sections — that is the documented cost of the "merged into" model.
+    ///
+    /// Runtime-only settings (log level, routing mode, Allow LAN, the local
+    /// proxy port) and the engine-mode DNS invariants are layered on top by
+    /// `buildEffectiveConfig` at start time and are never written back here.
+    func loadBaseConfig() -> String {
+        try? ensureBaseConfig()
+        return (try? loadConfig()) ?? defaultConfig()
+    }
+
+    /// Create `config.yaml` when it does not exist yet. A fresh container
+    /// with a subscription already selected gets that subscription merged
+    /// onto the defaults, so the first start does not silently run on
+    /// built-in rules while the UI shows a selected subscription; otherwise
+    /// the built-in defaults are written. An existing file is left alone.
+    func ensureBaseConfig() throws {
+        if configExists() { return }
+        if applySelectedSubscription() { return }
+        try saveConfig(defaultConfig())
+    }
+
+    /// Layer runtime settings on top of the user's base config to produce
+    /// the YAML the engine starts from. Pure — the result is handed to the
+    /// provider (`providerConfiguration`) or written to the runtime
+    /// directory, never back to `configFileURL`.
+    ///
+    /// `sanitizeConfigString` re-runs here because the file was sanitized
+    /// for whichever engine mode was active when it was saved; the DNS
+    /// `enhanced-mode` / `fake-ip-range` invariants depend on the mode the
+    /// engine is about to start in. `ensureProxyGroupFallback` keeps a base
+    /// whose rules still target `PROXY` startable after the user removed or
+    /// renamed that group in the editor.
+    static func buildEffectiveConfig(
+        base: String, engineMode: EngineMode, settings: EngineRuntimeSettings
+    ) -> String {
+        var yaml = base
+        sanitizeConfigString(&yaml, engineMode: engineMode)
+        ensureProxyGroupFallback(&yaml)
+
+        if let logLevel = settings.logLevel {
+            yaml = replacingTopLevelScalar(in: yaml, key: "log-level", value: logLevel)
+        }
+        yaml = replacingTopLevelScalar(in: yaml, key: "mode", value: settings.proxyMode)
+        // The engine creates GLOBAL from the final MATCH target, preserving
+        // any explicitly declared GLOBAL and following per-group selections.
+
+        // Clash-compatible allow-lan: engine reads these from YAML (no FFI arg).
+        // When enabled, mixed-port is the LAN-facing listener; in local-proxy
+        // mode it usually equals the user-facing mixed port and merges into
+        // one 0.0.0.0 bind. DNS + external-controller stay loopback either way.
+        let lan = settings.lanSharing
+        yaml = replacingTopLevelScalar(
+            in: yaml, key: "allow-lan", value: lan.enabled ? "true" : "false"
+        )
+        if lan.enabled {
+            yaml = replacingTopLevelScalar(in: yaml, key: "bind-address", value: "0.0.0.0")
+            yaml = replacingTopLevelScalar(
+                in: yaml, key: "mixed-port", value: String(lan.effectiveProxyPort)
+            )
+        } else if engineMode == .localProxy {
+            // Document the local mixed port even without LAN; the bridge still
+            // forces the actual bind from the socks_port argument.
+            yaml = replacingTopLevelScalar(
+                in: yaml, key: "mixed-port", value: String(settings.localProxyPort)
+            )
+        }
+        return yaml
+    }
+
+    /// Prepare `runtimeDirectoryURL` for an in-process engine start: write
+    /// the derived `runtimeYAML` as its `config.yaml` and link the shared
+    /// geodata files in beside it. The user's `configFileURL` is not touched.
+    /// Returns the runtime directory to pass to `BridgeSetHomeDir`.
+    func prepareRuntimeDirectory(runtimeYAML: String) throws -> URL {
+        guard let configDir = configDirectoryURL, let runtimeDir = runtimeDirectoryURL else {
+            throw ConfigError.sharedContainerUnavailable
+        }
+        try ensureConfigDirectory()
+        ensureGeodataFiles(configDir: configDir.path)
+        try Self.prepareRuntimeDirectory(
+            at: runtimeDir, geodataDir: configDir, runtimeYAML: runtimeYAML
+        )
+        return runtimeDir
+    }
+
+    /// Filesystem half of `prepareRuntimeDirectory(runtimeYAML:)`, split out
+    /// so tests can point it at temporary directories. Geodata is hard-linked
+    /// (falling back to a copy) and re-linked on every start so a
+    /// re-downloaded database in `geodataDir` is picked up.
+    static func prepareRuntimeDirectory(at runtimeDir: URL, geodataDir: URL, runtimeYAML: String) throws {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: runtimeDir, withIntermediateDirectories: true)
+        let runtimeConfig = runtimeDir.appendingPathComponent(AppConstants.configFileName)
+        try runtimeYAML.write(to: runtimeConfig, atomically: true, encoding: .utf8)
+        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: runtimeConfig.path)
+
+        for file in geodataFiles {
+            let name = "\(file.name).\(file.ext)"
+            let src = geodataDir.appendingPathComponent(name)
+            let dst = runtimeDir.appendingPathComponent(name)
+            guard fileManager.fileExists(atPath: src.path) else { continue }
+            try? fileManager.removeItem(at: dst)
+            do {
+                try fileManager.linkItem(at: src, to: dst)
+            } catch {
+                try fileManager.copyItem(at: src, to: dst)
+            }
+        }
     }
 
     /// Save the desired mode to UserDefaults. The tunnel reads this on startup.
@@ -868,8 +1006,12 @@ final class ConfigManager {
         return err?.localizedDescription
     }
 
-    /// Merge subscription YAML: take proxies, proxy-groups, rules, and their providers from subscription.
-    private func mergeSubscription(_ yaml: String) -> String {
+    /// Merge subscription YAML into the saved base without writing anything:
+    /// take proxies, proxy-groups, rules, and their providers from the
+    /// subscription, the header from `config.yaml`. `applySubscriptionConfig`
+    /// is this plus `saveConfig`; the Config Editor uses the unsaved form to
+    /// render the read-only subscription view.
+    func mergeSubscription(_ yaml: String) -> String {
         let base = (try? loadConfig()) ?? defaultConfig()
         return ConfigManager.mergeSubscription(
             yaml, baseConfig: base, defaultConfig: defaultConfig(),
@@ -1189,7 +1331,7 @@ final class ConfigManager {
         // mixed-port / dns.listen / external-controller values below are
         // placeholders only — the bridge forces SOCKS/DNS/API ports at
         // runtime. allow-lan / bind-address / mixed-port are rewritten by
-        // VPNManager.buildEffectiveConfigYAML from LANSharingSettings.
+        // ConfigManager.buildEffectiveConfig from LANSharingSettings.
         return """
         mixed-port: 0
         mode: rule
@@ -1278,6 +1420,27 @@ final class ConfigManager {
           # Catch-all
           - MATCH,PROXY
         """
+    }
+}
+
+// MARK: - Engine runtime settings
+
+/// Per-start settings layered onto the saved base config by
+/// `ConfigManager.buildEffectiveConfig`. Read from UserDefaults at start
+/// time; never written into `config.yaml`.
+struct EngineRuntimeSettings {
+    var logLevel: String?
+    var proxyMode: String = "rule"
+    var lanSharing: LANSharingSettings = LANSharingSettings()
+    var localProxyPort: UInt16 = UInt16(AppConstants.defaultLocalProxyPort)
+
+    static func load(from defaults: UserDefaults = AppConstants.sharedDefaults) -> EngineRuntimeSettings {
+        EngineRuntimeSettings(
+            logLevel: defaults.string(forKey: "logLevel"),
+            proxyMode: defaults.string(forKey: "proxyMode") ?? "rule",
+            lanSharing: LANSharingSettings.load(from: defaults),
+            localProxyPort: AppConstants.localProxyPort
+        )
     }
 }
 

--- a/Shared/LANSharingSettings.swift
+++ b/Shared/LANSharingSettings.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Clash-compatible `allow-lan: true`, `bind-address: 0.0.0.0`, and
 /// `mixed-port: <proxyPort>` so other devices on the local network can use
 /// this Mac as their SOCKS5/HTTP proxy. Stored as JSON in shared UserDefaults;
-/// applied in `VPNManager.buildEffectiveConfigYAML` (no separate FFI path).
+/// applied in `ConfigManager.buildEffectiveConfig` (no separate FFI path).
 struct LANSharingSettings: Codable, Equatable {
     static let defaultProxyPort = 7890
 

--- a/Shared/LocalProxyController.swift
+++ b/Shared/LocalProxyController.swift
@@ -42,7 +42,12 @@ final class LocalProxyController {
         }
     }
 
-    /// Write `configYAML` to the config directory and start the engine.
+    /// Write `configYAML` (the derived effective config) to the engine's
+    /// runtime directory and start the engine from there. The user's saved
+    /// `config.yaml` is never written on this path — it is the editable
+    /// base that `configYAML` was derived from, so overwriting it would turn
+    /// runtime-only settings into "saved" edits and, worse, replace whatever
+    /// the user saved with whatever this start happened to compute.
     /// Blocking (engine startup + geodata check) — call off the main thread.
     func start(configYAML: String) throws {
         guard !isRunning else { return }
@@ -50,15 +55,9 @@ final class LocalProxyController {
         guard let configDirURL = ConfigManager.shared.configDirectoryURL else {
             throw LocalProxyError.configDirectoryUnavailable
         }
-        let configDir = configDirURL.path
-        try FileManager.default.createDirectory(
-            atPath: configDir, withIntermediateDirectories: true
-        )
-        try configYAML.write(
-            toFile: configDir + "/" + AppConstants.configFileName,
-            atomically: true, encoding: .utf8
-        )
-        ConfigManager.shared.sanitizeConfig()
+        // `configYAML` comes already sanitized for this engine mode from
+        // `ConfigManager.buildEffectiveConfig`; nothing on disk needs patching.
+        let runtimeDir = try ConfigManager.shared.prepareRuntimeDirectory(runtimeYAML: configYAML)
 
         let defaults = AppConstants.sharedDefaults
         let port = AppConstants.localProxyPort
@@ -74,8 +73,10 @@ final class LocalProxyController {
 
         let logDir = configDirURL.deletingLastPathComponent()
         BridgeSetLogFile(logDir.appendingPathComponent("rust_bridge.log").path)
-        ConfigManager.shared.ensureGeodataFiles(configDir: configDir)
-        BridgeSetHomeDir(configDir)
+        // The engine loads `<home>/config.yaml` and pins geodata paths to
+        // `<home>`; both live in the runtime dir (geodata is linked in from
+        // the config dir by `prepareRuntimeDirectory`).
+        BridgeSetHomeDir(runtimeDir.path)
 
         let controllerAddr = "127.0.0.1:\(ctrlPort)"
         let secret = AppConstants.generateControllerSecret() ?? ""

--- a/Shared/VPNManager.swift
+++ b/Shared/VPNManager.swift
@@ -435,16 +435,13 @@ final class VPNManager: NSObject, ObservableObject {
             }
         }
 
-        // Ensure config exists before starting
-        if !ConfigManager.shared.configExists() {
-            do {
-                let defaultConfig = ConfigManager.shared.defaultConfig()
-                try ConfigManager.shared.saveConfig(defaultConfig)
-            } catch {
-                isProcessing = false
-                errorMessage = "Failed to create default config: \(error.localizedDescription)"
-                return
-            }
+        // Ensure the editable base config exists before starting
+        do {
+            try ConfigManager.shared.ensureBaseConfig()
+        } catch {
+            isProcessing = false
+            errorMessage = "Failed to create default config: \(error.localizedDescription)"
+            return
         }
 
         // Pass subscription URL and settings to the extension via providerConfiguration
@@ -478,16 +475,13 @@ final class VPNManager: NSObject, ObservableObject {
         isProcessing = true
         errorMessage = nil
 
-        // Ensure config exists before starting (same as the tunnel path)
-        if !ConfigManager.shared.configExists() {
-            do {
-                let defaultConfig = ConfigManager.shared.defaultConfig()
-                try ConfigManager.shared.saveConfig(defaultConfig)
-            } catch {
-                isProcessing = false
-                errorMessage = "Failed to create default config: \(error.localizedDescription)"
-                return
-            }
+        // Ensure the editable base config exists before starting (same as the tunnel path)
+        do {
+            try ConfigManager.shared.ensureBaseConfig()
+        } catch {
+            isProcessing = false
+            errorMessage = "Failed to create default config: \(error.localizedDescription)"
+            return
         }
 
         let yaml = buildEffectiveConfigYAML()
@@ -674,78 +668,33 @@ final class VPNManager: NSObject, ObservableObject {
         }.resume()
     }
 
-    /// Build the full effective YAML config: base + selected subscription +
-    /// user settings (log level and routing mode).
+    /// Build the full effective YAML config the engine starts from: the
+    /// user's saved `config.yaml` (into which the selected subscription was
+    /// merged when it was selected — see `ConfigManager.loadBaseConfig`)
+    /// plus runtime settings (log level, routing mode, Allow LAN).
     /// Shared by the tunnel path (compressed into providerConfiguration) and
-    /// the local proxy path (written straight to disk).
+    /// the local proxy path (written to the engine's runtime directory).
+    ///
+    /// The subscription is deliberately NOT re-merged here: the saved file
+    /// already contains it, and re-merging from the stored `rawContent`
+    /// would discard every edit the Config Editor saved on top of it.
+    ///
+    /// No group rewriting here either. The engine starts each Selector group
+    /// on the config's own first member and `replaySavedGroupSelections()`
+    /// pushes the user's per-group choices once the controller is up. The
+    /// old `applySelectedNode()` rewrite was both wrong (one global node
+    /// forced into every group) and lossy: it round-tripped proxy-groups
+    /// through the editable parser, which drops `use:`, `filter:`, `lazy:`
+    /// and friends, emptying provider-backed groups.
     private func buildEffectiveConfigYAML() -> String {
-        let defaults = AppConstants.sharedDefaults
-
-        // Start with the base config
-        var yaml = ConfigManager.shared.defaultConfig()
-
-        // Merge selected subscription if available
-        if let idString = defaults.string(forKey: "selectedSubscriptionID"),
-           let data = defaults.data(forKey: "subscriptions") {
-            struct Sub: Decodable { var id: UUID; var rawContent: String? }
-            if let subs = try? JSONDecoder().decode([Sub].self, from: data),
-               let selectedID = UUID(uuidString: idString),
-               let selected = subs.first(where: { $0.id == selectedID }),
-               let raw = selected.rawContent {
-                yaml = ConfigManager.mergeSubscription(
-                    raw, baseConfig: yaml, defaultConfig: yaml, engineMode: engineMode
-                )
-            }
-        }
-
-        // No group rewriting here. The engine starts each Selector group on
-        // the config's own first member and `replaySavedGroupSelections()`
-        // pushes the user's per-group choices once the controller is up. The
-        // old `applySelectedNode()` rewrite was both wrong (one global node
-        // forced into every group) and lossy: it round-tripped proxy-groups
-        // through the editable parser, which drops `use:`, `filter:`, `lazy:`
-        // and friends, emptying provider-backed groups.
-
-        // Apply user settings
-        if let logLevel = defaults.string(forKey: "logLevel") {
-            yaml = ConfigManager.replacingTopLevelScalar(
-                in: yaml, key: "log-level", value: logLevel
-            )
-        }
-        let mode = defaults.string(forKey: "proxyMode") ?? "rule"
-        yaml = ConfigManager.replacingTopLevelScalar(
-            in: yaml, key: "mode", value: mode
+        ConfigManager.buildEffectiveConfig(
+            base: ConfigManager.shared.loadBaseConfig(),
+            engineMode: engineMode,
+            settings: EngineRuntimeSettings.load(from: AppConstants.sharedDefaults)
         )
-        // The engine creates GLOBAL from the final MATCH target, preserving
-        // any explicitly declared GLOBAL and following per-group selections.
-
-        // Clash-compatible allow-lan: engine reads these from YAML (no FFI arg).
-        // When enabled, mixed-port is the LAN-facing listener; in local-proxy
-        // mode it usually equals the user-facing mixed port and merges into
-        // one 0.0.0.0 bind. DNS + external-controller stay loopback either way.
-        let lan = LANSharingSettings.load(from: defaults)
-        yaml = ConfigManager.replacingTopLevelScalar(
-            in: yaml, key: "allow-lan", value: lan.enabled ? "true" : "false"
-        )
-        if lan.enabled {
-            yaml = ConfigManager.replacingTopLevelScalar(
-                in: yaml, key: "bind-address", value: "0.0.0.0"
-            )
-            yaml = ConfigManager.replacingTopLevelScalar(
-                in: yaml, key: "mixed-port", value: String(lan.effectiveProxyPort)
-            )
-        } else if engineMode == .localProxy {
-            // Document the local mixed port even without LAN; the bridge still
-            // forces the actual bind from the socks_port argument.
-            yaml = ConfigManager.replacingTopLevelScalar(
-                in: yaml, key: "mixed-port", value: String(AppConstants.localProxyPort)
-            )
-        }
-
-        return yaml
     }
 
-    /// Build the full YAML config (base + subscription + user settings),
+    /// Build the full YAML config (saved base + user settings),
     /// zlib-compress it, and pass via providerConfiguration to overcome the 512 KB IPC limit.
     private func passSettingsToProvider() {
         guard let proto = manager?.protocolConfiguration as? NETunnelProviderProtocol else { return }

--- a/TransparentProxy/SOCKS5Client.swift
+++ b/TransparentProxy/SOCKS5Client.swift
@@ -97,10 +97,16 @@ enum SOCKS5Client {
         }
     }
 
-    static func readSome(connection: NWConnection) async throws -> Data {
-        let gate = OnceResume<Result<Data, Error>>()
+    /// One chunk from the connection. `isComplete` is set when the peer's
+    /// FIN arrived — possibly together with the last bytes (`data` non-empty
+    /// **and** `isComplete`), or on its own (`data` empty, `isComplete`).
+    /// Network.framework reports the FIN exactly once; a `receive` issued
+    /// after that fails with `ENODATA` instead of repeating `isComplete`, so
+    /// callers must not discard the flag when data accompanies it.
+    static func readSome(connection: NWConnection) async throws -> (data: Data, isComplete: Bool) {
+        let gate = OnceResume<Result<(data: Data, isComplete: Bool), Error>>()
         return try await withTaskCancellationHandler {
-            let result = await withCheckedContinuation { (cont: CheckedContinuation<Result<Data, Error>, Never>) in
+            let result = await withCheckedContinuation { (cont: CheckedContinuation<Result<(data: Data, isComplete: Bool), Error>, Never>) in
                 gate.arm(cont)
                 readSomeLoop(connection: connection, gate: gate)
             }
@@ -113,13 +119,12 @@ enum SOCKS5Client {
 
     /// Callback body for `readSome`, split out so the "no data yet" case can
     /// re-arm the receive instead of resolving the continuation (#75). Only
-    /// `isComplete` (remote closed) or an error end the stream; callers such
-    /// as `relayTCP` treat an empty `Data()` result as "connection closed,"
-    /// so returning empty for a healthy connection with nothing to deliver
-    /// yet would end the relay prematurely.
+    /// `isComplete` (remote closed) or an error end the stream; returning an
+    /// empty, not-complete chunk for a healthy connection with nothing to
+    /// deliver yet would make the relay see a false end-of-stream.
     private static func readSomeLoop(
         connection: NWConnection,
-        gate: OnceResume<Result<Data, Error>>
+        gate: OnceResume<Result<(data: Data, isComplete: Bool), Error>>
     ) {
         connection.receive(
             minimumIncompleteLength: 1,
@@ -128,10 +133,10 @@ enum SOCKS5Client {
             if let error = error {
                 gate.resume(.failure(error))
             } else if let data = data, !data.isEmpty {
-                gate.resume(.success(data))
+                gate.resume(.success((data, isComplete)))
             } else if isComplete {
                 // Genuine remote close / end-of-stream.
-                gate.resume(.success(Data()))
+                gate.resume(.success((Data(), true)))
             } else {
                 // No data, no error, not complete. `receive` with
                 // minimumIncompleteLength: 1 shouldn't invoke the callback in

--- a/TransparentProxy/TCPRelay.swift
+++ b/TransparentProxy/TCPRelay.swift
@@ -221,17 +221,12 @@ final class NWConnectionRelayEndpoint: TCPRelayEndpoint, @unchecked Sendable {
     }
 
     func read() async throws -> TCPRelayRead {
-        lock.lock()
-        let eofAlreadySeen = pendingEOF
-        lock.unlock()
-        if eofAlreadySeen { return .eof }
+        if lock.withLock({ pendingEOF }) { return .eof }
 
         let chunk = try await SOCKS5Client.readSome(connection: connection)
         if chunk.data.isEmpty { return .eof }
         if chunk.isComplete {
-            lock.lock()
-            pendingEOF = true
-            lock.unlock()
+            lock.withLock { pendingEOF = true }
         }
         return .data(chunk.data)
     }

--- a/TransparentProxy/TCPRelay.swift
+++ b/TransparentProxy/TCPRelay.swift
@@ -1,0 +1,259 @@
+// Copyright (c) 2026 Max Lv <max.c.lv@gmail.com>
+//
+// Licensed under the MIT License. See the LICENSE file for details.
+
+import Foundation
+@preconcurrency import Network
+@preconcurrency import NetworkExtension
+
+// MARK: - Endpoint abstraction
+
+/// What one relay direction read from its source.
+enum TCPRelayRead: Sendable, Equatable {
+    case data(Data)
+    /// The peer closed its write side (orderly half-close). The stream in the
+    /// other direction may still carry data.
+    case eof
+}
+
+/// One side of a TCP relay — the app-side `NEAppProxyTCPFlow` or the
+/// proxy-side `NWConnection` in production, in-memory fakes in tests.
+///
+/// `read` returns `.eof` only for an orderly end of stream; errors and task
+/// cancellation are thrown so `TCPRelay` can tell "the peer is done sending"
+/// apart from "this direction is broken".
+protocol TCPRelayEndpoint: Sendable {
+    func read() async throws -> TCPRelayRead
+    func write(_ data: Data) async throws
+    /// Propagate the opposite peer's half-close: send a FIN / close the
+    /// write side while leaving the read side open.
+    func finishWriting() async throws
+}
+
+// MARK: - Outcome
+
+enum TCPRelayOutcome: Sendable, Equatable {
+    /// Both directions reached EOF and each was propagated to the other side.
+    case completed
+    /// A direction failed (I/O error or cancellation); the relay stopped and
+    /// the caller must tear both endpoints down.
+    case failed
+    /// After one direction half-closed, the remaining one carried no data for
+    /// `halfCloseIdleTimeout`. Guards against a peer that never closes.
+    case halfCloseTimedOut
+}
+
+// MARK: - Relay
+
+/// Bidirectional TCP relay with proper half-close semantics.
+///
+/// EOF from one side finishes only that direction: the FIN is forwarded to
+/// the other endpoint (`finishWriting`) and the opposite direction keeps
+/// running until it hits EOF too. A client that does `shutdown(SHUT_WR)`
+/// after its request therefore still receives the response, and a server
+/// that closes its write side first still receives the rest of the upload.
+///
+/// Errors and cancellation stop the relay immediately. The caller owns
+/// endpoint teardown — closing/cancelling both endpoints after `run`
+/// returns force-resumes any callback that never fires (see
+/// `SOCKS5Client.withCancellableResult`), so the pre-existing leak guard for
+/// abandoned NE / Network.framework callbacks still applies.
+enum TCPRelay {
+    /// Default idle bound for the direction left open after a half-close.
+    /// Long enough for a slow server to answer a half-closed request, short
+    /// enough that a peer which never closes cannot pin a flow for the life
+    /// of the extension.
+    static let defaultHalfCloseIdleTimeout: TimeInterval = 120
+
+    private enum DirectionOutcome: Sendable {
+        case finished
+        case failed
+        case timedOut
+    }
+
+    static func run(
+        app: some TCPRelayEndpoint,
+        proxy: some TCPRelayEndpoint,
+        halfCloseIdleTimeout: TimeInterval = defaultHalfCloseIdleTimeout
+    ) async -> TCPRelayOutcome {
+        let activity = ActivityClock()
+        return await withTaskGroup(of: DirectionOutcome.self) { group in
+            group.addTask { await pump(from: app, to: proxy, activity: activity) }
+            group.addTask { await pump(from: proxy, to: app, activity: activity) }
+
+            guard let first = await group.next(), first == .finished else {
+                group.cancelAll()
+                await group.waitForAll()
+                return .failed
+            }
+
+            // Half-closed: let the sibling finish, but bound its idle time.
+            group.addTask {
+                await idleWatchdog(activity: activity, timeout: halfCloseIdleTimeout)
+            }
+            let second = await group.next()
+            group.cancelAll()
+            await group.waitForAll()
+
+            switch second {
+            case .finished: return .completed
+            case .timedOut: return .halfCloseTimedOut
+            case .failed, .none: return .failed
+            }
+        }
+    }
+
+    private static func pump(
+        from source: some TCPRelayEndpoint,
+        to sink: some TCPRelayEndpoint,
+        activity: ActivityClock
+    ) async -> DirectionOutcome {
+        while !Task.isCancelled {
+            do {
+                switch try await source.read() {
+                case .data(let data):
+                    activity.touch()
+                    try await sink.write(data)
+                case .eof:
+                    activity.touch()
+                    try await sink.finishWriting()
+                    return .finished
+                }
+            } catch {
+                return .failed
+            }
+        }
+        return .failed
+    }
+
+    private static func idleWatchdog(
+        activity: ActivityClock, timeout: TimeInterval
+    ) async -> DirectionOutcome {
+        while !Task.isCancelled {
+            let remaining = timeout - activity.idleInterval
+            if remaining <= 0 { return .timedOut }
+            do {
+                try await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+            } catch {
+                return .failed
+            }
+        }
+        return .failed
+    }
+}
+
+/// Last-activity timestamp shared by the two pump tasks and the watchdog.
+private final class ActivityClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var last = Date()
+
+    func touch() {
+        lock.lock()
+        last = Date()
+        lock.unlock()
+    }
+
+    var idleInterval: TimeInterval {
+        lock.lock()
+        defer { lock.unlock() }
+        return Date().timeIntervalSince(last)
+    }
+}
+
+// MARK: - Production endpoints
+
+/// App side of the relay: `NEAppProxyTCPFlow`.
+///
+/// `readData`/`write` belong to the same flow family as `NEAppProxyFlow.open`:
+/// the completion can fire more than once during teardown races, or never at
+/// all after `closeRead`/`closeWrite`. `SOCKS5Client.withCancellableResult`
+/// resumes exactly once and force-resumes on task cancellation, so a waiter
+/// cannot pin the flow forever (this is how finished relays once leaked ~11k
+/// flows).
+struct FlowRelayEndpoint: TCPRelayEndpoint {
+    let flow: NEAppProxyTCPFlow
+
+    func read() async throws -> TCPRelayRead {
+        try await SOCKS5Client.withCancellableResult(TCPRelayRead.self) { resume in
+            flow.readData { data, error in
+                if let error = error {
+                    resume(.failure(error))
+                } else if let data = data, !data.isEmpty {
+                    resume(.success(.data(data)))
+                } else {
+                    // Empty data with no error: the app closed its write side.
+                    resume(.success(.eof))
+                }
+            }
+        }
+    }
+
+    func write(_ data: Data) async throws {
+        try await SOCKS5Client.withCancellableResult(Void.self) { resume in
+            flow.write(data) { error in
+                if let error = error {
+                    resume(.failure(error))
+                } else {
+                    resume(.success(()))
+                }
+            }
+        }
+    }
+
+    /// Half-close towards the app; the app can keep sending.
+    func finishWriting() async throws {
+        flow.closeWriteWithError(nil)
+    }
+}
+
+/// Proxy side of the relay: the SOCKS5 `NWConnection` to mihomo.
+///
+/// A class rather than a struct because Network.framework reports the peer's
+/// FIN only once, possibly on the same callback as the final bytes; that
+/// trailing EOF is remembered here and handed out on the next `read`.
+final class NWConnectionRelayEndpoint: TCPRelayEndpoint, @unchecked Sendable {
+    let connection: NWConnection
+    private let lock = NSLock()
+    private var pendingEOF = false
+
+    init(connection: NWConnection) {
+        self.connection = connection
+    }
+
+    func read() async throws -> TCPRelayRead {
+        lock.lock()
+        let eofAlreadySeen = pendingEOF
+        lock.unlock()
+        if eofAlreadySeen { return .eof }
+
+        let chunk = try await SOCKS5Client.readSome(connection: connection)
+        if chunk.data.isEmpty { return .eof }
+        if chunk.isComplete {
+            lock.lock()
+            pendingEOF = true
+            lock.unlock()
+        }
+        return .data(chunk.data)
+    }
+
+    func write(_ data: Data) async throws {
+        try await SOCKS5Client.sendAll(connection: connection, data: data)
+    }
+
+    /// TCP half-close (FIN) on the SOCKS5 connection; receives keep working.
+    func finishWriting() async throws {
+        try await SOCKS5Client.withCancellableResult(Void.self) { resume in
+            connection.send(
+                content: nil,
+                contentContext: .finalMessage,
+                isComplete: true,
+                completion: .contentProcessed { error in
+                    if let error = error {
+                        resume(.failure(error))
+                    } else {
+                        resume(.success(()))
+                    }
+                })
+        }
+    }
+}

--- a/TransparentProxy/TransparentProxyProvider.swift
+++ b/TransparentProxy/TransparentProxyProvider.swift
@@ -487,64 +487,34 @@ class TransparentProxyProvider: NETransparentProxyProvider {
 
     // MARK: - TCP Relay
 
+    /// Relay flow <-> SOCKS5 with half-close semantics (see `TCPRelay`): EOF
+    /// from the app forwards a FIN to mihomo and keeps draining the response;
+    /// EOF from mihomo half-closes the flow's write side and keeps forwarding
+    /// the app's upload. Only errors, cancellation, or the post-half-close
+    /// idle bound stop the relay early.
     private func relayTCP(flow: NEAppProxyTCPFlow, connection: NWConnection) async {
-        await withTaskGroup(of: Void.self) { group in
-            // Flow → SOCKS5
-            group.addTask {
-                while !Task.isCancelled {
-                    let data: Data? = await withCancellableFlowContinuation(onCancel: nil) { resume in
-                        flow.readData { data, error in
-                            if error != nil || data == nil || data!.isEmpty {
-                                resume(nil)
-                            } else {
-                                resume(data)
-                            }
-                        }
-                    }
-                    guard let data else { break }
-                    do {
-                        try await SOCKS5Client.sendAll(connection: connection, data: data)
-                    } catch {
-                        break
-                    }
-                }
-            }
-
-            // SOCKS5 → Flow
-            group.addTask {
-                while !Task.isCancelled {
-                    do {
-                        let data = try await SOCKS5Client.readSome(connection: connection)
-                        guard !data.isEmpty else { break }
-                        let writeOK: Bool = await withCancellableFlowContinuation(onCancel: false) { resume in
-                            flow.write(data) { error in
-                                resume(error == nil)
-                            }
-                        }
-                        if !writeOK { break }
-                    } catch {
-                        break
-                    }
-                }
-            }
-
-            // First direction to finish tears the sibling down.
-            //
-            // `closeRead`/`closeWrite` and `NWConnection.cancel()` do **not**
-            // reliably invoke a pending NE / Network.framework callback. The
-            // previous code waited for both tasks and only "signalled" by
-            // closing; the sibling then sat forever in `readData`/`receive`,
-            // retaining the flow, the SOCKS connection, and three Tasks.
-            // Heap on a 2-day process showed ~11k of each. `cancelAll()`
-            // force-resumes the pending continuation via
-            // `withTaskCancellationHandler`.
-            _ = await group.next()
-            connection.cancel()
-            flow.closeReadWithError(nil)
-            flow.closeWriteWithError(nil)
-            group.cancelAll()
-            await group.waitForAll()
+        let outcome = await TCPRelay.run(
+            app: FlowRelayEndpoint(flow: flow),
+            proxy: NWConnectionRelayEndpoint(connection: connection)
+        )
+        if outcome == .halfCloseTimedOut {
+            log("TCP relay: peer never closed after half-close, idle bound hit")
         }
+
+        // Tear both endpoints down unconditionally.
+        //
+        // `closeRead`/`closeWrite` and `NWConnection.cancel()` do **not**
+        // reliably invoke a pending NE / Network.framework callback. An
+        // earlier version waited for both directions and only "signalled" by
+        // closing; the sibling then sat forever in `readData`/`receive`,
+        // retaining the flow, the SOCKS connection, and three Tasks. Heap on
+        // a 2-day process showed ~11k of each. `TCPRelay.run` cancels its
+        // task group before returning, which force-resumes any pending
+        // continuation via `withTaskCancellationHandler`; the closes below
+        // then release the underlying objects.
+        connection.cancel()
+        flow.closeReadWithError(nil)
+        flow.closeWriteWithError(nil)
     }
 
     // MARK: - IPC
@@ -851,33 +821,6 @@ class TransparentProxyProvider: NETransparentProxyProvider {
 extension Collection {
     subscript(safe index: Index) -> Element? {
         indices.contains(index) ? self[index] : nil
-    }
-}
-
-// MARK: - Flow continuation helper
-
-/// Bridge a flow completion-handler callback to async, resuming exactly once
-/// even if the handler fires more than once during teardown races — or never
-/// fires at all after `closeRead`/`closeWrite`.
-///
-/// `NEAppProxyTCPFlow.readData`/`write` belong to the same flow family as
-/// `NEAppProxyFlow.open` (see `TransparentProxyProvider.openFlow`). The
-/// completion can fire multiple times (a bare `withCheckedContinuation`
-/// would trap "SWIFT TASK CONTINUATION MISUSE") **or never**, which is how
-/// finished TCP relays leaked ~11k flows. Task cancellation delivers
-/// `onCancel` so the waiter cannot pin the flow forever.
-private func withCancellableFlowContinuation<T: Sendable>(
-    onCancel: T,
-    _ body: (@escaping @Sendable (T) -> Void) -> Void
-) async -> T {
-    let gate = OnceResume<T>()
-    return await withTaskCancellationHandler {
-        await withCheckedContinuation { (cont: CheckedContinuation<T, Never>) in
-            gate.arm(cont)
-            body { gate.resume($0) }
-        }
-    } onCancel: {
-        gate.resume(onCancel)
     }
 }
 

--- a/TransparentProxy/TransparentProxyProvider.swift
+++ b/TransparentProxy/TransparentProxyProvider.swift
@@ -797,9 +797,15 @@ class TransparentProxyProvider: NETransparentProxyProvider {
     private func trimLogFile() {
         logQueue.sync {
             trimLog(at: logURL)
-            let rustLogURL = logURL.deletingLastPathComponent()
-                .appendingPathComponent("rust_bridge.log")
-            trimLog(at: rustLogURL)
+            // rust_bridge.log is owned by the engine's log sink, which keeps
+            // an open append handle. Rewriting it here (atomic replace) would
+            // leave that handle on the unlinked old inode — new engine lines
+            // would vanish from the viewer while the orphan kept growing — so
+            // the engine trims and reopens it under its own writer lock.
+            var trimError: NSError?
+            if !BridgeTrimLogFile(Int32(Self.maxLogLines), &trimError) {
+                log("WARN: rust_bridge.log trim failed: \(trimError?.localizedDescription ?? "unknown")")
+            }
         }
     }
 

--- a/scripts/build-appstore-pkg.sh
+++ b/scripts/build-appstore-pkg.sh
@@ -20,6 +20,10 @@
 #   SKIP_BUMP=1      — don't bump the Release build number
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/deploy-lib.sh
+source "${SCRIPT_DIR}/lib/deploy-lib.sh"
+
 PROJECT_DIR="/Volumes/DATA/workspace/BaoLianDeng"
 APP_NAME="BaoLianDeng"
 SCHEME="BaoLianDeng"
@@ -60,7 +64,9 @@ echo "=== Step 1: Build framework ==="
 make framework
 
 echo "=== Step 2: Archive (App Store signing) ==="
-xcodebuild archive \
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-archive.XXXXXX.log")"
+ARCHIVE_STATUS=0
+xcodebuild_logged "$BUILD_LOG" 3 archive \
   -project ${APP_NAME}.xcodeproj \
   -scheme "$SCHEME" \
   -configuration Release \
@@ -71,8 +77,12 @@ xcodebuild archive \
   -authenticationKeyID "$ASC_KEY_ID" \
   -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
   DEVELOPMENT_TEAM="$TEAM_ID" \
-  NE_PROVIDER_SUFFIX="" \
-  | tail -3
+  NE_PROVIDER_SUFFIX="" || ARCHIVE_STATUS=$?
+rm -f "$BUILD_LOG"
+if [ "$ARCHIVE_STATUS" -ne 0 ]; then
+  echo "ERROR: xcodebuild archive failed (exit ${ARCHIVE_STATUS})"
+  exit "$ARCHIVE_STATUS"
+fi
 
 echo "=== Step 2b: Prune system extension (MAS ships the appex) ==="
 # Both provider packagings are embedded during the build. App Store / local
@@ -105,15 +115,21 @@ cat > "$EXPORT_PLIST" <<PLIST
 PLIST
 
 rm -rf "$EXPORT_PATH"
-xcodebuild -exportArchive \
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-export.XXXXXX.log")"
+EXPORT_STATUS=0
+xcodebuild_logged "$BUILD_LOG" 3 -exportArchive \
   -archivePath "$ARCHIVE_PATH" \
   -exportPath "$EXPORT_PATH" \
   -exportOptionsPlist "$EXPORT_PLIST" \
   -allowProvisioningUpdates \
   -authenticationKeyPath "$ASC_KEY_P8_PATH" \
   -authenticationKeyID "$ASC_KEY_ID" \
-  -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
-  | tail -3
+  -authenticationKeyIssuerID "$ASC_ISSUER_ID" || EXPORT_STATUS=$?
+rm -f "$BUILD_LOG"
+if [ "$EXPORT_STATUS" -ne 0 ]; then
+  echo "ERROR: xcodebuild -exportArchive failed (exit ${EXPORT_STATUS})"
+  exit "$EXPORT_STATUS"
+fi
 
 if [ ! -f "$PKG_PATH" ]; then
   echo "ERROR: ${PKG_PATH} not found after export"

--- a/scripts/build-appstore-pkg.sh
+++ b/scripts/build-appstore-pkg.sh
@@ -64,7 +64,7 @@ echo "=== Step 1: Build framework ==="
 make framework
 
 echo "=== Step 2: Archive (App Store signing) ==="
-BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-archive.XXXXXX.log")"
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-archive.XXXXXX")"
 ARCHIVE_STATUS=0
 xcodebuild_logged "$BUILD_LOG" 3 archive \
   -project ${APP_NAME}.xcodeproj \
@@ -115,7 +115,7 @@ cat > "$EXPORT_PLIST" <<PLIST
 PLIST
 
 rm -rf "$EXPORT_PATH"
-BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-export.XXXXXX.log")"
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-export.XXXXXX")"
 EXPORT_STATUS=0
 xcodebuild_logged "$BUILD_LOG" 3 -exportArchive \
   -archivePath "$ARCHIVE_PATH" \

--- a/scripts/build-appstore-pkg.sh
+++ b/scripts/build-appstore-pkg.sh
@@ -78,11 +78,12 @@ xcodebuild_logged "$BUILD_LOG" 3 archive \
   -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
   DEVELOPMENT_TEAM="$TEAM_ID" \
   NE_PROVIDER_SUFFIX="" || ARCHIVE_STATUS=$?
-rm -f "$BUILD_LOG"
 if [ "$ARCHIVE_STATUS" -ne 0 ]; then
   echo "ERROR: xcodebuild archive failed (exit ${ARCHIVE_STATUS})"
+  echo "Full log: $BUILD_LOG"
   exit "$ARCHIVE_STATUS"
 fi
+rm -f "$BUILD_LOG"
 
 echo "=== Step 2b: Prune system extension (MAS ships the appex) ==="
 # Both provider packagings are embedded during the build. App Store / local
@@ -125,11 +126,12 @@ xcodebuild_logged "$BUILD_LOG" 3 -exportArchive \
   -authenticationKeyPath "$ASC_KEY_P8_PATH" \
   -authenticationKeyID "$ASC_KEY_ID" \
   -authenticationKeyIssuerID "$ASC_ISSUER_ID" || EXPORT_STATUS=$?
-rm -f "$BUILD_LOG"
 if [ "$EXPORT_STATUS" -ne 0 ]; then
   echo "ERROR: xcodebuild -exportArchive failed (exit ${EXPORT_STATUS})"
+  echo "Full log: $BUILD_LOG"
   exit "$EXPORT_STATUS"
 fi
+rm -f "$BUILD_LOG"
 
 if [ ! -f "$PKG_PATH" ]; then
   echo "ERROR: ${PKG_PATH} not found after export"

--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -50,7 +50,7 @@ echo "=== Step 1: Build framework ==="
 make framework
 
 echo "=== Step 2: Archive ==="
-BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-archive.XXXXXX.log")"
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-archive.XXXXXX")"
 ARCHIVE_STATUS=0
 xcodebuild_logged "$BUILD_LOG" 3 archive \
   -project ${APP_NAME}.xcodeproj \
@@ -103,7 +103,7 @@ cat > "$EXPORT_PLIST" <<PLIST
 PLIST
 
 rm -rf "$EXPORT_PATH"
-BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-export.XXXXXX.log")"
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-export.XXXXXX")"
 EXPORT_STATUS=0
 xcodebuild_logged "$BUILD_LOG" 3 -exportArchive \
   -archivePath "$ARCHIVE_PATH" \

--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -11,6 +11,10 @@
 #   ASC_ISSUER_ID    — App Store Connect issuer ID
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/deploy-lib.sh
+source "${SCRIPT_DIR}/lib/deploy-lib.sh"
+
 PROJECT_DIR="/Volumes/DATA/workspace/BaoLianDeng"
 APP_NAME="BaoLianDeng"
 SCHEME="BaoLianDeng"
@@ -46,14 +50,20 @@ echo "=== Step 1: Build framework ==="
 make framework
 
 echo "=== Step 2: Archive ==="
-xcodebuild archive \
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-archive.XXXXXX.log")"
+ARCHIVE_STATUS=0
+xcodebuild_logged "$BUILD_LOG" 3 archive \
   -project ${APP_NAME}.xcodeproj \
   -scheme "$SCHEME" \
   -configuration Release \
   -destination 'generic/platform=macOS' \
   -archivePath "$ARCHIVE_PATH" \
-  NE_PROVIDER_SUFFIX="-systemextension" \
-  | tail -3
+  NE_PROVIDER_SUFFIX="-systemextension" || ARCHIVE_STATUS=$?
+rm -f "$BUILD_LOG"
+if [ "$ARCHIVE_STATUS" -ne 0 ]; then
+  echo "ERROR: xcodebuild archive failed (exit ${ARCHIVE_STATUS})"
+  exit "$ARCHIVE_STATUS"
+fi
 
 echo "=== Step 2b: Prune app extension (Developer ID ships the sysext) ==="
 # Both provider packagings are embedded during the build. The default path
@@ -93,11 +103,17 @@ cat > "$EXPORT_PLIST" <<PLIST
 PLIST
 
 rm -rf "$EXPORT_PATH"
-xcodebuild -exportArchive \
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-export.XXXXXX.log")"
+EXPORT_STATUS=0
+xcodebuild_logged "$BUILD_LOG" 3 -exportArchive \
   -archivePath "$ARCHIVE_PATH" \
   -exportPath "$EXPORT_PATH" \
-  -exportOptionsPlist "$EXPORT_PLIST" \
-  | tail -3
+  -exportOptionsPlist "$EXPORT_PLIST" || EXPORT_STATUS=$?
+rm -f "$BUILD_LOG"
+if [ "$EXPORT_STATUS" -ne 0 ]; then
+  echo "ERROR: xcodebuild -exportArchive failed (exit ${EXPORT_STATUS})"
+  exit "$EXPORT_STATUS"
+fi
 
 APP_PATH="${EXPORT_PATH}/${APP_NAME}.app"
 if [ ! -d "$APP_PATH" ]; then

--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -59,11 +59,12 @@ xcodebuild_logged "$BUILD_LOG" 3 archive \
   -destination 'generic/platform=macOS' \
   -archivePath "$ARCHIVE_PATH" \
   NE_PROVIDER_SUFFIX="-systemextension" || ARCHIVE_STATUS=$?
-rm -f "$BUILD_LOG"
 if [ "$ARCHIVE_STATUS" -ne 0 ]; then
   echo "ERROR: xcodebuild archive failed (exit ${ARCHIVE_STATUS})"
+  echo "Full log: $BUILD_LOG"
   exit "$ARCHIVE_STATUS"
 fi
+rm -f "$BUILD_LOG"
 
 echo "=== Step 2b: Prune app extension (Developer ID ships the sysext) ==="
 # Both provider packagings are embedded during the build. The default path
@@ -109,11 +110,12 @@ xcodebuild_logged "$BUILD_LOG" 3 -exportArchive \
   -archivePath "$ARCHIVE_PATH" \
   -exportPath "$EXPORT_PATH" \
   -exportOptionsPlist "$EXPORT_PLIST" || EXPORT_STATUS=$?
-rm -f "$BUILD_LOG"
 if [ "$EXPORT_STATUS" -ne 0 ]; then
   echo "ERROR: xcodebuild -exportArchive failed (exit ${EXPORT_STATUS})"
+  echo "Full log: $BUILD_LOG"
   exit "$EXPORT_STATUS"
 fi
+rm -f "$BUILD_LOG"
 
 APP_PATH="${EXPORT_PATH}/${APP_NAME}.app"
 if [ ! -d "$APP_PATH" ]; then

--- a/scripts/build-release-pkg.sh
+++ b/scripts/build-release-pkg.sh
@@ -56,7 +56,7 @@ echo "=== Step 2: Archive ==="
 # Developer ID distribution requires the -systemextension variant of the
 # Network Extension entitlement (development and App Store profiles only
 # carry the unsuffixed value).
-BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-archive.XXXXXX.log")"
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-archive.XXXXXX")"
 ARCHIVE_STATUS=0
 xcodebuild_logged "$BUILD_LOG" 3 archive \
   -project ${APP_NAME}.xcodeproj \
@@ -109,7 +109,7 @@ cat > "$EXPORT_PLIST" <<PLIST
 PLIST
 
 rm -rf "$EXPORT_PATH"
-BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-export.XXXXXX.log")"
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-export.XXXXXX")"
 EXPORT_STATUS=0
 xcodebuild_logged "$BUILD_LOG" 3 -exportArchive \
   -archivePath "$ARCHIVE_PATH" \

--- a/scripts/build-release-pkg.sh
+++ b/scripts/build-release-pkg.sh
@@ -65,11 +65,12 @@ xcodebuild_logged "$BUILD_LOG" 3 archive \
   -destination 'generic/platform=macOS' \
   -archivePath "$ARCHIVE_PATH" \
   NE_PROVIDER_SUFFIX="-systemextension" || ARCHIVE_STATUS=$?
-rm -f "$BUILD_LOG"
 if [ "$ARCHIVE_STATUS" -ne 0 ]; then
   echo "ERROR: xcodebuild archive failed (exit ${ARCHIVE_STATUS})"
+  echo "Full log: $BUILD_LOG"
   exit "$ARCHIVE_STATUS"
 fi
+rm -f "$BUILD_LOG"
 
 echo "=== Step 2b: Prune app extension (Developer ID ships the sysext) ==="
 # Both provider packagings are embedded during the build. The default path
@@ -115,11 +116,12 @@ xcodebuild_logged "$BUILD_LOG" 3 -exportArchive \
   -archivePath "$ARCHIVE_PATH" \
   -exportPath "$EXPORT_PATH" \
   -exportOptionsPlist "$EXPORT_PLIST" || EXPORT_STATUS=$?
-rm -f "$BUILD_LOG"
 if [ "$EXPORT_STATUS" -ne 0 ]; then
   echo "ERROR: xcodebuild -exportArchive failed (exit ${EXPORT_STATUS})"
+  echo "Full log: $BUILD_LOG"
   exit "$EXPORT_STATUS"
 fi
+rm -f "$BUILD_LOG"
 
 APP_PATH="${EXPORT_PATH}/${APP_NAME}.app"
 if [ ! -d "$APP_PATH" ]; then

--- a/scripts/build-release-pkg.sh
+++ b/scripts/build-release-pkg.sh
@@ -12,6 +12,10 @@
 #   ASC_ISSUER_ID    — App Store Connect issuer ID
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/deploy-lib.sh
+source "${SCRIPT_DIR}/lib/deploy-lib.sh"
+
 PROJECT_DIR="/Volumes/DATA/workspace/BaoLianDeng"
 APP_NAME="BaoLianDeng"
 SCHEME="BaoLianDeng"
@@ -52,14 +56,20 @@ echo "=== Step 2: Archive ==="
 # Developer ID distribution requires the -systemextension variant of the
 # Network Extension entitlement (development and App Store profiles only
 # carry the unsuffixed value).
-xcodebuild archive \
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-archive.XXXXXX.log")"
+ARCHIVE_STATUS=0
+xcodebuild_logged "$BUILD_LOG" 3 archive \
   -project ${APP_NAME}.xcodeproj \
   -scheme "$SCHEME" \
   -configuration Release \
   -destination 'generic/platform=macOS' \
   -archivePath "$ARCHIVE_PATH" \
-  NE_PROVIDER_SUFFIX="-systemextension" \
-  | tail -3
+  NE_PROVIDER_SUFFIX="-systemextension" || ARCHIVE_STATUS=$?
+rm -f "$BUILD_LOG"
+if [ "$ARCHIVE_STATUS" -ne 0 ]; then
+  echo "ERROR: xcodebuild archive failed (exit ${ARCHIVE_STATUS})"
+  exit "$ARCHIVE_STATUS"
+fi
 
 echo "=== Step 2b: Prune app extension (Developer ID ships the sysext) ==="
 # Both provider packagings are embedded during the build. The default path
@@ -99,11 +109,17 @@ cat > "$EXPORT_PLIST" <<PLIST
 PLIST
 
 rm -rf "$EXPORT_PATH"
-xcodebuild -exportArchive \
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/${APP_NAME}-export.XXXXXX.log")"
+EXPORT_STATUS=0
+xcodebuild_logged "$BUILD_LOG" 3 -exportArchive \
   -archivePath "$ARCHIVE_PATH" \
   -exportPath "$EXPORT_PATH" \
-  -exportOptionsPlist "$EXPORT_PLIST" \
-  | tail -3
+  -exportOptionsPlist "$EXPORT_PLIST" || EXPORT_STATUS=$?
+rm -f "$BUILD_LOG"
+if [ "$EXPORT_STATUS" -ne 0 ]; then
+  echo "ERROR: xcodebuild -exportArchive failed (exit ${EXPORT_STATUS})"
+  exit "$EXPORT_STATUS"
+fi
 
 APP_PATH="${EXPORT_PATH}/${APP_NAME}.app"
 if [ ! -d "$APP_PATH" ]; then

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -35,37 +35,28 @@ echo "=== Step 3: Bump Debug build number ==="
 echo "=== Step 4: Build framework ==="
 make framework
 
-echo "=== Step 5: Build app ==="
+echo "=== Step 5: Build and install app ==="
 rm -rf ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*
-BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/BaoLianDeng-build.XXXXXX.log")"
-BUILD_STATUS=0
-xcodebuild_logged "$BUILD_LOG" 3 build \
+# build_and_install_app validates and stages the freshly built bundle before
+# touching the installed app — a failed or incomplete build must never
+# remove a working install (issue #113 finding 3).
+if ! build_and_install_app \
+  '$HOME/Library/Developer/Xcode/DerivedData/BaoLianDeng-*/Build/Products/Debug/BaoLianDeng.app' \
+  "$APP_PATH" 3 "Contents/PlugIns/TransparentProxy.appex" -- \
+  build \
   -project BaoLianDeng.xcodeproj \
   -scheme BaoLianDeng \
   -configuration Debug \
-  -destination 'platform=macOS' || BUILD_STATUS=$?
-rm -f "$BUILD_LOG"
-if [ "$BUILD_STATUS" -ne 0 ]; then
-    echo "ERROR: xcodebuild build failed (exit ${BUILD_STATUS}); leaving installed app untouched"
-    exit "$BUILD_STATUS"
-fi
-
-echo "=== Step 6: Install ==="
-# Validate the freshly built bundle and stage it before touching the
-# installed app — a failed or incomplete build must never remove a working
-# install (issue #113 finding 3).
-BUILT_APP=$(echo ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*/Build/Products/Debug/BaoLianDeng.app)
-if ! install_app_bundle "$BUILT_APP" "$APP_PATH"; then
-    echo "ERROR: install failed; any previously-installed app was left in place"
+  -destination 'platform=macOS'; then
     exit 1
 fi
 
-echo "=== Step 7: Launch app ==="
+echo "=== Step 6: Launch app ==="
 touch /tmp/.bld-autoconnect
 open "$APP_PATH"
 sleep 3
 
-echo "=== Step 8: Start VPN ==="
+echo "=== Step 7: Start VPN ==="
 scutil --nc start "$VPN_NAME" 2>/dev/null || true
 for i in $(seq 1 30); do
     vpnstatus=$(scutil --nc status "$VPN_NAME" 2>&1 | head -1)
@@ -80,7 +71,7 @@ for i in $(seq 1 30); do
     sleep 1
 done
 
-echo "=== Step 9: Wait for tunnel + meow engine startup ==="
+echo "=== Step 8: Wait for tunnel + meow engine startup ==="
 LOG_FILE="$LOG_DIR/rust_bridge.log"
 for i in $(seq 1 30); do
     if grep -q "meow engine started" "$LOG_FILE" 2>/dev/null ||
@@ -93,17 +84,17 @@ for i in $(seq 1 30); do
 done
 
 # Verify mihomo SOCKS5 proxy is listening
-echo "=== Step 10: Verify SOCKS5 proxy ==="
+echo "=== Step 9: Verify SOCKS5 proxy ==="
 if curl -s --connect-timeout 3 --socks5 127.0.0.1:7890 http://www.baidu.com/ -o /dev/null -w "SOCKS5 proxy: HTTP %{http_code}\n"; then
     echo "SOCKS5 proxy OK"
 else
     echo "SOCKS5 proxy NOT ready"
 fi
 
-echo "=== Step 11: Test curl ==="
+echo "=== Step 10: Test curl ==="
 curl -s -o /dev/null -w "HTTP %{http_code} (%{time_total}s)\n" --max-time 30 http://ipinfo.io/ || echo "curl failed"
 
-echo "=== Step 12: Show logs ==="
+echo "=== Step 11: Show logs ==="
 echo "--- rust_bridge.log (STATS) ---"
 grep "STATS" "$LOG_DIR/rust_bridge.log" 2>/dev/null | tail -3
 echo "--- rust_bridge.log (TX DATA) ---"

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -2,6 +2,10 @@
 # Build, install, and test BaoLianDeng with VPN toggle automation
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/deploy-lib.sh
+source "${SCRIPT_DIR}/lib/deploy-lib.sh"
+
 VPN_NAME="BaoLianDeng"
 APP_PATH="/Applications/BaoLianDeng.app"
 PROJECT_DIR="/Volumes/DATA/workspace/BaoLianDeng"
@@ -33,23 +37,28 @@ make framework
 
 echo "=== Step 5: Build app ==="
 rm -rf ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*
-xcodebuild build \
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/BaoLianDeng-build.XXXXXX.log")"
+BUILD_STATUS=0
+xcodebuild_logged "$BUILD_LOG" 3 build \
   -project BaoLianDeng.xcodeproj \
   -scheme BaoLianDeng \
   -configuration Debug \
-  -destination 'platform=macOS' 2>&1 | tail -3
+  -destination 'platform=macOS' || BUILD_STATUS=$?
+rm -f "$BUILD_LOG"
+if [ "$BUILD_STATUS" -ne 0 ]; then
+    echo "ERROR: xcodebuild build failed (exit ${BUILD_STATUS}); leaving installed app untouched"
+    exit "$BUILD_STATUS"
+fi
 
 echo "=== Step 6: Install ==="
-rm -rf "$APP_PATH"
-cp -R ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*/Build/Products/Debug/BaoLianDeng.app "$APP_PATH"
-if [ ! -d "$APP_PATH/Contents/PlugIns/TransparentProxy.appex" ]; then
-    echo "ERROR: TransparentProxy.appex missing from installed app"
+# Validate the freshly built bundle and stage it before touching the
+# installed app — a failed or incomplete build must never remove a working
+# install (issue #113 finding 3).
+BUILT_APP=$(echo ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*/Build/Products/Debug/BaoLianDeng.app)
+if ! install_app_bundle "$BUILT_APP" "$APP_PATH"; then
+    echo "ERROR: install failed; any previously-installed app was left in place"
     exit 1
 fi
-# The Xcode project still embeds the Developer ID system-extension product.
-# Local Debug uses the app extension; prune the sysext so the two providers
-# (same bundle ID) cannot compete at runtime.
-rm -rf "$APP_PATH/Contents/Library/SystemExtensions"
 
 echo "=== Step 7: Launch app ==="
 touch /tmp/.bld-autoconnect

--- a/scripts/lib/deploy-lib.sh
+++ b/scripts/lib/deploy-lib.sh
@@ -8,6 +8,12 @@
 # `xcodebuild` — so a failed build (e.g. exit 65) was silently treated as
 # success, and callers went on to `rm -rf` the previously-installed app
 # before copying in a missing/incomplete replacement.
+#
+# dev-deploy.sh and release-deploy.sh call `build_and_install_app` (below)
+# for their whole build+install sequence, rather than each re-implementing
+# the build/status-check/install control flow inline — that keeps the real
+# code path small enough for tests/scripts/test-deploy-guards.sh to exercise
+# directly instead of re-deriving it.
 
 # xcodebuild_logged <log_file> <tail_lines> <xcodebuild args...>
 #
@@ -62,7 +68,10 @@ install_app_bundle() {
   fi
 
   local staging
-  staging="$(mktemp -d "${TMPDIR:-/tmp}/${app_name}-stage.XXXXXX")"
+  staging="$(mktemp -d "${TMPDIR:-/tmp}/${app_name}-stage.XXXXXX")" || {
+    echo "ERROR: mktemp -d failed while staging the built app"
+    return 1
+  }
   if ! cp -R "$built_app" "${staging}/${app_name}.app"; then
     echo "ERROR: failed to stage built app"
     rm -rf "$staging"
@@ -95,6 +104,61 @@ install_app_bundle() {
   rm -rf "$staging"
   if [ -n "$backup" ]; then
     rm -rf "$backup"
+  fi
+  return 0
+}
+
+# build_and_install_app <built_app_glob> <install_path> <tail_lines> <required_plugin> -- <xcodebuild args...>
+#
+# The single code path dev-deploy.sh and release-deploy.sh use to turn an
+# `xcodebuild build` invocation into an installed app. Runs xcodebuild via
+# xcodebuild_logged (so a failed build reports its own exit status, never
+# tail's) and, on any build failure, returns that status immediately
+# *without touching <install_path>* — the previous install is left exactly
+# as it was. The log is kept (not deleted) on failure and its path is
+# printed, since the caller only ever sees the last <tail_lines> lines of
+# it. On a successful build, <built_app_glob> (a shell glob pattern — e.g.
+# one containing a DerivedData `BaoLianDeng-*` wildcard, which is why this
+# resolves it with `eval echo` rather than a literal path) is expanded to
+# the produced .app and installed via install_app_bundle, which validates
+# the bundle and stages the swap before ever removing a previous install.
+#
+# tests/scripts/test-deploy-guards.sh calls this exact function (with a
+# stub failing xcodebuild on PATH) to guard against a regression of issue
+# #113 finding 3 — the test exercises this real code path, not a
+# reimplementation of the scripts' control flow.
+build_and_install_app() {
+  local built_app_glob="$1"
+  shift
+  local install_path="$1"
+  shift
+  local tail_lines="$1"
+  shift
+  local required_plugin="$1"
+  shift
+  if [ "${1:-}" = "--" ]; then
+    shift
+  fi
+
+  local build_log
+  build_log="$(mktemp "${TMPDIR:-/tmp}/BaoLianDeng-build.XXXXXX")" || {
+    echo "ERROR: mktemp failed while preparing the build log"
+    return 1
+  }
+  local build_status=0
+  xcodebuild_logged "$build_log" "$tail_lines" "$@" || build_status=$?
+  if [ "$build_status" -ne 0 ]; then
+    echo "ERROR: xcodebuild build failed (exit ${build_status}); leaving installed app untouched"
+    echo "Full log: $build_log"
+    return "$build_status"
+  fi
+  rm -f "$build_log"
+
+  local built_app
+  built_app=$(eval echo "$built_app_glob")
+  if ! install_app_bundle "$built_app" "$install_path" "$required_plugin"; then
+    echo "ERROR: install failed; any previously-installed app was left in place"
+    return 1
   fi
   return 0
 }

--- a/scripts/lib/deploy-lib.sh
+++ b/scripts/lib/deploy-lib.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Shared helpers for the local deploy/build scripts (dev-deploy.sh,
+# release-deploy.sh, build-appstore-pkg.sh, build-release-pkg.sh,
+# build-release-dmg.sh). Sourced, never executed directly.
+#
+# Fixes GitHub issue #113 finding 3: `xcodebuild ... | tail -N` under
+# `set -e` (without pipefail) reports the exit status of `tail`, not
+# `xcodebuild` — so a failed build (e.g. exit 65) was silently treated as
+# success, and callers went on to `rm -rf` the previously-installed app
+# before copying in a missing/incomplete replacement.
+
+# xcodebuild_logged <log_file> <tail_lines> <xcodebuild args...>
+#
+# Runs `xcodebuild "$@"` with combined stdout/stderr captured to
+# <log_file>, then prints the last <tail_lines> lines of it (matching the
+# old `2>&1 | tail -N` output — `tail` without `-f` only ever prints once
+# the input is exhausted, so this produces the same visible output).
+# Returns xcodebuild's own exit status, never a status masked by a pipe.
+xcodebuild_logged() {
+  local log_file="$1"
+  shift
+  local tail_lines="$1"
+  shift
+  local status=0
+  xcodebuild "$@" >"$log_file" 2>&1 || status=$?
+  tail -n "$tail_lines" "$log_file"
+  return "$status"
+}
+
+# install_app_bundle <built_app_path> <install_path> [required_plugin_rel_path]
+#
+# Validates that a freshly built .app bundle looks complete (an executable
+# at Contents/MacOS/<name>, Contents/Info.plist, and the expected plugin —
+# Contents/PlugIns/TransparentProxy.appex by default), stages a copy of it,
+# and only then swaps it into <install_path>: the previous install (if any)
+# is moved aside, the staged copy is moved into place, and the old install
+# is removed only after that swap succeeds. On any failure the previous
+# install is left exactly as it was (restored from the aside-move if the
+# final swap itself failed).
+install_app_bundle() {
+  local built_app="$1"
+  local install_path="$2"
+  local required_plugin="${3:-Contents/PlugIns/TransparentProxy.appex}"
+  local app_name
+  app_name="$(basename "$install_path" .app)"
+
+  if [ ! -d "$built_app" ]; then
+    echo "ERROR: built app not found at ${built_app}"
+    return 1
+  fi
+  if [ ! -f "${built_app}/Contents/MacOS/${app_name}" ]; then
+    echo "ERROR: built app missing executable Contents/MacOS/${app_name}"
+    return 1
+  fi
+  if [ ! -f "${built_app}/Contents/Info.plist" ]; then
+    echo "ERROR: built app missing Contents/Info.plist"
+    return 1
+  fi
+  if [ ! -d "${built_app}/${required_plugin}" ]; then
+    echo "ERROR: built app missing ${required_plugin}"
+    return 1
+  fi
+
+  local staging
+  staging="$(mktemp -d "${TMPDIR:-/tmp}/${app_name}-stage.XXXXXX")"
+  if ! cp -R "$built_app" "${staging}/${app_name}.app"; then
+    echo "ERROR: failed to stage built app"
+    rm -rf "$staging"
+    return 1
+  fi
+  # The Xcode project still embeds the Developer ID system-extension
+  # product. Local Debug/Release uses the app extension; prune the sysext
+  # so the two providers (same bundle ID) cannot compete at runtime.
+  rm -rf "${staging}/${app_name}.app/Contents/Library/SystemExtensions"
+
+  local backup=""
+  if [ -d "$install_path" ]; then
+    backup="${install_path}.bak.$$"
+    if ! mv "$install_path" "$backup"; then
+      echo "ERROR: failed to move aside existing install at ${install_path}"
+      rm -rf "$staging"
+      return 1
+    fi
+  fi
+
+  if ! mv "${staging}/${app_name}.app" "$install_path"; then
+    echo "ERROR: failed to move staged app into ${install_path}"
+    if [ -n "$backup" ]; then
+      mv "$backup" "$install_path"
+    fi
+    rm -rf "$staging"
+    return 1
+  fi
+
+  rm -rf "$staging"
+  if [ -n "$backup" ]; then
+    rm -rf "$backup"
+  fi
+  return 0
+}

--- a/scripts/release-deploy.sh
+++ b/scripts/release-deploy.sh
@@ -41,32 +41,23 @@ sleep 1
 echo "=== Step 3: Build framework ==="
 make framework
 
-echo "=== Step 4: Build app (Release) ==="
+echo "=== Step 4: Build and install app (Release) ==="
 rm -rf ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*
-BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/BaoLianDeng-build.XXXXXX.log")"
-BUILD_STATUS=0
-xcodebuild_logged "$BUILD_LOG" 3 build \
+# build_and_install_app validates and stages the freshly built bundle before
+# touching the installed app — a failed or incomplete build must never
+# remove a working install (issue #113 finding 3).
+if ! build_and_install_app \
+  '$HOME/Library/Developer/Xcode/DerivedData/BaoLianDeng-*/Build/Products/Release/BaoLianDeng.app' \
+  "$APP_PATH" 3 "Contents/PlugIns/TransparentProxy.appex" -- \
+  build \
   -project BaoLianDeng.xcodeproj \
   -scheme BaoLianDeng \
   -configuration Release \
-  -destination 'platform=macOS' || BUILD_STATUS=$?
-rm -f "$BUILD_LOG"
-if [ "$BUILD_STATUS" -ne 0 ]; then
-    echo "ERROR: xcodebuild build failed (exit ${BUILD_STATUS}); leaving installed app untouched"
-    exit "$BUILD_STATUS"
-fi
-
-echo "=== Step 5: Install ==="
-# Validate the freshly built bundle and stage it before touching the
-# installed app — a failed or incomplete build must never remove a working
-# install (issue #113 finding 3).
-BUILT_APP=$(echo ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*/Build/Products/Release/BaoLianDeng.app)
-if ! install_app_bundle "$BUILT_APP" "$APP_PATH"; then
-    echo "ERROR: install failed; any previously-installed app was left in place"
+  -destination 'platform=macOS'; then
     exit 1
 fi
 
-echo "=== Step 6: Launch app ==="
+echo "=== Step 5: Launch app ==="
 # Sentinel makes VPNManager.start() after the NE manager is ready — more
 # reliable for an app-extension provider than scutil --nc, which can race
 # before the configuration is registered.
@@ -74,7 +65,7 @@ touch /tmp/.bld-autoconnect
 open "$APP_PATH"
 sleep 3
 
-echo "=== Step 7: Start VPN ==="
+echo "=== Step 6: Start VPN ==="
 scutil --nc start "$VPN_NAME" 2>/dev/null || true
 CONNECTED=0
 for i in $(seq 1 30); do
@@ -95,7 +86,7 @@ if [ "$CONNECTED" -eq 0 ]; then
     echo "WARNING: VPN did not report connected within 30s"
 fi
 
-echo "=== Step 8: Wait for tunnel + meow engine startup ==="
+echo "=== Step 7: Wait for tunnel + meow engine startup ==="
 LOG_FILE="$LOG_DIR/rust_bridge.log"
 for i in $(seq 1 30); do
     if grep -q "meow engine started" "$LOG_FILE" 2>/dev/null ||
@@ -107,14 +98,14 @@ for i in $(seq 1 30); do
     sleep 1
 done
 
-echo "=== Step 9: Verify SOCKS5 proxy ==="
+echo "=== Step 8: Verify SOCKS5 proxy ==="
 if curl -s --connect-timeout 3 --socks5 127.0.0.1:7890 http://www.baidu.com/ -o /dev/null -w "SOCKS5 proxy: HTTP %{http_code}\n"; then
     echo "SOCKS5 proxy OK"
 else
     echo "SOCKS5 proxy NOT ready"
 fi
 
-echo "=== Step 10: Test curl ==="
+echo "=== Step 9: Test curl ==="
 HTTP=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 http://ipinfo.io/ || echo "000")
 if ! [ "$HTTP" -ge 200 ] 2>/dev/null || [ "$HTTP" -ge 300 ]; then
     ADDR=$(defaults read io.github.baoliandeng.macos externalControllerAddr 2>/dev/null || true)

--- a/scripts/release-deploy.sh
+++ b/scripts/release-deploy.sh
@@ -15,6 +15,10 @@
 # hash pin, so a build-number bump is not required for reload.
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/deploy-lib.sh
+source "${SCRIPT_DIR}/lib/deploy-lib.sh"
+
 VPN_NAME="BaoLianDeng"
 APP_PATH="/Applications/BaoLianDeng.app"
 PROJECT_DIR="/Volumes/DATA/workspace/BaoLianDeng"
@@ -39,23 +43,28 @@ make framework
 
 echo "=== Step 4: Build app (Release) ==="
 rm -rf ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*
-xcodebuild build \
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/BaoLianDeng-build.XXXXXX.log")"
+BUILD_STATUS=0
+xcodebuild_logged "$BUILD_LOG" 3 build \
   -project BaoLianDeng.xcodeproj \
   -scheme BaoLianDeng \
   -configuration Release \
-  -destination 'platform=macOS' 2>&1 | tail -3
+  -destination 'platform=macOS' || BUILD_STATUS=$?
+rm -f "$BUILD_LOG"
+if [ "$BUILD_STATUS" -ne 0 ]; then
+    echo "ERROR: xcodebuild build failed (exit ${BUILD_STATUS}); leaving installed app untouched"
+    exit "$BUILD_STATUS"
+fi
 
 echo "=== Step 5: Install ==="
-rm -rf "$APP_PATH"
-cp -R ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*/Build/Products/Release/BaoLianDeng.app "$APP_PATH"
-if [ ! -d "$APP_PATH/Contents/PlugIns/TransparentProxy.appex" ]; then
-    echo "ERROR: TransparentProxy.appex missing from installed app"
+# Validate the freshly built bundle and stage it before touching the
+# installed app — a failed or incomplete build must never remove a working
+# install (issue #113 finding 3).
+BUILT_APP=$(echo ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*/Build/Products/Release/BaoLianDeng.app)
+if ! install_app_bundle "$BUILT_APP" "$APP_PATH"; then
+    echo "ERROR: install failed; any previously-installed app was left in place"
     exit 1
 fi
-# The Xcode project still embeds the Developer ID system-extension product.
-# Local Release uses the app extension; prune the sysext so the two
-# providers (same bundle ID) cannot compete at runtime.
-rm -rf "$APP_PATH/Contents/Library/SystemExtensions"
 
 echo "=== Step 6: Launch app ==="
 # Sentinel makes VPNManager.start() after the NE manager is ready — more

--- a/tests/e2e/vm-setup.sh
+++ b/tests/e2e/vm-setup.sh
@@ -128,17 +128,35 @@ echo ""
 echo "--- Step 6: Build and install app ---"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=../../scripts/lib/deploy-lib.sh
+source "$PROJECT_DIR/scripts/lib/deploy-lib.sh"
 
 echo "Building framework..."
 cd "$PROJECT_DIR"
 make framework
 
 echo "Building app (Debug, signed)..."
-xcodebuild build \
+# Wipe DerivedData first (matches dev-deploy.sh/release-deploy.sh) so a
+# failed build below can never leave the `find` on the next line picking up
+# a stale app from an earlier successful run. Use xcodebuild_logged instead
+# of `xcodebuild ... 2>&1 | tail -5` so a failed build's real exit status
+# (e.g. 65) is what `set -e` sees, not tail's — see issue #113 finding 3;
+# this script does the same DerivedData/build/appex checks dev-deploy.sh
+# and release-deploy.sh do, so it needs the same fix.
+rm -rf ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*
+BUILD_LOG="$(mktemp "${TMPDIR:-/tmp}/BaoLianDeng-vm-build.XXXXXX")"
+BUILD_STATUS=0
+xcodebuild_logged "$BUILD_LOG" 5 build \
     -project BaoLianDeng.xcodeproj \
     -scheme BaoLianDeng \
     -configuration Debug \
-    -destination 'platform=macOS' 2>&1 | tail -5
+    -destination 'platform=macOS' || BUILD_STATUS=$?
+if [ "$BUILD_STATUS" -ne 0 ]; then
+    echo "ERROR: xcodebuild build failed (exit ${BUILD_STATUS})"
+    echo "Full log: $BUILD_LOG"
+    exit "$BUILD_STATUS"
+fi
+rm -f "$BUILD_LOG"
 
 APP_BUILD_PATH=$(find ~/Library/Developer/Xcode/DerivedData/BaoLianDeng-*/Build/Products/Debug -name "BaoLianDeng.app" -maxdepth 1 2>/dev/null | head -1)
 if [ -z "$APP_BUILD_PATH" ]; then

--- a/tests/scripts/test-deploy-guards.sh
+++ b/tests/scripts/test-deploy-guards.sh
@@ -20,9 +20,16 @@
 #
 #   1. xcodebuild_logged returns xcodebuild's own exit status (65), not the
 #      exit status of whatever consumed its output.
-#   2. build_and_install_app itself returns non-zero on a failed build.
+#   2. build_and_install_app itself returns that exact propagated status (65)
+#      on a failed build — checked with a *structurally complete stale
+#      bundle* already sitting at the DerivedData glob location, so a
+#      mutant that drops the exit-status check would actually install that
+#      stale bundle (and return 0) instead of failing harmlessly at "built
+#      app not found". Asserting the precise status, not just "non-zero",
+#      is what makes this catch that mutant.
 #   3. A previously-installed app is left completely untouched — same
-#      content, never removed — when the build fails.
+#      content (still its OLD marker, not the stale build's), never
+#      removed — when the build fails.
 #   4. No rm/cp/mv invocation ever targeted the installed app path during
 #      that failed run.
 #   5. install_app_bundle rejects an incomplete bundle (missing appex)
@@ -121,7 +128,25 @@ fi
 # ---------------------------------------------------------------------------
 # Tests 2-4: call build_and_install_app itself — the exact function
 # dev-deploy.sh/release-deploy.sh call — against the failing xcodebuild stub.
+#
+# Crucially, a *structurally complete stale bundle* is pre-seeded at the
+# DerivedData glob location before this runs. This is the realistic failure
+# mode the finding describes (a late-phase failure — codesign, embed, etc. —
+# after xcodebuild has already assembled a .app on disk) and it is also what
+# makes this test actually exercise the exit-status check: without a stale
+# bundle at the glob, a mutant that deletes the `build_status -ne 0` guard
+# would still fail harmlessly at install_app_bundle's "built app not found"
+# check, satisfying the old (weaker) assertions for the wrong reason. With a
+# complete stale bundle present, that mutant instead installs the stale
+# bundle over the working install and returns 0 — so asserting the exact
+# propagated exit status (65, not just "non-zero") and that the install still
+# has its OLD marker (not the STALE one) genuinely guards the fix.
 # ---------------------------------------------------------------------------
+
+STALE_APP="${DERIVED_DATA_ROOT}/BaoLianDeng-stalebuild/Build/Products/Debug/BaoLianDeng.app"
+mkdir -p "${STALE_APP}/Contents/MacOS" "${STALE_APP}/Contents/PlugIns/TransparentProxy.appex"
+echo "STALE-BINARY-MARKER" >"${STALE_APP}/Contents/MacOS/BaoLianDeng"
+echo "<plist/>" >"${STALE_APP}/Contents/Info.plist"
 
 : >"$TRACE_LOG"
 
@@ -130,16 +155,16 @@ build_and_install_app "$BUILT_APP_GLOB" "$APP_PATH" 3 \
   "Contents/PlugIns/TransparentProxy.appex" -- \
   "${xcodebuild_args[@]}" || BAI_STATUS=$?
 
-if [ "$BAI_STATUS" -ne 0 ]; then
-  pass "build_and_install_app returned non-zero (${BAI_STATUS}) after a failed build"
+if [ "$BAI_STATUS" -eq 65 ]; then
+  pass "build_and_install_app propagated xcodebuild's exit status (65) after a failed build"
 else
-  fail "build_and_install_app returned success despite a failed build"
+  fail "expected build_and_install_app to return 65 after a failed build, got ${BAI_STATUS}"
 fi
 
 if [ -f "${APP_PATH}/Contents/MacOS/BaoLianDeng" ] &&
   [ "$(cat "${APP_PATH}/Contents/MacOS/BaoLianDeng")" = "OLD-BINARY-MARKER" ] &&
   [ -d "${APP_PATH}/Contents/PlugIns/TransparentProxy.appex" ]; then
-  pass "installed app is untouched after a failed build"
+  pass "installed app is untouched (still OLD-BINARY-MARKER, not the stale build) after a failed build"
 else
   fail "installed app was modified or removed after a failed build"
 fi
@@ -149,6 +174,12 @@ if [ -s "$TRACE_LOG" ] && grep -q -- "$APP_PATH" "$TRACE_LOG"; then
 else
   pass "no rm/cp/mv command ever referenced the installed app path during the failed run"
 fi
+
+# Remove the stale build fixture so it can never satisfy BUILT_APP_GLOB
+# (a "BaoLianDeng-*" wildcard) in later tests — leaving it in place would
+# make the glob match two directories once test 6 creates its own build
+# product, breaking that unrelated assertion.
+rm -rf "$STALE_APP"
 
 # ---------------------------------------------------------------------------
 # Test 5: install_app_bundle itself refuses an incomplete bundle (missing

--- a/tests/scripts/test-deploy-guards.sh
+++ b/tests/scripts/test-deploy-guards.sh
@@ -8,18 +8,29 @@
 # proceeded to `rm -rf` the installed app, then `cp -R` a missing/incomplete
 # replacement over it.
 #
-# This test exercises the shared helpers in scripts/lib/deploy-lib.sh
-# (`xcodebuild_logged` and `install_app_bundle`) that scripts/dev-deploy.sh
-# and scripts/release-deploy.sh now use for their build+install step,
-# against a stub `xcodebuild` that always fails, and traced rm/cp/mv
-# wrappers, then asserts:
+# This test calls `build_and_install_app` in scripts/lib/deploy-lib.sh —
+# the *exact* function dev-deploy.sh and release-deploy.sh now call for
+# their whole build+install step — against a stub `xcodebuild` and traced
+# rm/cp/mv wrappers. It deliberately does not re-implement any part of the
+# build/status-check/install control flow itself: if dev-deploy.sh or
+# release-deploy.sh (or build_and_install_app itself) regressed back to
+# `xcodebuild ... | tail -N` or dropped the exit-status check, this test
+# would fail because it drives that same shared code path, not a copy of
+# it. It asserts:
 #
 #   1. xcodebuild_logged returns xcodebuild's own exit status (65), not the
 #      exit status of whatever consumed its output.
-#   2. A previously-installed app is left completely untouched — same
+#   2. build_and_install_app itself returns non-zero on a failed build.
+#   3. A previously-installed app is left completely untouched — same
 #      content, never removed — when the build fails.
-#   3. No rm/cp/mv invocation ever targeted the installed app path during
+#   4. No rm/cp/mv invocation ever targeted the installed app path during
 #      that failed run.
+#   5. install_app_bundle rejects an incomplete bundle (missing appex)
+#      without touching the existing install.
+#   6. build_and_install_app's success path: the new bundle is swapped in,
+#      the old one is gone, and no stray staging/backup directories survive.
+#   7. If the final move-into-place fails, the previous install is restored
+#      rather than left missing.
 #
 # Run with: bash tests/scripts/test-deploy-guards.sh
 
@@ -40,42 +51,38 @@ pass() { echo "PASS: $1"; }
 fail() { echo "FAIL: $1"; FAILURES=$((FAILURES + 1)); }
 
 # ---------------------------------------------------------------------------
-# Fixture: a fake DerivedData tree, a fake project dir, and a fake
-# already-installed app with a marker file we can check survives.
+# Fixture: a fake DerivedData tree and a fake already-installed app with a
+# marker file we can check survives.
 # ---------------------------------------------------------------------------
 
 DERIVED_DATA_ROOT="${WORKDIR}/DerivedData"
-PROJECT_DIR="${WORKDIR}/project"
 APP_PATH="${WORKDIR}/Applications/BaoLianDeng.app"
 TRACE_LOG="${WORKDIR}/trace.log"
+BUILT_APP_GLOB="${DERIVED_DATA_ROOT}/BaoLianDeng-*/Build/Products/Debug/BaoLianDeng.app"
 
-mkdir -p "$DERIVED_DATA_ROOT" "$PROJECT_DIR" "$(dirname "$APP_PATH")"
-mkdir -p "${APP_PATH}/Contents/MacOS" "${APP_PATH}/Contents/PlugIns/TransparentProxy.appex"
-echo "OLD-BINARY-MARKER" > "${APP_PATH}/Contents/MacOS/BaoLianDeng"
-echo "<plist/>" > "${APP_PATH}/Contents/Info.plist"
+reset_installed_app() {
+  rm -rf "$APP_PATH"
+  mkdir -p "${APP_PATH}/Contents/MacOS" "${APP_PATH}/Contents/PlugIns/TransparentProxy.appex"
+  echo "OLD-BINARY-MARKER" >"${APP_PATH}/Contents/MacOS/BaoLianDeng"
+  echo "<plist/>" >"${APP_PATH}/Contents/Info.plist"
+}
+
+mkdir -p "$DERIVED_DATA_ROOT" "$(dirname "$APP_PATH")"
+reset_installed_app
 
 # ---------------------------------------------------------------------------
-# Stub bin dir: xcodebuild always fails like a real build error (exit 65);
-# rm/cp/mv are traced (every invocation logged) but still perform the real
-# operation via their absolute path, so staging/backup dirs made by the code
-# under test keep working.
+# Stub bin dir: rm/cp/mv are traced (every invocation logged) but still
+# perform the real operation via their absolute path, so staging/backup dirs
+# made by the code under test keep working. xcodebuild is stubbed per-test
+# below (failing, succeeding, or succeeding-but-doomed-to-fail-the-final-mv).
 # ---------------------------------------------------------------------------
 
 STUB_BIN="${WORKDIR}/bin"
 mkdir -p "$STUB_BIN"
 
-cat > "${STUB_BIN}/xcodebuild" <<'EOF'
-#!/bin/bash
-echo "=== BUILD TARGET BaoLianDeng ==="
-echo "CompileSwift normal arm64 SomeFile.swift"
-echo "** BUILD FAILED **"
-exit 65
-EOF
-chmod +x "${STUB_BIN}/xcodebuild"
-
 for tool in rm cp mv; do
   real="/bin/${tool}"
-  cat > "${STUB_BIN}/${tool}" <<EOF
+  cat >"${STUB_BIN}/${tool}" <<EOF
 #!/bin/bash
 echo "${tool} \$*" >> "${TRACE_LOG}"
 exec ${real} "\$@"
@@ -85,17 +92,25 @@ done
 
 export PATH="${STUB_BIN}:${PATH}"
 
+xcodebuild_args=(build -project BaoLianDeng.xcodeproj -scheme BaoLianDeng \
+  -configuration Debug -destination 'platform=macOS')
+
 # ---------------------------------------------------------------------------
 # Test 1: xcodebuild_logged propagates the real (failing) exit status.
 # ---------------------------------------------------------------------------
 
+cat >"${STUB_BIN}/xcodebuild" <<'EOF'
+#!/bin/bash
+echo "=== BUILD TARGET BaoLianDeng ==="
+echo "CompileSwift normal arm64 SomeFile.swift"
+echo "** BUILD FAILED **"
+exit 65
+EOF
+chmod +x "${STUB_BIN}/xcodebuild"
+
 BUILD_LOG="${WORKDIR}/build.log"
 XCB_STATUS=0
-xcodebuild_logged "$BUILD_LOG" 3 build \
-  -project BaoLianDeng.xcodeproj \
-  -scheme BaoLianDeng \
-  -configuration Debug \
-  -destination 'platform=macOS' || XCB_STATUS=$?
+xcodebuild_logged "$BUILD_LOG" 3 "${xcodebuild_args[@]}" || XCB_STATUS=$?
 
 if [ "$XCB_STATUS" -eq 65 ]; then
   pass "xcodebuild_logged propagated xcodebuild's real exit status (65)"
@@ -104,38 +119,26 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 2/3: the dev-deploy.sh/release-deploy.sh build+install sequence,
-# reproduced exactly as those scripts now call it, must leave the installed
-# app untouched when the build fails, and must never call rm/cp/mv on it
-# before that point.
+# Tests 2-4: call build_and_install_app itself — the exact function
+# dev-deploy.sh/release-deploy.sh call — against the failing xcodebuild stub.
 # ---------------------------------------------------------------------------
 
-: > "$TRACE_LOG"
+: >"$TRACE_LOG"
 
-BUILD_STATUS=0
-xcodebuild_logged "$BUILD_LOG" 3 build \
-  -project BaoLianDeng.xcodeproj \
-  -scheme BaoLianDeng \
-  -configuration Debug \
-  -destination 'platform=macOS' || BUILD_STATUS=$?
+BAI_STATUS=0
+build_and_install_app "$BUILT_APP_GLOB" "$APP_PATH" 3 \
+  "Contents/PlugIns/TransparentProxy.appex" -- \
+  "${xcodebuild_args[@]}" || BAI_STATUS=$?
 
-INSTALL_RAN=0
-if [ "$BUILD_STATUS" -eq 0 ]; then
-  # Would only run on a successful build — must not happen in this test.
-  INSTALL_RAN=1
-  BUILT_APP="${DERIVED_DATA_ROOT}/BaoLianDeng-x/Build/Products/Debug/BaoLianDeng.app"
-  install_app_bundle "$BUILT_APP" "$APP_PATH" || true
-fi
-
-if [ "$BUILD_STATUS" -ne 0 ] && [ "$INSTALL_RAN" -eq 0 ]; then
-  pass "install step was skipped after the build failed (matches dev-deploy.sh/release-deploy.sh control flow)"
+if [ "$BAI_STATUS" -ne 0 ]; then
+  pass "build_and_install_app returned non-zero (${BAI_STATUS}) after a failed build"
 else
-  fail "install step ran despite a failed build"
+  fail "build_and_install_app returned success despite a failed build"
 fi
 
-if [ -f "${APP_PATH}/Contents/MacOS/BaoLianDeng" ] && \
-   [ "$(cat "${APP_PATH}/Contents/MacOS/BaoLianDeng")" = "OLD-BINARY-MARKER" ] && \
-   [ -d "${APP_PATH}/Contents/PlugIns/TransparentProxy.appex" ]; then
+if [ -f "${APP_PATH}/Contents/MacOS/BaoLianDeng" ] &&
+  [ "$(cat "${APP_PATH}/Contents/MacOS/BaoLianDeng")" = "OLD-BINARY-MARKER" ] &&
+  [ -d "${APP_PATH}/Contents/PlugIns/TransparentProxy.appex" ]; then
   pass "installed app is untouched after a failed build"
 else
   fail "installed app was modified or removed after a failed build"
@@ -148,17 +151,17 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 4: install_app_bundle itself refuses an incomplete bundle (missing
+# Test 5: install_app_bundle itself refuses an incomplete bundle (missing
 # appex) and leaves the existing install in place — covers the "validate
 # before touching the installed app" half of the fix independent of the
 # xcodebuild status question above.
 # ---------------------------------------------------------------------------
 
-: > "$TRACE_LOG"
+: >"$TRACE_LOG"
 INCOMPLETE_APP="${WORKDIR}/incomplete/BaoLianDeng.app"
 mkdir -p "${INCOMPLETE_APP}/Contents/MacOS"
-echo "NEW-BINARY" > "${INCOMPLETE_APP}/Contents/MacOS/BaoLianDeng"
-echo "<plist/>" > "${INCOMPLETE_APP}/Contents/Info.plist"
+echo "NEW-BINARY" >"${INCOMPLETE_APP}/Contents/MacOS/BaoLianDeng"
+echo "<plist/>" >"${INCOMPLETE_APP}/Contents/Info.plist"
 # Deliberately no Contents/PlugIns/TransparentProxy.appex.
 
 INSTALL_STATUS=0
@@ -181,6 +184,101 @@ if [ -s "$TRACE_LOG" ] && grep -q -- "$APP_PATH" "$TRACE_LOG"; then
 else
   pass "no rm/cp/mv command ever referenced the installed app path while validating an incomplete bundle"
 fi
+
+# ---------------------------------------------------------------------------
+# Test 6: build_and_install_app's success path — a real (stub) successful
+# build must swap the new bundle into place, remove the old one, and leave
+# no stray staging/backup directories behind.
+# ---------------------------------------------------------------------------
+
+cat >"${STUB_BIN}/xcodebuild" <<EOF
+#!/bin/bash
+echo "=== BUILD TARGET BaoLianDeng ==="
+mkdir -p "${DERIVED_DATA_ROOT}/BaoLianDeng-abc123/Build/Products/Debug/BaoLianDeng.app/Contents/MacOS"
+mkdir -p "${DERIVED_DATA_ROOT}/BaoLianDeng-abc123/Build/Products/Debug/BaoLianDeng.app/Contents/PlugIns/TransparentProxy.appex"
+echo "NEW-BINARY-MARKER" > "${DERIVED_DATA_ROOT}/BaoLianDeng-abc123/Build/Products/Debug/BaoLianDeng.app/Contents/MacOS/BaoLianDeng"
+echo "<plist/>" > "${DERIVED_DATA_ROOT}/BaoLianDeng-abc123/Build/Products/Debug/BaoLianDeng.app/Contents/Info.plist"
+echo "** BUILD SUCCEEDED **"
+exit 0
+EOF
+chmod +x "${STUB_BIN}/xcodebuild"
+
+: >"$TRACE_LOG"
+BAI_STATUS=0
+build_and_install_app "$BUILT_APP_GLOB" "$APP_PATH" 3 \
+  "Contents/PlugIns/TransparentProxy.appex" -- \
+  "${xcodebuild_args[@]}" || BAI_STATUS=$?
+
+if [ "$BAI_STATUS" -eq 0 ]; then
+  pass "build_and_install_app returned success after a successful build"
+else
+  fail "build_and_install_app returned ${BAI_STATUS} after a successful build"
+fi
+
+if [ -f "${APP_PATH}/Contents/MacOS/BaoLianDeng" ] &&
+  [ "$(cat "${APP_PATH}/Contents/MacOS/BaoLianDeng")" = "NEW-BINARY-MARKER" ]; then
+  pass "installed app was swapped for the newly built bundle"
+else
+  fail "installed app was not updated to the newly built bundle"
+fi
+
+STRAY=$(find "$(dirname "$APP_PATH")" -maxdepth 1 \( -name "*.bak.*" -o -name "*-stage.*" \) 2>/dev/null || true)
+if [ -z "$STRAY" ]; then
+  pass "no stray backup/staging directories survive a successful swap"
+else
+  fail "stray backup/staging directories left behind: ${STRAY}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: install_app_bundle restores the previous install if the final
+# move-into-place fails (e.g. destination briefly unwritable).
+# ---------------------------------------------------------------------------
+
+reset_installed_app
+GOOD_APP="${WORKDIR}/good/BaoLianDeng.app"
+mkdir -p "${GOOD_APP}/Contents/MacOS" "${GOOD_APP}/Contents/PlugIns/TransparentProxy.appex"
+echo "SHOULD-NOT-INSTALL" >"${GOOD_APP}/Contents/MacOS/BaoLianDeng"
+echo "<plist/>" >"${GOOD_APP}/Contents/Info.plist"
+
+cat >"${STUB_BIN}/mv" <<EOF
+#!/bin/bash
+echo "mv \$*" >> "${TRACE_LOG}"
+# Fail only the final "staged app -> install path" move (the one whose
+# source path contains "-stage."); the "install path -> backup" move must
+# still succeed so this test exercises the restore branch specifically.
+for arg in "\$@"; do
+  case "\$arg" in
+    *-stage.*) exit 1 ;;
+  esac
+done
+exec /bin/mv "\$@"
+EOF
+chmod +x "${STUB_BIN}/mv"
+
+: >"$TRACE_LOG"
+INSTALL_STATUS=0
+install_app_bundle "$GOOD_APP" "$APP_PATH" || INSTALL_STATUS=$?
+
+if [ "$INSTALL_STATUS" -ne 0 ]; then
+  pass "install_app_bundle reported failure when the final move failed"
+else
+  fail "install_app_bundle reported success despite the final move failing"
+fi
+
+if [ -f "${APP_PATH}/Contents/MacOS/BaoLianDeng" ] &&
+  [ "$(cat "${APP_PATH}/Contents/MacOS/BaoLianDeng")" = "OLD-BINARY-MARKER" ]; then
+  pass "previous install was restored after the final move failed"
+else
+  fail "previous install was NOT restored after the final move failed (install path: $([ -e "$APP_PATH" ] && echo present || echo MISSING))"
+fi
+
+# restore the real mv stub for anything after this point
+cat >"${STUB_BIN}/mv" <<EOF
+#!/bin/bash
+echo "mv \$*" >> "${TRACE_LOG}"
+exec /bin/mv "\$@"
+EOF
+chmod +x "${STUB_BIN}/mv"
 
 # ---------------------------------------------------------------------------
 

--- a/tests/scripts/test-deploy-guards.sh
+++ b/tests/scripts/test-deploy-guards.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# Regression test for GitHub issue #113 finding 3: a failed Xcode build must
+# never remove or corrupt the installed app.
+#
+# Before the fix, dev-deploy.sh / release-deploy.sh piped `xcodebuild` into
+# `tail -3` under `set -e` (no pipefail), so a failed build's real exit
+# status (e.g. 65) was masked by tail's exit status (0) and the script
+# proceeded to `rm -rf` the installed app, then `cp -R` a missing/incomplete
+# replacement over it.
+#
+# This test exercises the shared helpers in scripts/lib/deploy-lib.sh
+# (`xcodebuild_logged` and `install_app_bundle`) that scripts/dev-deploy.sh
+# and scripts/release-deploy.sh now use for their build+install step,
+# against a stub `xcodebuild` that always fails, and traced rm/cp/mv
+# wrappers, then asserts:
+#
+#   1. xcodebuild_logged returns xcodebuild's own exit status (65), not the
+#      exit status of whatever consumed its output.
+#   2. A previously-installed app is left completely untouched — same
+#      content, never removed — when the build fails.
+#   3. No rm/cp/mv invocation ever targeted the installed app path during
+#      that failed run.
+#
+# Run with: bash tests/scripts/test-deploy-guards.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# shellcheck source=../../scripts/lib/deploy-lib.sh
+source "${REPO_ROOT}/scripts/lib/deploy-lib.sh"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/bld-deploy-guard-test.XXXXXX")"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+FAILURES=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; FAILURES=$((FAILURES + 1)); }
+
+# ---------------------------------------------------------------------------
+# Fixture: a fake DerivedData tree, a fake project dir, and a fake
+# already-installed app with a marker file we can check survives.
+# ---------------------------------------------------------------------------
+
+DERIVED_DATA_ROOT="${WORKDIR}/DerivedData"
+PROJECT_DIR="${WORKDIR}/project"
+APP_PATH="${WORKDIR}/Applications/BaoLianDeng.app"
+TRACE_LOG="${WORKDIR}/trace.log"
+
+mkdir -p "$DERIVED_DATA_ROOT" "$PROJECT_DIR" "$(dirname "$APP_PATH")"
+mkdir -p "${APP_PATH}/Contents/MacOS" "${APP_PATH}/Contents/PlugIns/TransparentProxy.appex"
+echo "OLD-BINARY-MARKER" > "${APP_PATH}/Contents/MacOS/BaoLianDeng"
+echo "<plist/>" > "${APP_PATH}/Contents/Info.plist"
+
+# ---------------------------------------------------------------------------
+# Stub bin dir: xcodebuild always fails like a real build error (exit 65);
+# rm/cp/mv are traced (every invocation logged) but still perform the real
+# operation via their absolute path, so staging/backup dirs made by the code
+# under test keep working.
+# ---------------------------------------------------------------------------
+
+STUB_BIN="${WORKDIR}/bin"
+mkdir -p "$STUB_BIN"
+
+cat > "${STUB_BIN}/xcodebuild" <<'EOF'
+#!/bin/bash
+echo "=== BUILD TARGET BaoLianDeng ==="
+echo "CompileSwift normal arm64 SomeFile.swift"
+echo "** BUILD FAILED **"
+exit 65
+EOF
+chmod +x "${STUB_BIN}/xcodebuild"
+
+for tool in rm cp mv; do
+  real="/bin/${tool}"
+  cat > "${STUB_BIN}/${tool}" <<EOF
+#!/bin/bash
+echo "${tool} \$*" >> "${TRACE_LOG}"
+exec ${real} "\$@"
+EOF
+  chmod +x "${STUB_BIN}/${tool}"
+done
+
+export PATH="${STUB_BIN}:${PATH}"
+
+# ---------------------------------------------------------------------------
+# Test 1: xcodebuild_logged propagates the real (failing) exit status.
+# ---------------------------------------------------------------------------
+
+BUILD_LOG="${WORKDIR}/build.log"
+XCB_STATUS=0
+xcodebuild_logged "$BUILD_LOG" 3 build \
+  -project BaoLianDeng.xcodeproj \
+  -scheme BaoLianDeng \
+  -configuration Debug \
+  -destination 'platform=macOS' || XCB_STATUS=$?
+
+if [ "$XCB_STATUS" -eq 65 ]; then
+  pass "xcodebuild_logged propagated xcodebuild's real exit status (65)"
+else
+  fail "expected xcodebuild_logged to return 65, got ${XCB_STATUS}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2/3: the dev-deploy.sh/release-deploy.sh build+install sequence,
+# reproduced exactly as those scripts now call it, must leave the installed
+# app untouched when the build fails, and must never call rm/cp/mv on it
+# before that point.
+# ---------------------------------------------------------------------------
+
+: > "$TRACE_LOG"
+
+BUILD_STATUS=0
+xcodebuild_logged "$BUILD_LOG" 3 build \
+  -project BaoLianDeng.xcodeproj \
+  -scheme BaoLianDeng \
+  -configuration Debug \
+  -destination 'platform=macOS' || BUILD_STATUS=$?
+
+INSTALL_RAN=0
+if [ "$BUILD_STATUS" -eq 0 ]; then
+  # Would only run on a successful build — must not happen in this test.
+  INSTALL_RAN=1
+  BUILT_APP="${DERIVED_DATA_ROOT}/BaoLianDeng-x/Build/Products/Debug/BaoLianDeng.app"
+  install_app_bundle "$BUILT_APP" "$APP_PATH" || true
+fi
+
+if [ "$BUILD_STATUS" -ne 0 ] && [ "$INSTALL_RAN" -eq 0 ]; then
+  pass "install step was skipped after the build failed (matches dev-deploy.sh/release-deploy.sh control flow)"
+else
+  fail "install step ran despite a failed build"
+fi
+
+if [ -f "${APP_PATH}/Contents/MacOS/BaoLianDeng" ] && \
+   [ "$(cat "${APP_PATH}/Contents/MacOS/BaoLianDeng")" = "OLD-BINARY-MARKER" ] && \
+   [ -d "${APP_PATH}/Contents/PlugIns/TransparentProxy.appex" ]; then
+  pass "installed app is untouched after a failed build"
+else
+  fail "installed app was modified or removed after a failed build"
+fi
+
+if [ -s "$TRACE_LOG" ] && grep -q -- "$APP_PATH" "$TRACE_LOG"; then
+  fail "a destructive command touched the installed app path: $(grep -- "$APP_PATH" "$TRACE_LOG")"
+else
+  pass "no rm/cp/mv command ever referenced the installed app path during the failed run"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: install_app_bundle itself refuses an incomplete bundle (missing
+# appex) and leaves the existing install in place — covers the "validate
+# before touching the installed app" half of the fix independent of the
+# xcodebuild status question above.
+# ---------------------------------------------------------------------------
+
+: > "$TRACE_LOG"
+INCOMPLETE_APP="${WORKDIR}/incomplete/BaoLianDeng.app"
+mkdir -p "${INCOMPLETE_APP}/Contents/MacOS"
+echo "NEW-BINARY" > "${INCOMPLETE_APP}/Contents/MacOS/BaoLianDeng"
+echo "<plist/>" > "${INCOMPLETE_APP}/Contents/Info.plist"
+# Deliberately no Contents/PlugIns/TransparentProxy.appex.
+
+INSTALL_STATUS=0
+install_app_bundle "$INCOMPLETE_APP" "$APP_PATH" || INSTALL_STATUS=$?
+
+if [ "$INSTALL_STATUS" -ne 0 ]; then
+  pass "install_app_bundle rejected a bundle missing TransparentProxy.appex"
+else
+  fail "install_app_bundle accepted a bundle missing TransparentProxy.appex"
+fi
+
+if [ "$(cat "${APP_PATH}/Contents/MacOS/BaoLianDeng")" = "OLD-BINARY-MARKER" ]; then
+  pass "installed app is untouched after a rejected (incomplete) bundle"
+else
+  fail "installed app was modified after a rejected (incomplete) bundle"
+fi
+
+if [ -s "$TRACE_LOG" ] && grep -q -- "$APP_PATH" "$TRACE_LOG"; then
+  fail "a destructive command touched the installed app path while validating an incomplete bundle: $(grep -- "$APP_PATH" "$TRACE_LOG")"
+else
+  pass "no rm/cp/mv command ever referenced the installed app path while validating an incomplete bundle"
+fi
+
+# ---------------------------------------------------------------------------
+
+echo ""
+if [ "$FAILURES" -ne 0 ]; then
+  echo "=== test-deploy-guards.sh: ${FAILURES} check(s) FAILED ==="
+  exit 1
+fi
+
+echo "=== test-deploy-guards.sh: all checks passed ==="


### PR DESCRIPTION
Fixes #113.

One branch per finding group, merged here after each was reviewed against the issue's acceptance criteria.

## Changes

**1. Startup/reload use the saved config (P1)** — `ConfigManager.loadBaseConfig` / `buildEffectiveConfig` now feed both the local-proxy start and the VPN `providerConfiguration`. The saved `config.yaml` is the authoritative editable base; the selected subscription is merged into it when selected/fetched and is no longer re-merged from `rawContent` at every start (which discarded editor saves). Local-proxy mode runs the engine from a separate `<configDir>/runtime` directory instead of overwriting the user's file. Deleting or de-selecting a subscription now detaches its sections from the file (`clearSubscriptionConfig`). The editor no longer writes the subscription merge to disk on appear.

**2. Stop cancels sessions and probes (P1)** — each engine generation owns a private tokio `Runtime` (`engine::build_runtime`, stored in `EngineState`); `bridge_stop_proxy` shuts it down with `shutdown_timeout(2s)`, which cancels and awaits every task the kernel detached (per-connection relays, url-test/fallback loops, NAT sweeper, DNS/API). Final traffic snapshot is folded into the bases only after the runtime is quiescent. The process-global runtime remains only for validation/diagnostics.

**3. Deploy scripts keep the installed app on build failure (P1)** — new `scripts/lib/deploy-lib.sh` with `xcodebuild_logged` (exit status propagated, full log kept on failure) and a staged `install_app_bundle` (validate bundle → stage → swap, restore on failure). `dev-deploy.sh`, `release-deploy.sh`, the three packaging scripts and `tests/e2e/vm-setup.sh` use it. `tests/scripts/test-deploy-guards.sh` drives the real helper with stub `xcodebuild`/`mv` (12 assertions, mutation-checked).

**4. Structured editor preserves unmodelled group fields (P2)** — `EditableProxyGroup.extraFields` round-trips `use`, `filter`, `lazy`, `include-all`, strategy options, etc.; a no-edit Structured → Raw switch or save leaves the YAML untouched.

**5. Inline DNS mappings survive sanitization (P2)** — `normalizeFlowSection` expands flow-style sections (including multi-line and nested provider `health-check: {...}`) to block style before line patching; idempotent and validated through `BridgeValidateConfig` in new `MihomoCoreIntegrationTests` cases. Provider sanitization now inspects `url:`/`path:` only at the provider's own depth.

**6. TCP half-close propagation (P2)** — new `TransparentProxy/TCPRelay.swift`: EOF ends only its own direction and is forwarded as a half-close (`closeWriteWithError(nil)` / `.finalMessage`); the other direction runs to its own EOF, bounded by a 120 s post-half-close idle watchdog. `SOCKS5Client.readSome` now reports a FIN delivered with the last bytes. `TCPRelayTests` cover request-EOF-then-response and the reverse case against a real loopback `NWConnection`.

**7. Log trim keeps the Rust sink attached (P2)** — trimming moved into Rust: `logging::trim_log_file` rotates under the writer lock and reopens the handle (also reattaches if the file was replaced externally), exported as `BridgeTrimLogFile` and called from the provider.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --lib`: 28 passed (5 new lifecycle/log tests)
- `swiftlint lint --strict`: 0 violations
- `xcodebuild build` Debug: succeeded, no new warnings
- `xcodebuild test -only-testing:BaoLianDengTests`: 260 tests, 258 pass. The two failing cases are `ProxyEngineIntegrationTests` "GLOBAL uses MATCH…", which fail identically on pristine `main` in a full run (pass in isolation): `bridge_set_home_dir` pins meow-common's first-write-wins home `OnceLock`, so when `MihomoCoreIntegrationTests` runs first the GLOBAL test's `selector-cache.json` lands in a directory the engine never reads. Pre-existing test-isolation bug, tracked separately.
- `bash tests/scripts/test-deploy-guards.sh`: 12/12

## Behaviour notes

- Subscription-owned sections now live in `config.yaml` and are replaced on refresh; edits to the header (ports, `dns:`) persist across refreshes.
- `disableProviderRefresh` no longer zeroes a nested `health-check: interval:` as a side effect.
- Local-proxy mode: engine home is now `<configDir>/runtime` (geodata linked in; provider/selector caches move there).

https://claude.ai/code/session_013zZY3FBE344VAB2JyNb8JF
